### PR TITLE
Update prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@typescript-eslint/parser": "^6.13.2",
         "eslint": "^8.55.0",
         "glob": "8.1.0",
-        "prettier": "^3.1.0",
+        "prettier": "^3.1.1",
         "ts-node": "10.9.1",
         "typedoc": "^0.25.4"
       },
@@ -1577,9 +1577,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@typescript-eslint/parser": "^6.13.2",
     "eslint": "^8.55.0",
     "glob": "8.1.0",
-    "prettier": "^3.1.0",
+    "prettier": "^3.1.1",
     "ts-node": "10.9.1",
     "typedoc": "^0.25.4"
   },


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the version of `prettier` from `3.1.0` to `3.1.1`.
> 
> ## What changed
> The `prettier` package in both `package.json` and `package-lock.json` files has been updated to the latest version `3.1.1`.
> 
> ## How to test
> After pulling the changes, run `npm install` to update the dependencies. Then, you can test the new version of `prettier` by running `npm run prettier` or any other script that uses `prettier`.
> 
> ## Why make this change
> Updating to the latest version of `prettier` ensures that we have the latest features, improvements, and bug fixes. This can help improve the quality of our code and make our development process more efficient.
</details>