### PR TITLE
Feature/RC4FromH1emu-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@swc/cli": "0.1.55",
         "@swc/core": "1.2.127",
         "debug": "4.3.3",
-        "h1emu-core": "0.6.6",
+        "h1emu-core": "0.7.0",
         "h1z1-dataschema": "1.5.9",
         "mongodb": "4.4.0",
         "mongodb-restore-dump": "1.0.1",
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/h1emu-core": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/h1emu-core/-/h1emu-core-0.6.6.tgz",
-      "integrity": "sha512-qz08EohUjFUiPm3GrwjpqO8cFtmOt3xN3F7qtkqB8EIhcjRGdjywoO+s9knk+uYqRdEdSCFwaus7Q+BrCncMwQ=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/h1emu-core/-/h1emu-core-0.7.0.tgz",
+      "integrity": "sha512-HXkfQnxavBtWp1H+RjzbMP53TJ+9m/9u1ML4YCFiBV/R6PvxfZy9nixeXjE4CxNIw/DOvmE1NU44M5SngRRU2g=="
     },
     "node_modules/h1z1-buffer": {
       "version": "1.0.1",
@@ -1683,9 +1683,9 @@
       }
     },
     "h1emu-core": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/h1emu-core/-/h1emu-core-0.6.6.tgz",
-      "integrity": "sha512-qz08EohUjFUiPm3GrwjpqO8cFtmOt3xN3F7qtkqB8EIhcjRGdjywoO+s9knk+uYqRdEdSCFwaus7Q+BrCncMwQ=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/h1emu-core/-/h1emu-core-0.7.0.tgz",
+      "integrity": "sha512-HXkfQnxavBtWp1H+RjzbMP53TJ+9m/9u1ML4YCFiBV/R6PvxfZy9nixeXjE4CxNIw/DOvmE1NU44M5SngRRU2g=="
     },
     "h1z1-buffer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@swc/cli": "0.1.55",
     "@swc/core": "1.2.127",
     "debug": "4.3.3",
-    "h1emu-core": "0.6.6",
+    "h1emu-core": "0.7.0",
     "h1z1-dataschema": "1.5.9",
     "mongodb": "4.4.0",
     "mongodb-restore-dump": "1.0.1",

--- a/src/servers/SoeServer/soeinputstream.ts
+++ b/src/servers/SoeServer/soeinputstream.ts
@@ -12,7 +12,7 @@
 // ======================================================================
 
 import { EventEmitter } from "events";
-import { createDecipheriv, Decipher } from "crypto";
+import { RC4 } from "h1emu-core"
 
 const debug = require("debug")("SOEInputStream");
 
