### PR TITLE
CollectingEntity fixes

### DIFF
--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -148,4 +148,4 @@ decay:
 
 smelting:
   burnTime: 120000 # consume fuel every 120 seconds
-  smeltTime: 40000 # smelt 1 item every 40 seconds
+  smeltTime: 7000 # smelt 1 item every 7 seconds

--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -177,9 +177,9 @@ export class SmeltingManager {
 
   getBurnTime(item: BaseItem): number {
     if (item.itemDefinitionId == Items.CHARCOAL) {
-      return this.burnTime = 2400000
+      return (this.burnTime = 2400000);
     } else {
-      return this.burnTime = 120000
+      return (this.burnTime = 120000);
     }
   }
 
@@ -191,7 +191,7 @@ export class SmeltingManager {
     for (const a in container!.items) {
       const item = container!.items[a];
       if (entity.subEntity!.allowedFuel.includes(item.itemDefinitionId)) {
-        this.getBurnTime(item)
+        this.getBurnTime(item);
         server.removeContainerItem(entity, item, entity.getContainer(), 1);
         if (item.itemDefinitionId == Items.WOOD_LOG) {
           // give charcoal if wood log was burned

--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -175,8 +175,8 @@ export class SmeltingManager {
     );
   }*/
 
-  getBurnTime(entity: BaseItem): number {
-    if (entity.itemDefinitionId == Items.CHARCOAL) {
+  getBurnTime(item: BaseItem): number {
+    if (item.itemDefinitionId == Items.CHARCOAL) {
       return this.burnTime = 2400000
     } else {
       return this.burnTime = 120000

--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -31,6 +31,7 @@ import { BaseItem } from "../classes/baseItem";
 import { LoadoutContainer } from "../classes/loadoutcontainer";
 import { smeltingData } from "../data/Recipes";
 import { scheduler } from "timers/promises";
+import { CharacterPlayWorldCompositeEffect } from "types/zone2016packets";
 
 export class SmeltingManager {
   _smeltingEntities: { [characterId: string]: string } = {};
@@ -84,7 +85,7 @@ export class SmeltingManager {
           this.smelt(server, entity);
         }
       }
-      server.sendDataToAllWithSpawnedEntity(
+      server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
         subEntity!.dictionary,
         entity.characterId,
         "Character.PlayWorldCompositeEffect",
@@ -92,7 +93,7 @@ export class SmeltingManager {
           characterId: entity.characterId,
           effectId: entity.subEntity!.workingEffect,
           position: entity.state.position,
-          unk3: Math.ceil(this.burnTime / 1000)
+          effectTime: Math.ceil(this.burnTime / 1000)
         }
       );
     }
@@ -174,6 +175,14 @@ export class SmeltingManager {
     );
   }*/
 
+  getBurnTime(entity: BaseItem): number {
+    if (entity.itemDefinitionId == Items.CHARCOAL) {
+      return this.burnTime = 2400000
+    } else {
+      return this.burnTime = 120000
+    }
+  }
+
   private checkFuel(
     server: ZoneServer2016,
     entity: LootableConstructionEntity
@@ -182,6 +191,7 @@ export class SmeltingManager {
     for (const a in container!.items) {
       const item = container!.items[a];
       if (entity.subEntity!.allowedFuel.includes(item.itemDefinitionId)) {
+        this.getBurnTime(item)
         server.removeContainerItem(entity, item, entity.getContainer(), 1);
         if (item.itemDefinitionId == Items.WOOD_LOG) {
           // give charcoal if wood log was burned

--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -131,6 +131,17 @@ export class SmeltingManager {
           this.checkAnimalTrap(server, entity, subEntity, container);
           break;
       }
+      server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
+        subEntity!.dictionary,
+        entity.characterId,
+        "Character.PlayWorldCompositeEffect",
+        {
+          characterId: entity.characterId,
+          effectId: entity.subEntity!.workingEffect,
+          position: entity.state.position,
+          effectTime: Math.ceil(this.collectingTickTime / 1000)
+        }
+      );
     }
     this.checkCollectorsTimer = setTimeout(() => {
       this.checkCollectors(server);


### PR DESCRIPTION
https://www.youtube.com/watch?v=vpChC-4cKhE

Using this video as reference ^, furnaces in December 2016 used to smelt items in ~7 seconds, DBG also changed in the April 2016 update to where charcoal burns for 40 minutes rather than at the same speed as wood logs/planks etc. This PR changes the following:
- change smeltTime from 40 seconds to 7 seconds.
- add getBurnTime function to check if our current fuel item is charcoal or not, if so adjust the burnTime accordingly (40 mins for charcoal and 2 minutes for wood types)
- fix furnace sound bug where furnace noise would stop playing after the 1st item was done smelting.
- fix bee box fx (so bees fly around the bee box + noise)