### PR TITLE
Adapt GatewayServerThreaded to get clientinfo

### DIFF
--- a/src/servers/GatewayServer/gatewayserver.threaded.ts
+++ b/src/servers/GatewayServer/gatewayserver.threaded.ts
@@ -12,10 +12,10 @@
 // ======================================================================
 
 import { EventEmitter } from "node:events";
-import SOEClient from "../SoeServer/soeclient";
 import { SOEOutputChannels } from "servers/SoeServer/soeoutputstream";
 import { Worker, MessageChannel } from "node:worker_threads";
 import { scheduler } from "node:timers/promises";
+import { ClientInfoMessage } from "./gatewayserver.worker";
 
 export enum GatewayServerThreadedInternalEvents {
   START,
@@ -27,7 +27,10 @@ export class GatewayServerThreaded extends EventEmitter {
   appDataChannel: MessageChannel = new MessageChannel();
   loginChannel: MessageChannel = new MessageChannel();
   disconnectChannel: MessageChannel = new MessageChannel();
+  clientInfoChannel: MessageChannel = new MessageChannel();
   internalChannel: MessageChannel = new MessageChannel();
+  reqCount: number = 0;
+  requestQueue: Map<number, any> = new Map();
   constructor(serverPort: number, gatewayKey: Uint8Array) {
     super();
     this.worker = new Worker(
@@ -39,18 +42,30 @@ export class GatewayServerThreaded extends EventEmitter {
           appDataChannel: this.appDataChannel.port1,
           disconnectChannel: this.disconnectChannel.port1,
           loginChannel: this.loginChannel.port1,
-          internalChannel: this.internalChannel.port1
+          internalChannel: this.internalChannel.port1,
+          clientInfoChannel: this.clientInfoChannel.port1
         },
         transferList: [
           this.appDataChannel.port1,
           this.disconnectChannel.port1,
           this.loginChannel.port1,
-          this.internalChannel.port1
+          this.internalChannel.port1,
+          this.clientInfoChannel.port1
         ]
       }
     );
+    this.clientInfoChannel.port2.on("message", (msg) => {
+      // Resolve the promise with the result
+      this.requestQueue.get(msg.requestId)(msg.result);
+      this.requestQueue.delete(msg.requestId);
+    });
     this.appDataChannel.port2.on("message", (msg) => {
-      this.emit("tunneldata", msg.client, msg.data, msg.channel);
+      this.emit(
+        "tunneldata",
+        msg.sessionId,
+        Buffer.from(msg.data),
+        msg.channel
+      );
     });
     this.disconnectChannel.port2.on("message", (sessionId: number) => {
       this.emit("disconnect", sessionId);
@@ -58,9 +73,8 @@ export class GatewayServerThreaded extends EventEmitter {
     this.loginChannel.port2.on("message", (msg) => {
       this.emit(
         "login",
-        msg.client,
-
-        msg.character_id,
+        msg.soeClientId,
+        msg.characterId,
         msg.ticket,
         msg.client_protocol
       );
@@ -76,10 +90,14 @@ export class GatewayServerThreaded extends EventEmitter {
     );
   }
 
-  sendTunnelData(client: SOEClient, data: Buffer, channel: SOEOutputChannels) {
+  sendTunnelData(
+    soeClientId: string,
+    data: Buffer,
+    channel: SOEOutputChannels
+  ) {
     this.appDataChannel.port2.postMessage(
       {
-        client,
+        soeClientId,
         data,
         channel
       },
@@ -95,16 +113,43 @@ export class GatewayServerThreaded extends EventEmitter {
     this.worker.terminate();
   }
 
-  getSoeClient(soeClientId: string): SOEClient | undefined {
-    soeClientId;
-    // TODO: implement
-    // return this._soeServer.getSoeClient(soeClientId);
-    return undefined;
+  async getSoeClientAvgPing(soeClientId: string): Promise<number | undefined> {
+    const fnName = this.getSoeClientAvgPing.name;
+    return this.askGatewayThread(fnName, soeClientId);
   }
 
-  deleteSoeClient(soeClient: SOEClient) {
-    soeClient;
-    // TODO: implement
-    // this._soeServer.deleteClient(soeClient);
+  async getSoeClientNetworkStats(soeClientId: string): Promise<string[]> {
+    const fnName = this.getSoeClientNetworkStats.name;
+    return this.askGatewayThread(fnName, soeClientId);
+  }
+
+  private askGatewayThread<T>(fnName: string, soeClientId: string): Promise<T> {
+    const reqId = this.reqCount++;
+    this.clientInfoChannel.port2.postMessage({
+      fnName,
+      soeClientId,
+      requestId: reqId
+    } as ClientInfoMessage);
+    return new Promise((resolve) => {
+      this.requestQueue.set(reqId, resolve);
+    });
+  }
+
+  async getSoeClientSessionId(
+    soeClientId: string
+  ): Promise<number | undefined> {
+    const fnName = this.getSoeClientSessionId.name;
+    return this.askGatewayThread(fnName, soeClientId);
+  }
+  async getSoeClientNetworkInfos(
+    soeClientId: string
+  ): Promise<{ address: string; port: number } | undefined> {
+    const fnName = this.getSoeClientNetworkInfos.name;
+    return this.askGatewayThread(fnName, soeClientId);
+  }
+
+  async deleteSoeClient(soeClientId: string) {
+    const fnName = this.deleteSoeClient.name;
+    return this.askGatewayThread(fnName, soeClientId);
   }
 }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request makes changes to the `gatewayserver.threaded.ts` and `gatewayserver.worker.ts` files. It adds a new `clientInfoChannel` to the `GatewayServerThreaded` class and handles messages sent to this channel in the `gatewayserver.worker.ts` file. It also adds new methods to the `GatewayServerThreaded` class for retrieving information about a client and deletes a client.
> 
> ## What changed
> - Added a new `clientInfoChannel` to the `GatewayServerThreaded` class.
> - Handled messages sent to the `clientInfoChannel` in the `gatewayserver.worker.ts` file.
> - Added new methods to the `GatewayServerThreaded` class for retrieving information about a client and deleting a client.
> 
> ## How to test
> 1. Run the application.
> 2. Perform actions that trigger the new methods added to the `GatewayServerThreaded` class.
> 3. Verify that the expected information is retrieved or the client is deleted successfully.
> 
> ## Why make this change
> This change was made to enhance the functionality of the `GatewayServerThreaded` class by adding the ability to retrieve information about a client and delete a client. This can be useful for managing client connections and performing actions based on client data.
</details>