### PR TITLE
Add proximityItems without having to search first

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1112,8 +1112,7 @@ export class ZoneServer2016 extends EventEmitter {
             client.character.state.position,
             object.state.position,
             1
-          ) &&
-          client.searchedProps.includes(object)
+          )
         ) {
           const container = object.getContainer();
           if (container) {
@@ -1159,6 +1158,9 @@ export class ZoneServer2016 extends EventEmitter {
           }
         }
       }
+
+      
+
     }
 
     return proximityItems;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1158,9 +1158,6 @@ export class ZoneServer2016 extends EventEmitter {
           }
         }
       }
-
-      
-
     }
 
     return proximityItems;


### PR DESCRIPTION
https://www.youtube.com/watch?v=aFpSNGow3QI (Timestamps: 18:22 | 18:51 | 21:33 | 23:30 | 25:09 | 57:06 - can show more proof if need be 👍 )

In #1777, avcio optimized getProximityItems so users can't proximity containers through base shelters (essentially esp), and just general code clean-up. Wonderful change! But in the process made it so world lootable props (armoires, cabinets, fridges etc.) had to be searched through at least once before you could proximity them. In december 2016 this wasn't a thing however. You could proximity world lootable props no matter what, so this PR aims to remove that restriction WHILE keeping avcios wonderful change from before :D