### PR TITLE
Hotfix props & remove unnecessary checks

### DIFF
--- a/src/servers/ZoneServer/zoneserver.ts
+++ b/src/servers/ZoneServer/zoneserver.ts
@@ -821,8 +821,6 @@ export class ZoneServer extends EventEmitter {
       const characterId = object.characterId
         ? object.characterId
         : object.npcData.characterId;
-      const propCheck = characterId in this._props;
-      if (!propCheck) {
         if (characterId in this._vehicles) {
           this.sendData(client, "PlayerUpdate.ManagedObject", {
             guid: characterId,
@@ -837,7 +835,6 @@ export class ZoneServer extends EventEmitter {
           },
           1
         );
-      }
     });
   }
 
@@ -890,22 +887,12 @@ export class ZoneServer extends EventEmitter {
   spawnProps(client: Client): void {
     setImmediate(() => {
       for (const prop in this._props) {
-        if (
-          isPosInRadius(
-            this._npcRenderDistance,
-            client.character.state.position,
-            this._props[prop].position
-          ) &&
-          !client.spawnedEntities.includes(this._props[prop])
-        ) {
           this.sendData(
             client,
             "PlayerUpdate.AddLightweightNpc",
             this._props[prop],
             1
           );
-          client.spawnedEntities.push(this._props[prop]);
-        }
       }
     });
   }


### PR DESCRIPTION
Looks like i forgot to remove pos radius check on spawn props earlier, we spawn all props then there is no need to include them in client.spawnedEntities, No need to check prop characterId in remove out of dist since they arent there anymore.