### PR TITLE
speedup nights

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -385,8 +385,8 @@ export class ZoneServer2016 extends EventEmitter {
   routinesLoopTimer?: NodeJS.Timeout;
   private _mongoClient?: MongoClient;
   rebootTimeTimer?: NodeJS.Timeout;
-  // 3600 * 5 = 5 hours so server always starts at 5am
-  inGameTimeManager: IngameTimeManager = new IngameTimeManager(3600 * 5);
+  // 3600 * 6 = 6 hours so server always starts at 6am
+  inGameTimeManager: IngameTimeManager = new IngameTimeManager(3600 * 6);
 
   /* MANAGED BY CONFIGMANAGER */
   proximityItemsDistance!: number;
@@ -4182,13 +4182,9 @@ export class ZoneServer2016 extends EventEmitter {
 
   sendGameTimeSync(client: Client) {
     debug("GameTimeSync");
-    const cycleSpeed = this.inGameTimeManager.timeFrozen
-      ? 0
-      : // 0.97222 is the multiplier to make the game time sync with real time
-        this.inGameTimeManager.timeMultiplier * 0.97222;
     this.sendData<GameTimeSync>(client, "GameTimeSync", {
       time: Int64String(this.inGameTimeManager.time),
-      cycleSpeed,
+      cycleSpeed: this.inGameTimeManager.getCycleSpeed(),
       unknownBoolean1: false
     });
   }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces changes to the `IngameTimeManager` class in the `gametimemanager.ts` file and the `ZoneServer2016` class in the `zoneserver.ts` file. The changes include the addition of a `nightMultiplier` property and a `getCycleSpeed` method to the `IngameTimeManager` class, and the replacement of the `cycleSpeed` calculation in the `sendGameTimeSync` method of the `ZoneServer2016` class with a call to the new `getCycleSpeed` method.
> 
> ## What changed
> In the `IngameTimeManager` class, a `nightMultiplier` property was added to adjust the game time speed during night hours. The `getCycleSpeed` method was added to calculate the cycle speed based on the `timeMultiplier` and `nightMultiplier` properties. The `updateTime` method was updated to adjust the `nightMultiplier` based on the current game time.
> 
> In the `ZoneServer2016` class, the `sendGameTimeSync` method was updated to use the `getCycleSpeed` method from the `IngameTimeManager` class to calculate the `cycleSpeed`.
> 
> ## How to test
> To test these changes, you can run the game and observe the game time speed during different hours of the day. The game time speed should be faster during night hours (from 7 PM to 5 AM) compared to day hours.
> 
> ## Why make this change
> This change was made to introduce a dynamic game time speed that changes based on the time of day. This can enhance the game experience by making the game world feel more immersive and realistic.
</details>