### PR TITLE
Hotfix props & remove unnecessary checks

### DIFF
--- a/src/servers/ZoneServer/commands/hax.ts
+++ b/src/servers/ZoneServer/commands/hax.ts
@@ -259,6 +259,7 @@ const hax: any = {
       );
     });
     client.spawnedEntities = [];
+    server._props = {};
     server._npcs = {};
     server._objects = {};
     server._vehicles = {};

--- a/src/servers/ZoneServer/zonepackethandlers.ts
+++ b/src/servers/ZoneServer/zonepackethandlers.ts
@@ -25,7 +25,7 @@ import { ZoneServer } from "./zoneserver";
 import { Client } from "types/zoneserver";
 const modelToName = require("../../../data/2015/sampleData/ModelToName.json");
 
-const _ = require("lodash");
+import _ from "lodash";
 const debug = require("debug")("zonepacketHandlers");
 
 const packetHandlers: any = {
@@ -493,7 +493,7 @@ const packetHandlers: any = {
           );
           server.sendChatText(
             client,
-            `objects : ${_.size(objects)} vehicles : ${_.size(vehicles)}`
+            `objects : ${_.size(objects)} props : ${_.size(objects)} vehicles : ${_.size(vehicles)}`
           );
           break;
         }

--- a/src/servers/ZoneServer/zoneserver.ts
+++ b/src/servers/ZoneServer/zoneserver.ts
@@ -821,8 +821,6 @@ export class ZoneServer extends EventEmitter {
       const characterId = object.characterId
         ? object.characterId
         : object.npcData.characterId;
-      const propCheck = characterId in this._props;
-      if (!propCheck) {
         if (characterId in this._vehicles) {
           this.sendData(client, "PlayerUpdate.ManagedObject", {
             guid: characterId,
@@ -837,8 +835,8 @@ export class ZoneServer extends EventEmitter {
           },
           1
         );
-      }
     });
+  }
   }
 
   spawnObjects(client: Client): void {
@@ -890,22 +888,12 @@ export class ZoneServer extends EventEmitter {
   spawnProps(client: Client): void {
     setImmediate(() => {
       for (const prop in this._props) {
-        if (
-          isPosInRadius(
-            this._npcRenderDistance,
-            client.character.state.position,
-            this._props[prop].position
-          ) &&
-          !client.spawnedEntities.includes(this._props[prop])
-        ) {
           this.sendData(
             client,
             "PlayerUpdate.AddLightweightNpc",
             this._props[prop],
             1
           );
-          client.spawnedEntities.push(this._props[prop]);
-        }
       }
     });
   }

--- a/src/servers/ZoneServer/zoneserver.ts
+++ b/src/servers/ZoneServer/zoneserver.ts
@@ -837,7 +837,6 @@ export class ZoneServer extends EventEmitter {
         );
     });
   }
-  }
 
   spawnObjects(client: Client): void {
     setImmediate(() => {


### PR DESCRIPTION
Looks like i forgot to remove pos radius check on spawn props earlier, we spawn all props then there is no need to include them in client.spawnedEntities, No need to check prop characterId in remove out of dist since they arent there anymore.