### PR TITLE
remove unused "clientban" lzprotocol packet

### DIFF
--- a/src/protocols/lzconnectionprotocol.ts
+++ b/src/protocols/lzconnectionprotocol.ts
@@ -159,17 +159,17 @@ const packets: PacketStructures = [
       ]
     }
   ],
-  // Doesn't have a req/rep sys
-  [
-    "ClientBan",
-    0x16,
-    {
-      fields: [
-        { name: "loginSessionId", type: "uint64string", defaultValue: "" },
-        { name: "status", type: "boolean", defaultValue: 0 }
-      ]
-    }
-  ],
+  // removed
+  // [
+  //   "ClientBan",
+  //   0x16,
+  //   {
+  //     fields: [
+  //       { name: "loginSessionId", type: "uint64string", defaultValue: "" },
+  //       { name: "status", type: "boolean", defaultValue: 0 }
+  //     ]
+  //   }
+  // ],
   [
     "ClientMessage",
     0x17,

--- a/src/servers/LoginServer/loginserver.ts
+++ b/src/servers/LoginServer/loginserver.ts
@@ -238,40 +238,6 @@ export class LoginServer extends EventEmitter {
                   );
                   break;
                 }
-                case "ClientBan": {
-                  const { status, loginSessionId } = packet.data;
-                  const serverId = this._zoneConnections[client.clientId],
-                    isGlobal = await this._isServerOfficial(serverId);
-
-                  // login server should not track non-global bans
-                  if (!isGlobal) return;
-
-                  try {
-                    const userSession = await this._db
-                      .collection(DB_COLLECTIONS.USERS_SESSIONS)
-                      .findOne({ guid: loginSessionId });
-                    this._db
-                      ?.collection(DB_COLLECTIONS.BANNED_LIGHT)
-                      .findOneAndUpdate(
-                        { serverId: serverId },
-                        {
-                          $set: {
-                            serverId,
-                            authKey: userSession.authKey,
-                            status,
-                            isGlobal
-                          }
-                        },
-                        { upsert: true }
-                      );
-                  } catch (e) {
-                    console.log(e);
-                    console.log(
-                      `Failed to register clientBan serverId:${serverId} loginSessionId:${loginSessionId}`
-                    );
-                  }
-                  break;
-                }
                 case "ClientMessage": {
                   const { guid, message, showConsole, clearOutput } =
                     packet.data;


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request removes the "ClientBan" functionality from the `lzconnectionprotocol.ts` and `loginserver.ts` files. 
> 
> ## What changed
> The "ClientBan" functionality was removed from the `lzconnectionprotocol.ts` file. This included removing the packet structure for "ClientBan" and the associated fields. 
> 
> In the `loginserver.ts` file, the case for "ClientBan" was removed from the switch statement. This included removing the logic for handling a "ClientBan" event, such as fetching the user session from the database and updating the banned light collection.
> 
> ## How to test
> To test these changes, run the application and ensure that it still functions as expected without the "ClientBan" functionality. This could include testing the login functionality, as well as any other functionality that may have interacted with the "ClientBan" functionality.
> 
> ## Why make this change
> The "ClientBan" functionality was removed because it was no longer needed in the application. This could be due to a change in requirements, or a decision to handle client bans in a different way. By removing this unused code, we can make the codebase cleaner and easier to maintain.
</details>