### PR TITLE
change bee fx and add bee retaliation hudindicator, damage and fx

### DIFF
--- a/data/2016/dataSources/HudIndicators.json
+++ b/data/2016/dataSources/HudIndicators.json
@@ -110,5 +110,12 @@
     "nameId": 9300,
     "descriptionId": 9301,
     "imageSetId": 177
+  },
+  {
+    "id": 20,
+    "typeName": "BEES!",
+    "nameId": 11884,
+    "descriptionId": 11885,
+    "imageSetId": 552
   }
 ]

--- a/src/servers/ZoneServer2016/classes/collectingentity.ts
+++ b/src/servers/ZoneServer2016/classes/collectingentity.ts
@@ -11,7 +11,7 @@
 //   Based on https://github.com/psemu/soe-network
 // ======================================================================
 
-import { Items, StringIds } from "../models/enums";
+import { Effects, Items, StringIds } from "../models/enums";
 import { ZoneServer2016 } from "../zoneserver";
 import { LootableConstructionEntity } from "../entities/lootableconstructionentity";
 import { lootableContainerDefaultLoadouts } from "../data/loadouts";
@@ -26,7 +26,7 @@ function getSubEntityData(
   switch (entity.itemDefinitionId) {
     case Items.BEE_BOX:
       entity.defaultLoadout = lootableContainerDefaultLoadouts.bee_box;
-      child.workingEffect = 188;
+      child.workingEffect = Effects.EFX_Bees_BeeHiveBox;
       break;
     case Items.DEW_COLLECTOR:
       entity.defaultLoadout = lootableContainerDefaultLoadouts.dew_collector;

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -122,6 +122,7 @@ export class Character2016 extends BaseFullCharacter {
   creationDate!: string;
   lastLoginDate!: string;
   lastWhisperedPlayer!: string;
+  hasAlertedBees = false;
   vehicleExitDate: number = new Date().getTime();
   currentLoadoutSlot = LoadoutSlots.FISTS;
   readonly loadoutId = LoadoutIds.CHARACTER;

--- a/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
+++ b/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
@@ -11,7 +11,12 @@
 //   Based on https://github.com/psemu/soe-network
 // ======================================================================
 
-import { ConstructionPermissionIds, Effects, Items, StringIds } from "../models/enums";
+import {
+  ConstructionPermissionIds,
+  Effects,
+  Items,
+  StringIds
+} from "../models/enums";
 import { DamageInfo, HudIndicator } from "types/zoneserver";
 import { ZoneServer2016 } from "../zoneserver";
 import { BaseLootableEntity } from "./baselootableentity";
@@ -262,9 +267,8 @@ export class LootableConstructionEntity extends BaseLootableEntity {
   }
 
   async OnMeleeHit(server: ZoneServer2016, damageInfo: DamageInfo) {
-    
     if (this.itemDefinitionId == Items.BEE_BOX) {
-      const client = server.getClientByCharId(damageInfo.entity)
+      const client = server.getClientByCharId(damageInfo.entity);
       const dictionary = server.getEntityDictionary(this.characterId);
 
       if (!client) return;
@@ -282,13 +286,13 @@ export class LootableConstructionEntity extends BaseLootableEntity {
         }
       );
 
-      for (let i = 0; i < 3; i++){
+      for (let i = 0; i < 3; i++) {
         const dmgInfo: DamageInfo = {
           entity: "",
           damage: 100
         };
         client.character.damage(server, dmgInfo);
-        await scheduler.wait(500)
+        await scheduler.wait(500);
       }
 
       let hudIndicator: HudIndicator | undefined = undefined;
@@ -297,13 +301,14 @@ export class LootableConstructionEntity extends BaseLootableEntity {
       if (!hudIndicator) return;
 
       if (client.character.hudIndicators[hudIndicator.typeName]) {
-        client.character.hudIndicators[hudIndicator.typeName].expirationTime += 5000;
+        client.character.hudIndicators[hudIndicator.typeName].expirationTime +=
+          5000;
       } else {
         client.character.hudIndicators[hudIndicator.typeName] = {
           typeName: hudIndicator.typeName,
           expirationTime: Date.now() + 5000
         };
-        server.sendHudIndicators(client)
+        server.sendHudIndicators(client);
       }
     }
 

--- a/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
+++ b/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
@@ -11,8 +11,8 @@
 //   Based on https://github.com/psemu/soe-network
 // ======================================================================
 
-import { ConstructionPermissionIds, Items, StringIds } from "../models/enums";
-import { DamageInfo } from "types/zoneserver";
+import { ConstructionPermissionIds, Effects, Items, StringIds } from "../models/enums";
+import { DamageInfo, HudIndicator } from "types/zoneserver";
 import { ZoneServer2016 } from "../zoneserver";
 import { BaseLootableEntity } from "./baselootableentity";
 import { ConstructionChildEntity } from "./constructionchildentity";
@@ -22,6 +22,8 @@ import { SmeltingEntity } from "../classes/smeltingentity";
 import { lootableContainerDefaultLoadouts } from "../data/loadouts";
 import { CollectingEntity } from "../classes/collectingentity";
 import { EXTERNAL_CONTAINER_GUID } from "../../../utils/constants";
+import { CharacterPlayWorldCompositeEffect } from "types/zone2016packets";
+import { scheduler } from "timers/promises";
 
 function getMaxHealth(itemDefinitionId: Items): number {
   switch (itemDefinitionId) {
@@ -259,7 +261,52 @@ export class LootableConstructionEntity extends BaseLootableEntity {
     }
   }
 
-  OnMeleeHit(server: ZoneServer2016, damageInfo: DamageInfo) {
+  async OnMeleeHit(server: ZoneServer2016, damageInfo: DamageInfo) {
+    
+    if (this.itemDefinitionId == Items.BEE_BOX) {
+      const client = server.getClientByCharId(damageInfo.entity)
+      const dictionary = server.getEntityDictionary(this.characterId);
+
+      if (!client) return;
+      if (!dictionary) return;
+
+      server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
+        dictionary,
+        this.characterId,
+        "Character.PlayWorldCompositeEffect",
+        {
+          characterId: this.characterId,
+          effectId: Effects.PFX_Bee_Swarm_Attack,
+          position: client.character.state.position,
+          effectTime: 5
+        }
+      );
+
+      for (let i = 0; i < 3; i++){
+        const dmgInfo: DamageInfo = {
+          entity: "",
+          damage: 100
+        };
+        client.character.damage(server, dmgInfo);
+        await scheduler.wait(500)
+      }
+
+      let hudIndicator: HudIndicator | undefined = undefined;
+      hudIndicator = server._hudIndicators["BEES!"];
+
+      if (!hudIndicator) return;
+
+      if (client.character.hudIndicators[hudIndicator.typeName]) {
+        client.character.hudIndicators[hudIndicator.typeName].expirationTime += 5000;
+      } else {
+        client.character.hudIndicators[hudIndicator.typeName] = {
+          typeName: hudIndicator.typeName,
+          expirationTime: Date.now() + 5000
+        };
+        server.sendHudIndicators(client)
+      }
+    }
+
     server.constructionManager.OnMeleeHit(server, damageInfo, this);
   }
 }

--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -333,7 +333,7 @@ export class SmeltingManager {
       const item = container.items[a];
       if (item.itemDefinitionId == Items.HONEYCOMB) {
         isEmpty = false;
-        
+
         server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
           subEntity!.dictionary,
           entity.characterId,

--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -131,17 +131,6 @@ export class SmeltingManager {
           this.checkAnimalTrap(server, entity, subEntity, container);
           break;
       }
-      server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
-        subEntity!.dictionary,
-        entity.characterId,
-        "Character.PlayWorldCompositeEffect",
-        {
-          characterId: entity.characterId,
-          effectId: entity.subEntity!.workingEffect,
-          position: entity.state.position,
-          effectTime: Math.ceil(this.collectingTickTime / 1000)
-        }
-      );
     }
     this.checkCollectorsTimer = setTimeout(() => {
       this.checkCollectors(server);
@@ -344,6 +333,18 @@ export class SmeltingManager {
       const item = container.items[a];
       if (item.itemDefinitionId == Items.HONEYCOMB) {
         isEmpty = false;
+        
+        server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
+          subEntity!.dictionary,
+          entity.characterId,
+          "Character.PlayWorldCompositeEffect",
+          {
+            characterId: entity.characterId,
+            effectId: entity.subEntity!.workingEffect,
+            position: entity.state.position,
+            effectTime: Math.ceil(this.collectingTickTime / 1000)
+          }
+        );
       }
     }
     if (!isEmpty) return;
@@ -356,13 +357,15 @@ export class SmeltingManager {
         1,
         false
       );
-      server.sendDataToAllWithSpawnedEntity(
-        subEntity.dictionary,
+      server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
+        subEntity!.dictionary,
         entity.characterId,
-        "Command.PlayDialogEffect",
+        "Character.PlayWorldCompositeEffect",
         {
           characterId: entity.characterId,
-          effectId: subEntity.workingEffect
+          effectId: entity.subEntity!.workingEffect,
+          position: entity.state.position,
+          effectTime: Math.ceil(this.collectingTickTime / 1000)
         }
       );
       return;


### PR DESCRIPTION
https://www.youtube.com/watch?v=-ay3Osxv3Zc&t=158s

People (JayR and Statix) were losing their minds over the bee fx change and their bee boxes always buzzing with bees 😂😂 A quote from JayR directly: "all bee boxes have loud ass bees in them, i play muted now" 🤣 So this PR changes the bee fx to only occur when a honeycomb spawns and when a honeycomb is currently inside of the bee box (to alert players to loot their bee box for their honeycomb!) 

Also added some type safety stuff, bee retaliation damage hudindicator, and fx 