### PR TITLE
bugfix/npcReplication

### DIFF
--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -1726,7 +1726,7 @@ export class ZonePacketHandlers {
       entity = server.getEntity(guid);
 
     if (!entity) return;
-    if (entity instanceof Crate || entity instanceof BaseFullCharacter) {
+    if (entity instanceof Crate) {
       client.character.currentInteractionGuid = guid;
       client.character.lastInteractionStringTime = Date.now();
       return;
@@ -1748,9 +1748,12 @@ export class ZonePacketHandlers {
     }
     client.character.currentInteractionGuid = guid;
     client.character.lastInteractionStringTime = Date.now();
+    const isNonReplicatable =
+      entity instanceof Destroyable ||
+      entity instanceof Character2016
     if (
       entity instanceof BaseLightweightCharacter &&
-      !(entity instanceof Destroyable) &&
+      !(isNonReplicatable) &&
       !client.sentInteractionData.includes(entity)
     ) {
       server.sendData<ReplicationNpcComponent>(

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -1749,11 +1749,10 @@ export class ZonePacketHandlers {
     client.character.currentInteractionGuid = guid;
     client.character.lastInteractionStringTime = Date.now();
     const isNonReplicatable =
-      entity instanceof Destroyable ||
-      entity instanceof Character2016
+      entity instanceof Destroyable || entity instanceof Character2016;
     if (
       entity instanceof BaseLightweightCharacter &&
-      !(isNonReplicatable) &&
+      !isNonReplicatable &&
       !client.sentInteractionData.includes(entity)
     ) {
       server.sendData<ReplicationNpcComponent>(


### PR DESCRIPTION
Essentially the fix for #1750 and #1733 only worked because the function never even got down to Replication.NpcComponent. Objects still need to be sent the packet so instead revert the change and move the logic down the function. This fixes #1673 for good.