### PR TITLE
Make some gatewayServer fields properly private

### DIFF
--- a/src/servers/GatewayServer/gatewayserver.threaded.ts
+++ b/src/servers/GatewayServer/gatewayserver.threaded.ts
@@ -15,6 +15,7 @@ import { EventEmitter } from "node:events";
 import SOEClient from "../SoeServer/soeclient";
 import { SOEOutputChannels } from "servers/SoeServer/soeoutputstream";
 import { Worker, MessageChannel } from "node:worker_threads";
+import { scheduler } from "node:timers/promises";
 
 export enum GatewayServerThreadedInternalEvents {
   START,
@@ -90,8 +91,20 @@ export class GatewayServerThreaded extends EventEmitter {
     this.internalChannel.port2.postMessage(
       GatewayServerThreadedInternalEvents.STOP
     );
-    setTimeout(() => {
-      this.worker.terminate();
-    }, 1000);
+    await scheduler.wait(1000);
+    this.worker.terminate();
+  }
+
+  getSoeClient(soeClientId: string): SOEClient | undefined {
+    soeClientId;
+    // TODO: implement
+    // return this._soeServer.getSoeClient(soeClientId);
+    return undefined;
+  }
+
+  deleteSoeClient(soeClient: SOEClient) {
+    soeClient;
+    // TODO: implement
+    // this._soeServer.deleteClient(soeClient);
   }
 }

--- a/src/servers/GatewayServer/gatewayserver.ts
+++ b/src/servers/GatewayServer/gatewayserver.ts
@@ -21,8 +21,8 @@ import { SOEOutputChannels } from "servers/SoeServer/soeoutputstream";
 const debug = require("debug")("GatewayServer");
 
 export class GatewayServer extends EventEmitter {
-  _soeServer: SOEServer;
-  _protocol: GatewayProtocol;
+  private _soeServer: SOEServer;
+  private _protocol: GatewayProtocol;
   private _crcLength: crc_length_options;
   private _udpLength: number;
 
@@ -91,6 +91,14 @@ export class GatewayServer extends EventEmitter {
         }
       }
     );
+  }
+
+  getSoeClient(soeClientId: string): SOEClient | undefined {
+    return this._soeServer.getSoeClient(soeClientId);
+  }
+
+  deleteSoeClient(soeClient: SOEClient) {
+    this._soeServer.deleteClient(soeClient);
   }
 
   start() {

--- a/src/servers/ZoneServer2015/zoneserver.ts
+++ b/src/servers/ZoneServer2015/zoneserver.ts
@@ -160,12 +160,6 @@ export class ZoneServer2015 extends EventEmitter {
       this.onZoneLoginEvent(client);
     });
 
-    this._gatewayServer._soeServer.on("fatalError", (soeClient: SOEClient) => {
-      const client = this._clients[soeClient.sessionId];
-      this.deleteClient(client);
-      // TODO: force crash the client
-    });
-
     this._gatewayServer.on(
       "login",
       (
@@ -451,7 +445,7 @@ export class ZoneServer2015 extends EventEmitter {
   }
 
   getSoeClient(soeClientId: string): SOEClient | undefined {
-    return this._gatewayServer._soeServer.getSoeClient(soeClientId);
+    return this._gatewayServer.getSoeClient(soeClientId);
   }
 
   deleteClient(client: Client) {
@@ -467,7 +461,7 @@ export class ZoneServer2015 extends EventEmitter {
       delete this._clients[client.sessionId];
       const soeClient = this.getSoeClient(client.soeClientId);
       if (soeClient) {
-        this._gatewayServer._soeServer.deleteClient(soeClient);
+        this._gatewayServer.deleteSoeClient(soeClient);
       }
       if (!this._soloMode) {
         this.sendZonePopulationUpdate();

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -16,7 +16,6 @@ const debugName = "ZoneServer",
 
 process.env.isBin && require("./managers/worlddatamanagerthread");
 import { EventEmitter } from "node:events";
-import { GatewayServer } from "../GatewayServer/gatewayserver";
 import { H1Z1Protocol } from "../../protocols/h1z1protocol";
 import SOEClient from "../SoeServer/soeclient";
 import { LoginConnectionManager } from "../LoginZoneConnection/loginconnectionmanager";
@@ -229,6 +228,7 @@ import { SOEOutputChannels } from "../../servers/SoeServer/soeoutputstream";
 import { scheduler } from "node:timers/promises";
 import { GatewayChannels } from "h1emu-core";
 import { IngameTimeManager } from "./managers/gametimemanager";
+import { GatewayServer } from "../GatewayServer/gatewayserver";
 
 const spawnLocations2 = require("../../../data/2016/zoneData/Z1_gridSpawns.json"),
   deprecatedDoors = require("../../../data/2016/sampleData/deprecatedDoors.json"),
@@ -461,11 +461,6 @@ export class ZoneServer2016 extends EventEmitter {
       await this.onZoneLoginEvent(client);
     });
 
-    this._gatewayServer._soeServer.on("fatalError", (soeClient: SOEClient) => {
-      const client = this._clients[soeClient.sessionId];
-      this.deleteClient(client);
-      // TODO: force crash the client
-    });
     this._gatewayServer.on(
       "login",
       async (
@@ -1991,7 +1986,7 @@ export class ZoneServer2016 extends EventEmitter {
     delete this._clients[client.sessionId];
     const soeClient = this.getSoeClient(client.soeClientId);
     if (soeClient) {
-      this._gatewayServer._soeServer.deleteClient(soeClient);
+      this._gatewayServer.deleteSoeClient(soeClient);
     }
     if (!this._soloMode) {
       this.sendZonePopulationUpdate();
@@ -7598,7 +7593,7 @@ export class ZoneServer2016 extends EventEmitter {
     return generateRandomGuid();
   }
   getSoeClient(soeClientId: string): SOEClient | undefined {
-    return this._gatewayServer._soeServer.getSoeClient(soeClientId);
+    return this._gatewayServer.getSoeClient(soeClientId);
   }
   private _sendRawDataReliable(client: Client, data: Buffer) {
     const soeClient = this.getSoeClient(client.soeClientId);


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> 
> ## What changed
> - Added a new method `getSoeClient` to `GatewayServerThreaded`
> - Modified the `getSoeClient` and `deleteSoeClient` methods in `GatewayServer`
> 
> ## How to test
> 1. Run the application
> 2. Perform the actions that involve the `GatewayServerThreaded` and `GatewayServer` classes
> 3. Verify that the changes work as expected and do not introduce any issues
> 
> ## Why make this change
> - The addition of the `getSoeClient` method in `GatewayServerThreaded` allows retrieving a `SOEClient` object based on its ID
> - The modifications in the `getSoeClient` and `deleteSoeClient` methods in `GatewayServer` are made to use the corresponding methods in `GatewayServerThreaded`
</details>