### PR TITLE
bugfix/itemPickupsNotGlowing

### DIFF
--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -1726,7 +1726,7 @@ export class ZonePacketHandlers {
       entity = server.getEntity(guid);
 
     if (!entity) return;
-    if (entity instanceof Crate || entity instanceof BaseLightweightCharacter) {
+    if (entity instanceof Crate || entity instanceof BaseFullCharacter) {
       client.character.currentInteractionGuid = guid;
       client.character.lastInteractionStringTime = Date.now();
       return;


### PR DESCRIPTION
No items were being highlighted on pickups. Had a slight oversight on the object type. Fix for #1733.  