@@ -24,7 +24,7 @@ export class SOEInputStream extends EventEmitter {
   _lastProcessedFragment: number;
   _fragments: Array<any>;
   _useEncryption: boolean;
-  _rc4: Decipher;
+  _rc4: RC4;
 
   constructor(cryptoKey: Uint8Array) {
     super();
@@ -35,7 +35,7 @@ export class SOEInputStream extends EventEmitter {
     this._lastProcessedFragment = -1;
     this._fragments = [];
     this._useEncryption = false;
-    this._rc4 = createDecipheriv("rc4", cryptoKey, null);
+    this._rc4 = new RC4(cryptoKey)
   }
 
   _processDataFragments(): void {
@@ -109,11 +109,10 @@ export class SOEInputStream extends EventEmitter {
                       It does this by having all internal packets start with a zero (0) byte.
                     */
           if (data.length > 1 && data.readUInt16LE(0) === 0) {
-            this._rc4.write(data.slice(1));
+            data = Buffer.from(this._rc4.encrypt(new Uint32Array(data.slice(1))))
           } else {
-            this._rc4.write(data);
+            data = Buffer.from(this._rc4.encrypt(new Uint32Array(data)))
           }
-          data = this._rc4.read();
         }
         this.emit("data", null, data);
       }

--- a/src/servers/SoeServer/soeoutputstream.ts
+++ b/src/servers/SoeServer/soeoutputstream.ts
@@ -11,8 +11,8 @@
 //   Based on https://github.com/psemu/soe-network
 // ======================================================================
 
-import crypto from "crypto";
 import { EventEmitter } from "events";
+import {RC4} from "h1emu-core"
 
 const debug = require("debug")("SOEOutputStream");
 
@@ -22,7 +22,7 @@ export class SOEOutputStream extends EventEmitter {
   _sequence: number;
   _lastAck: number;
   _cache: any;
-  _rc4: crypto.Cipher;
+  _rc4: RC4;
   _enableCaching: boolean;
   constructor(cryptoKey: Uint8Array, fragmentSize: number = 0) {
     super();
@@ -32,13 +32,13 @@ export class SOEOutputStream extends EventEmitter {
     this._lastAck = -1;
     this._cache = {};
     this._enableCaching = true;
-    this._rc4 = crypto.createCipheriv("rc4", cryptoKey, null);
+    this._rc4 = new RC4(cryptoKey)
   }
 
   write(data: Buffer): void {
     if (this._useEncryption) {
-      this._rc4.write(data);
-      data = this._rc4.read();
+      data = Buffer.from(this._rc4.encrypt(new Uint32Array(data)))
+
       if (data[0] === 0) {
         const tmp = Buffer.allocUnsafe(1);
         tmp[0] = 0;


### PR DESCRIPTION
some benchmarks:

rust: 0.009ms
c: 0.024ms

rust: 0.007ms
c: 0.018ms

rust: 0.011ms
c: 0.023ms

rust: 0.007ms
c: 0.017ms

rust: 0.008ms
c: 0.019ms

rust: 0.008ms
c: 0.016ms

rust: 0.026ms
c: 0.023ms

rust: 0.008ms
c: 0.043ms

Knowing that the rust bench include using Buffer.from conversion and also creating a new Uint32array. That's impressive !

And also with this we're not stuck on nodejs v16 anymore since we're not using openssl !


others benchmarks:

c/windows :
Node v16.14.0
Client#2-fullLogin: 38.606ms
Client#3-fullLogin: 37.895ms
Client#4-fullLogin: 38.265ms
Client#5-fullLogin: 38.359ms
Client#6-fullLogin: 37.75ms
Client#7-fullLogin: 37.867ms
Client#8-fullLogin: 38.05ms
Client#0-fullLogin: 44.181ms
Client#1-fullLogin: 41.95ms
Client#9-fullLogin: 38.836ms


rust/ windows :
Client#0-fullLogin: 25.215ms
Client#1-fullLogin: 25.38ms
Client#9-fullLogin: 25.958ms
Client#2-fullLogin: 27.818ms
Client#3-fullLogin: 28.042ms
Client#4-fullLogin: 28.53ms
Client#5-fullLogin: 28.825ms
Client#6-fullLogin: 29.332ms
Client#7-fullLogin: 29.729ms
Client#8-fullLogin: 30.022ms


c/linux :

Client#1-fullLogin: 32.228ms
Client#0-fullLogin: 36.948ms
Client#2-fullLogin: 32.595ms
Client#3-fullLogin: 32.513ms
Client#4-fullLogin: 32.547ms
Client#5-fullLogin: 32.917ms
Client#6-fullLogin: 33.028ms
Client#7-fullLogin: 33.076ms
Client#8-fullLogin: 33.097ms
Client#9-fullLogin: 33.283ms

rust/linux :

Client#1-fullLogin: 22.858ms
Client#2-fullLogin: 23.224ms
Client#3-fullLogin: 23.425ms
Client#4-fullLogin: 24.397ms
Client#5-fullLogin: 24.512ms
Client#6-fullLogin: 24.625ms
Client#7-fullLogin: 25.098ms
Client#0-fullLogin: 29.873ms
Client#8-fullLogin: 26.606ms
Client#9-fullLogin: 31.904ms