### PR TITLE
Change salvaging ammo and update weapon workbench crafting

### DIFF
--- a/src/servers/ZoneServer2016/data/Recipes.ts
+++ b/src/servers/ZoneServer2016/data/Recipes.ts
@@ -520,7 +520,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 2
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.AMMO_308]: {
     filterId: FilterIds.WEAPONS,
@@ -541,7 +542,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 4
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.AMMO_380]: {
     filterId: FilterIds.WEAPONS,
@@ -558,7 +560,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 1
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.AMMO_44]: {
     filterId: FilterIds.WEAPONS,
@@ -579,7 +582,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 2
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.AMMO_45]: {
     filterId: FilterIds.WEAPONS,
@@ -596,7 +600,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 2
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.AMMO_12GA]: {
     filterId: FilterIds.WEAPONS,
@@ -617,7 +622,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 4
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.AMMO_762]: {
     filterId: FilterIds.WEAPONS,
@@ -638,7 +644,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 2
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.AMMO_9MM]: {
     filterId: FilterIds.WEAPONS,
@@ -655,7 +662,8 @@ export const recipes: { [recipeId: number]: Recipe } = {
         itemDefinitionId: Items.GUNPOWDER_REFINED,
         requiredAmount: 1
       }
-    ]
+    ],
+    requireWeaponWorkbench: true
   },
   [Items.WEAPON_BLAZE]: {
     filterId: FilterIds.WEAPONS,

--- a/src/servers/ZoneServer2016/managers/craftmanager.ts
+++ b/src/servers/ZoneServer2016/managers/craftmanager.ts
@@ -387,6 +387,28 @@ export class CraftManager {
         return false;
       }
     }
+    if (recipe.requireWeaponWorkbench) {
+      if (
+        !checkConstructionInRange(
+          server._constructionSimple,
+          client.character.state.position,
+          3,
+          Items.WORKBENCH_WEAPON
+        ) &&
+        !checkConstructionInRange(
+          server._worldSimpleConstruction,
+          client.character.state.position,
+          3,
+          Items.WORKBENCH_WEAPON
+        )
+      ) {
+        server.sendAlert(
+          client,
+          "You must be near a weapon workbench to complete this recipe"
+        );
+        return false;
+      }
+    }
 
     if (
       !(await this.generateCraftQueue(

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6663,26 +6663,6 @@ export class ZoneServer2016 extends EventEmitter {
       );
       return;
     }
-    if (
-      !checkConstructionInRange(
-        this._constructionSimple,
-        client.character.state.position,
-        3,
-        Items.WORKBENCH_WEAPON
-      ) &&
-      !checkConstructionInRange(
-        this._worldSimpleConstruction,
-        client.character.state.position,
-        3,
-        Items.WORKBENCH_WEAPON
-      )
-    ) {
-      this.sendAlert(
-        client,
-        "You must be near a weapon workbench to complete this recipe"
-      );
-      return;
-    }
     const count =
       item.itemDefinitionId == Items.AMMO_12GA ||
       item.itemDefinitionId == Items.AMMO_762 ||
@@ -6909,6 +6889,9 @@ export class ZoneServer2016 extends EventEmitter {
 
   salvageItemPass(client: Client, item: BaseItem, count: number) {
     if (!this.removeInventoryItem(client.character, item)) return;
+    if (item.itemDefinitionId == Items.AMMO_12GA) {
+      client.character.lootItem(this, this.generateItem(Items.SHARD_PLASTIC, 1));
+    }
     client.character.lootItem(this, this.generateItem(Items.ALLOY_LEAD, count));
     client.character.lootItem(this, this.generateItem(Items.SHARD_BRASS, 1));
     client.character.lootItem(

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6890,7 +6890,10 @@ export class ZoneServer2016 extends EventEmitter {
   salvageItemPass(client: Client, item: BaseItem, count: number) {
     if (!this.removeInventoryItem(client.character, item)) return;
     if (item.itemDefinitionId == Items.AMMO_12GA) {
-      client.character.lootItem(this, this.generateItem(Items.SHARD_PLASTIC, 1));
+      client.character.lootItem(
+        this,
+        this.generateItem(Items.SHARD_PLASTIC, 1)
+      );
     }
     client.character.lootItem(this, this.generateItem(Items.ALLOY_LEAD, count));
     client.character.lootItem(this, this.generateItem(Items.SHARD_BRASS, 1));

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -88,7 +88,6 @@ import {
   toBigHex,
   toHex,
   calculate_falloff,
-  checkConstructionInRange,
   resolveHostAddress,
   getDifference,
   logClientActionToMongo,

--- a/src/types/zoneserver.ts
+++ b/src/types/zoneserver.ts
@@ -229,6 +229,7 @@ export interface Recipe {
   bundleCount?: number;
   components: Array<RecipeComponent>;
   requireWorkbench?: boolean
+  requireWeaponWorkbench?: boolean
   leftOverItems?: number[]
 }
 


### PR DESCRIPTION
https://www.youtube.com/watch?v=aFpSNGow3QI
https://www.youtube.com/watch?v=DG7_CBDTsuM
https://www.youtube.com/watch?v=iQpJyKFLgnQ

I got my sources from these 3 videos, essentially ammo should require a weapon workbench to craft, and salvaging ammo shouldn't require a weapon workbench. In the first video, he is salvaging ammo inside of a bathroom, there's other parts of the video where he is salvaging ammo from file cabinets too, so this is more than enough to show that you don't need a weapon workbench for salvaging ammo. As for the weapon workbench crafting, https://survivorsrest.com/justsurvive/patchnotes the September 28th, 2016 update changed it so recipes that use gunpowder (ammo essentially), would require a weapon workbench for crafting, so add the logic for that and remove the check for a nearby weapon workbench when it comes to salvaging. I noticed too that shotgun shells don't produce a plastic shard, so updated that as-well.