### PR TITLE
Add dev command to list itemSpawners chances

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/dev.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/dev.ts
@@ -30,6 +30,7 @@ import { ConstructionChildEntity } from "../../entities/constructionchildentity"
 import { ConstructionDoor } from "../../entities/constructiondoor";
 import { randomIntFromInterval } from "../../../../utils/utils";
 import { Zombie } from "../../entities/zombie";
+import { WorldObjectManager } from "../../managers/worldobjectmanager";
 
 const abilities = require("../../../../../data/2016/dataSources/Abilities.json"),
   vehicleAbilities = require("../../../../../data/2016/dataSources/VehicleAbilities.json");
@@ -50,6 +51,9 @@ const dev: any = {
         }
       }
     }, 500);
+  },
+  sc: function (server: ZoneServer2016, client: Client, args: Array<string>) {
+    console.log(WorldObjectManager.itemSpawnersChances);
   },
   o: function (server: ZoneServer2016, client: Client, args: Array<string>) {
     server.sendOrderedData(client, "ClientUpdate.TextAlert", {

--- a/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
+++ b/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
@@ -189,6 +189,7 @@ export class WorldObjectManager {
     EquipSlots.FEET,
     EquipSlots.HAIR
   ];
+  static itemSpawnersChances: Record<string, number> = {};
 
   private getItemRespawnTimer(server: ZoneServer2016): void {
     if (this.hasCustomLootRespawnTime) return;
@@ -944,6 +945,15 @@ export class WorldObjectManager {
           if (this.spawnedLootObjects[itemInstance.id]) return;
           const chance = Math.floor(Math.random() * 100) + 1; // temporary spawnchance
           if (chance <= lootTable.spawnChance) {
+            if (!WorldObjectManager.itemSpawnersChances[itemInstance.id]) {
+              const realSpawnChance =
+                ((lootTable.spawnChance / lootTable.items.length) *
+                  spawnerType.instances.length) /
+                100;
+              WorldObjectManager.itemSpawnersChances[
+                spawnerType.actorDefinition
+              ] = realSpawnChance;
+            }
             // temporary spawnchance
             const item = getRandomItem(lootTable.items);
             if (item) {


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new feature to the `WorldObjectManager` class in the `ZoneServer2016` server. It adds a new static property `itemSpawnersChances` to keep track of the spawn chances of different items. It also adds a new command `sc` in the `dev` handler to log the `itemSpawnersChances`.
> 
> ## What changed
> Two files were modified in this pull request:
> 
> 1. `src/servers/ZoneServer2016/handlers/commands/dev.ts`: A new command `sc` was added to the `dev` handler. This command logs the `itemSpawnersChances` from the `WorldObjectManager`.
> 
> 2. `src/servers/ZoneServer2016/managers/worldobjectmanager.ts`: A new static property `itemSpawnersChances` was added to the `WorldObjectManager` class. This property is a record of item spawn chances. The spawn chance calculation was also added in the `WorldObjectManager` class.
> 
> ## How to test
> To test this change, follow these steps:
> 
> 1. Pull the changes from this pull request.
> 2. Start the `ZoneServer2016` server.
> 3. Use the `sc` command in the `dev` handler. This should log the `itemSpawnersChances` from the `WorldObjectManager`.
> 
> ## Why make this change
> This change was made to keep track of the spawn chances of different items in the game. This will help in balancing the game by providing insights into the spawn rates of different items. The `sc` command was added to allow developers to easily check the current spawn chances.
</details>