### PR TITLE
Reduce spawn timer on low / medium pop

### DIFF
--- a/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
+++ b/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
@@ -195,21 +195,12 @@ export class WorldObjectManager {
 
     const playerCount = _.size(server._characters);
 
-    switch (true) {
-      case playerCount <= 20:
-        this.lootRespawnTimer = 2400000; // 40 min
-        break;
-      case playerCount > 20 && playerCount <= 40:
-        this.lootRespawnTimer = 1800000; // 30 min
-        break;
-      case playerCount > 40 && playerCount <= 60:
-        this.lootRespawnTimer = 1200000; // 20 min
-        break;
-      case playerCount > 60:
-        this.lootRespawnTimer = 600000; // 10 min
-        break;
-      default:
-        this.lootRespawnTimer = 1200000;
+    if (playerCount >= 60) {
+      this.lootRespawnTimer = 600_000; // 10 min
+    } else if (playerCount >= 30) {
+      this.lootRespawnTimer = 900_000; // 15 min
+    } else {
+      this.lootRespawnTimer = 1_500_000; // 25 min
     }
   }
 


### PR DESCRIPTION
Maybe this is too much, but rn ppl don't play on low pop since the loot is so bad. I know we done that to avoid unemployed to have too much of an advantage but the fact is there is a lot of them. At the beginning of every wipe the server pop is always 40+ even at night, then these ppl have their bases and just stop playing and others who want to start the wipe mid train just can't due to low loot and that make a snowball and nobody play anymore.