### PR TITLE
Add enableDynamicWeather option to config file and change default weather to h1emubaseweather

### DIFF
--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -46,7 +46,8 @@ fairplay:
   #  crc32_hash: ""
 
 weather:
-  defaultTemplate: "z1br"
+  defaultTemplate: "h1emubaseweather"
+  dynamicEnabled: false
 
 # Anything to do with loot, vehicle, and npc spawning / despawning
 worldobjects:

--- a/src/servers/ZoneServer2016/managers/configmanager.ts
+++ b/src/servers/ZoneServer2016/managers/configmanager.ts
@@ -186,8 +186,9 @@ export class ConfigManager {
     //#endregion
 
     //#region weather
-    const { defaultTemplate } = this.config.weather;
+    const { defaultTemplate, dynamicEnabled } = this.config.weather;
     server.weatherManager.defaultTemplate = defaultTemplate;
+    server.weatherManager.dynamicEnabled = dynamicEnabled;
     //#endregion
 
     //#region worldobjects

--- a/src/servers/ZoneServer2016/managers/weathermanager.ts
+++ b/src/servers/ZoneServer2016/managers/weathermanager.ts
@@ -43,9 +43,10 @@ export class WeatherManager {
   weather!: Weather2016;
   templates: { [name: string]: WeatherTemplate } = localWeatherTemplates;
   dynamicWorker: any;
-  dynamicEnabled = true;
 
-  defaultTemplate = "z1br";
+  // setup by config file
+  dynamicEnabled = false;
+  defaultTemplate = "donotusethat";
 
   init() {
     this.weather = this.templates[this.defaultTemplate];

--- a/src/servers/ZoneServer2016/models/config.ts
+++ b/src/servers/ZoneServer2016/models/config.ts
@@ -44,9 +44,8 @@ interface FairplayConfig {
 }
 
 interface WeatherConfig {
-  cycleSpeed: number;
-  frozeCycle: boolean;
   defaultTemplate: string;
+  dynamicEnabled: boolean;
 }
 
 interface WorldObjectsConfig {


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the weather configuration in the game server. It changes the default weather template and introduces a new configuration option to enable or disable dynamic weather.
> 
> ## What changed
> - The default weather template was changed from "z1br" to "h1emubaseweather" in the `defaultconfig.yaml` file.
> - A new configuration option `dynamicEnabled` was added to the `defaultconfig.yaml` file. This option allows the dynamic weather feature to be enabled or disabled.
> - The `ConfigManager` class was updated to read the `dynamicEnabled` option from the configuration file and set it in the `WeatherManager` class.
> - The `WeatherManager` class was updated to use the `dynamicEnabled` and `defaultTemplate` options from the configuration file.
> - The `WeatherConfig` interface was updated to include the `dynamicEnabled` option.
> 
> ## How to test
> - Pull the changes from this branch into your local environment.
> - Update your `defaultconfig.yaml` file with the new `dynamicEnabled` option under the `weather` section.
> - Run the game server and verify that the weather behaves as expected based on the `dynamicEnabled` and `defaultTemplate` options.
> 
> ## Why make this change
> This change allows the game server to have more control over the weather system. The server can now use different weather templates and can enable or disable dynamic weather. This can be useful for creating different game environments and scenarios.
</details>