### PR TITLE
Dressed Bandage recipe

### DIFF
--- a/src/servers/ZoneServer2016/data/Recipes.ts
+++ b/src/servers/ZoneServer2016/data/Recipes.ts
@@ -1167,6 +1167,7 @@ export const recipes: { [recipeId: number]: Recipe } = {
   [Items.BANDAGE_DRESSED]: {
     filterId: FilterIds.SURVIVAL,
     bundleCount: 5,
+    leftOverItems: [Items.WATER_EMPTY],
     components: [
       {
         itemDefinitionId: Items.BANDAGE,


### PR DESCRIPTION
Reported by "The Rizzler" on discord. Dressed bandage recipe didn't give back the bottle when crafted, in his words: "you're emptying the honey bottle onto the dressing so it's weird that the bottle would be consumed in the process." Fix: return an empty bottle lol