### PR TITLE
Remove circular dependencies in Collecting and Smelting entitiesingentity.ts

### DIFF
--- a/src/servers/ZoneServer2016/classes/smeltingentity.ts
+++ b/src/servers/ZoneServer2016/classes/smeltingentity.ts
@@ -82,7 +82,7 @@ function getSmeltingEntityData(
 }
 
 export class SmeltingEntity {
-  parentObject: LootableConstructionEntity;
+  parentObjectCharacterId: string;
   allowedFuel: number[];
   filterId: number = FilterIds.FURNACE;
   workingEffect: number = 5028;
@@ -95,7 +95,7 @@ export class SmeltingEntity {
     parentObject: LootableConstructionEntity,
     server: ZoneServer2016
   ) {
-    this.parentObject = parentObject;
+    this.parentObjectCharacterId = parentObject.characterId;
     this.allowedFuel = getAllowedFuel(parentObject.itemDefinitionId);
     getSmeltingEntityData(parentObject, this);
     if (!parentObject.getParent(server)) {
@@ -105,7 +105,7 @@ export class SmeltingEntity {
 
   OnInteractionString(server: ZoneServer2016, client: ZoneClient2016) {
     server.sendData(client, "Command.InteractionString", {
-      guid: this.parentObject.characterId,
+      guid: this.parentObjectCharacterId,
       stringId: StringIds.USE_IGNITABLE
     });
   }
@@ -113,7 +113,7 @@ export class SmeltingEntity {
   OnFullCharacterDataRequest(server: ZoneServer2016, client: ZoneClient2016) {
     if (!this.isWorking) return;
     server.sendData(client, "Command.PlayDialogEffect", {
-      characterId: this.parentObject.characterId,
+      characterId: this.parentObjectCharacterId,
       effectId: this.workingEffect
     });
   }


### PR DESCRIPTION

This way we could save constructions data to mongo more efficiently without needing all the processing we currently do to setup save objects. #1798


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the `CollectingEntity` and `SmeltingEntity` classes in the `ZoneServer2016` server. The `parentObject` property, which was previously of type `LootableConstructionEntity`, has been replaced with `parentObjectCharacterId` of type `string`. This change simplifies the code .
> 
> ## What changed
> In both `CollectingEntity` and `SmeltingEntity` classes, the `parentObject` property has been replaced with `parentObjectCharacterId`. All references to `this.parentObject` have been updated to use `this.parentObjectCharacterId` instead. The `parentObject` is now retrieved from the server's `_lootableConstruction` dictionary when needed, using the `parentObjectCharacterId`.
> 
> ## How to test
> To test these changes, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Run the server and interact with a `CollectingEntity` or `SmeltingEntity`.
> 3. Verify that the interaction works as expected and no errors are thrown.
> 
> ## Why make this change
> This change improves the performance of the server by reducing the amount of data stored in memory. Instead of storing the entire `LootableConstructionEntity` object in memory for each `CollectingEntity` or `SmeltingEntity`, we now only store the `characterId` of the `parentObject`. This significantly reduces the memory footprint of each entity, which can lead to substantial performance improvements when dealing with large numbers of entities.
</details>