### PR TITLE
Added missing packets

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
@@ -8139,12 +8139,42 @@ var packets = [
   ["Facility.EmpireScoreValueUpdate", 0x8417, {}],
   ["Skill.Echo", 0x8501, {}],
   ["Skill.SelectSkillSet", 0x8502, {}],
-  ["Skill.SelectSkill", 0x8503, {}],
+  ["Skill.SelectSkill", 0x8503,
+          {
+            fields: [
+                { name: "unknownDword1", type: "uint32", defaultValue: 0 },
+                { name: "unknownWord1", type: "uint8", defaultValue: 0 },
+                { name: "unknownDword2", type: "uint32", defaultValue: 0 },
+          ]
+      },
+  ],
   ["Skill.GetSkillPointManager", 0x8504, {}],
   ["Skill.SetLoyaltyPoints", 0x8505, {}],
   ["Skill.LoadSkillDefinitionManager", 0x8506, {}],
-  ["Skill.SetSkillPointManager", 0x8507, {}],
-  [
+  ["Skill.SetSkillPointManager",
+        0x8507,
+        {
+            fields: [
+                { name: "unknownDword1", type: "uint32", defaultValue: 0 },
+
+                {
+                    name: "unknownSchema1",
+                    type: "schema",
+                    defaultValue: [],
+                    fields: [
+                        { name: "unknownQword1", type: "uint64string", defaultValue: "0x000" },
+                        { name: "unknownQword2", type: "uint64string", defaultValue: "0x000" },
+                        { name: "unknownQword3", type: "uint64string", defaultValue: "0x000" },
+                        { name: "unknownQword4", type: "uint64string", defaultValue: "0x000" },
+                        { name: "unknownQword5", type: "uint64string", defaultValue: "0x000" },
+                        { name: "unknownDword2", type: "uint32", defaultValue: 0 },
+
+                      ],
+                  },
+              ],
+          },
+      ],
+    [
     "Skill.SetSkillPointProgress",
     0x8508,
     {

--- a/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
@@ -7154,6 +7154,34 @@ var packets = [
   ["Report", 0x29, {}],
   ["LiveGamer", 0x2a, {}],
   ["Acquaintance", 0x2b, {}],
+  ["AcquaintanceAdd",
+    0x2b01,
+    {
+        fields: [
+            { name: "characterId", type: "uint64string", defaultValue: "0x000" },
+            { name: "characterName", type: "string", defaultValue: "0" },
+            { name: "type", type: "uint32", defaultValue: 0 },
+            { name: "elapsedTime", type: "uint64string", defaultValue: "0x000" },
+            { name: "isOnline", type: "uint8", defaultValue: 0 },
+          ],
+       },
+    ],
+    ["AcquaintanceRemove",
+    0x2b02,
+    {
+        fields: [
+          ],
+       },
+    ],
+    ["AcquaintanceOnline",
+    0x2b03,
+    {
+        fields: [
+            { name: "characterId", type: "uint64string", defaultValue: "0x000" },
+            { name: "isOnline", type: "boolean", defaultValue: 0 },
+        ],
+     },
+  ],
   ["ClientServerShuttingDown", 0x2c, {}],
   [
     "Friend.List",

--- a/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
@@ -9465,7 +9465,83 @@ var packets = [
   ["RewardBuffs.AddBonus", 0x9f03, {}],
   ["RewardBuffs.RemoveBonus", 0x9f04, {}],
   ["RewardBuffs.GiveRewardToPlayer", 0x9f05, {}],
-  ["Abilities.InitAbility", 0xa001, {}],
+  ["Abilities.InitAbility",
+        0xa001,
+        {
+            fields: [
+                { name: "unknownDword1", type: "uint32", defaultValue: 0 },
+                { name: "unknownDword2", type: "uint32", defaultValue: 0 },
+                { name: "unknownDword3", type: "uint32", defaultValue: 0 },
+                { name: "unknownDword4", type: "uint32", defaultValue: 0 },
+                { name: "unknownQword1", type: "uint64string", defaultValue: "0x000" },
+                { name: "unknownQword2", type: "uint64string", defaultValue: "0x000" },
+                {
+                    name: "unknownSchema1",
+                    type: "schema",
+                    defaultValue: [],
+                    fields: [
+                        { name: "unknownQword3", type: "uint64string", defaultValue: "0x000" },
+                        { name: "unknownQword4", type: "uint64string", defaultValue: "0x000" },
+                        { name: "unknownFloatVector1", type: "floatvector4", defaultValue: 0 },
+                    ],
+                },
+                { name: "unknownWord1", type: "uint8", defaultValue: 0 },
+                {
+                    name: "unknownArray6",
+                    type: "schema",
+                    defaultValue: [],
+                    fields: [
+                        { name: "unknownWord2", type: "uint8", defaultValue: 0 },
+                        {
+                            name: "unknownArray1",
+                            type: "array",
+                            defaultValue: [],
+                            fields: [
+                                { name: "unknownDword6", type: "uint32", defaultValue: 0 },
+                                { name: "unknownDword7", type: "uint32", defaultValue: 0 },
+                            ],
+                        },
+                        {
+                            name: "unknownArray2",
+                            type: "array",
+                            defaultValue: [],
+                            fields: [
+                                { name: "unknownDword8", type: "uint32", defaultValue: 0 },
+                                { name: "unknownDword9", type: "uint32", defaultValue: 0 },
+                            ],
+                        },
+                        {
+                            name: "unknownArray3",
+                            type: "array",
+                            defaultValue: [],
+                            fields: [
+                                { name: "unknownDword10", type: "uint32", defaultValue: 0 },
+                                { name: "unknownWord1", type: "uint8", defaultValue: 0 },
+                            ],
+                        },
+                        {
+                            name: "unknownArray4",
+                            type: "array",
+                            defaultValue: [],
+                            fields: [
+                                { name: "unknownDword11", type: "uint32", defaultValue: 0 },
+                                { name: "unknownFloatVector2", type: "floatvector4", defaultValue: 0 },
+                            ],
+                        },
+                        {
+                            name: "unknownArray5",
+                            type: "array",
+                            defaultValue: [],
+                            fields: [
+                                { name: "unknownDword13", type: "uint32", defaultValue: 0 },
+                                { name: "unknownString1", type: "string", defaultValue: "0" },
+                          ],
+                      },
+                  ],
+              },
+          ],
+      },
+  ],
   ["Abilities.UpdateAbility", 0xa002, {}],
   ["Abilities.UninitAbility", 0xa003, {}],
   ["Abilities.SetAbilityActivationManager", 0xa004, {}],

--- a/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
@@ -9464,7 +9464,7 @@ var packets = [
   ["RewardBuffs.GiveRewardToPlayer", 0x9f05, {}],
   ["Abilities.InitAbility",
         0xa001,
-        {
+         {
             fields: [
                 { name: "unknownDword1", type: "uint32", defaultValue: 0 },
                 { name: "unknownDword2", type: "uint32", defaultValue: 0 },

--- a/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
@@ -7151,7 +7151,15 @@ var packets = [
   ],
   ["QuickChat.SendTell", 0x2802, {}],
   ["QuickChat.SendChatToChannel", 0x2803, {}],
-  ["Report", 0x29, {}],
+  ["ReportReply",
+      0x093600,
+        {
+            fields: [
+               { name: "unknownDword1", type: "uint32", defaultValue: 0  },
+              { name: "unknownDword2", type: "uint32", defaultValue: 0  },
+          ]
+      }
+  ],
   ["LiveGamer", 0x2a, {}],
   ["Acquaintance", 0x2b, {}],
   ["AcquaintanceAdd",


### PR DESCRIPTION
![Acquaintances](https://user-images.githubusercontent.com/63957530/142745346-22d9d49c-6f03-4fa2-bdea-339affe77aa5.png)
Packet "AcquaintanceAdd" adds a entry to "BaseClient.Acquaintances".
---------------------------------------------------------------------------------------

![image](https://user-images.githubusercontent.com/63957530/142745730-2affa283-6822-403c-b018-26dacdd81e9f.png)
Fixed opcode and structure for reportreply packet. 

The first dword seems to be the typeId of report, available types are.
0 -  UI.ReportPlayer.Success
1 -  UI.ReportPlayer.Failure.PlayerNotFound
2 -  UI.ReportPlayer.Failure.RequestPending
4 -  UI.ReportPlayer.Failure.AlreadyReported
5 and above - UI.ReportPlayer.Failure.CampionWroteBadCode

---------------------------------------------------------------------------------------

**Ability.initAbility**
Reversed the initAbility packet, if first dword value is 3 the server sends the packet a second time?
Seems like the correct packet structure but packet aint doing that much? :O

