### PR TITLE
Bugfix/:bug:enable loading screen on player respawn

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/h1z1packets.ts
@@ -2134,7 +2134,7 @@ const respawnLocationDataSchema = [
   { name: "nameId", type: "uint32", defaultValue: 6 },
   { name: "distance", type: "float", defaultValue: 7 },
   { name: "unknownByte1", type: "uint8", defaultValue: 1 },
-  { name: "unknownByte2", type: "uint8", defaultValue: 1 },
+  { name: "isActive", type: "uint8", defaultValue: 1 },
   {
     name: "unknownData1",
     type: "schema",
@@ -2146,9 +2146,9 @@ const respawnLocationDataSchema = [
       { name: "unknownByte5", type: "uint8", defaultValue: 0 },
     ],
   },
-  { name: "zoneId", type: "uint32", defaultValue: 8 },
-  { name: "unknownByte3", type: "uint8", defaultValue: 0 },
-  { name: "unknownByte4", type: "uint8", defaultValue: 0 },
+  { name: "zoneId", type: "uint32", defaultValue: 1 },
+  { name: "seatCount", type: "uint8", defaultValue: 0 },
+  { name: "seatOccupiedCount", type: "uint8", defaultValue: 0 },
 ];
 
 var packets = [

--- a/src/servers/ZoneServer/zoneserver.ts
+++ b/src/servers/ZoneServer/zoneserver.ts
@@ -141,28 +141,26 @@ export class ZoneServer extends EventEmitter {
     this._respawnLocations = spawnLocations.map((spawn: any) => {
       return {
         guid: this.generateGuid(),
-        respawnType: 4,
+        respawnType: 1,
         position: spawn.position,
+        iconId: 1,
+        respawnTypeIconId: 1,
+        respawnTotalTimeMS: 1,
         unknownDword1: 1,
-        unknownDword2: 1,
-        iconId1: 1,
-        iconId2: 1,
-        respawnTotalTime: 10,
-        respawnTimeMs: 10000,
         nameId: 1,
-        distance: 1000,
-        unknownByte1: 1,
-        unknownByte2: 1,
+        distance: 3000,
+        unknownByte1: 0,
+        isActive: 1,
         unknownData1: {
-          unknownByte1: 1,
-          unknownByte2: 1,
-          unknownByte3: 1,
-          unknownByte4: 1,
-          unknownByte5: 1,
+          unknownByte1: 0,
+          unknownByte2: 0,
+          unknownByte3: 0,
+          unknownByte4: 0,
+          unknownByte5: 0,
         },
-        unknownDword4: 1,
-        unknownByte3: 1,
-        unknownByte4: 1,
+        zoneId: 1,
+        unknownByte3: 0,
+        unknownByte4: 0,
       };
     });
     if (!this._mongoAddress) {
@@ -1147,6 +1145,10 @@ export class ZoneServer extends EventEmitter {
     if (client.character.isBleeding) {
       client.character.isBleeding = false;
     }
+    this.sendData(client, "PlayerUpdate.RespawnReply", {
+        characterId: client.character.characterId,
+		    unk: 1,
+      });
     this.sendDataToAll("PlayerUpdate.UpdateCharacterState", {
       characterId: client.character.characterId,
       state: "000000000000000000",
@@ -2053,8 +2055,8 @@ export class ZoneServer extends EventEmitter {
       unknownBoolean1: true,
       zoneType: 4,
       skyData: weather,
-      zoneId1: 3905829720,
-      zoneId2: 3905829720,
+      zoneId1: 1,
+      zoneId2: 1,
       nameId: 7699,
       unknownBoolean7: true,
     };


### PR DESCRIPTION
Dont know if respawnLocations are used by the game, they are added to the datasource, but it seems that there is no way of using them.
RespawnReply packet wont do anything on its own, but it enables the loadingscreen preventing player from falling under map