### PR TITLE
Convey durability + randomized durability for conveys and crowbars

### DIFF
--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -1083,6 +1083,9 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
       case server.isHelmet(item.itemDefinitionId):
         durability = 100;
         break;
+      case server.isConvey(item.itemDefinitionId):
+        durability = 5400;
+        break;
     }
     return {
       itemDefinitionId: item.itemDefinitionId,

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1293,6 +1293,9 @@ export class Character2016 extends BaseFullCharacter {
       case server.isHelmet(item.itemDefinitionId):
         durability = 100;
         break;
+      case server.isConvey(item.itemDefinitionId):
+        durability = 5400;
+        break;
     }
     return {
       itemDefinitionId: item.itemDefinitionId,

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -1092,6 +1092,9 @@ export class Vehicle2016 extends BaseLootableEntity {
       case server.isHelmet(item.itemDefinitionId):
         durability = 100;
         break;
+      case server.isConvey(item.itemDefinitionId):
+        durability = 5400;
+        break;
     }
     return {
       itemDefinitionId: item.itemDefinitionId,

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5433,6 +5433,10 @@ export class ZoneServer2016 extends EventEmitter {
     let durability: number = 2000;
     switch (true) {
       case this.isWeapon(itemDefinitionId):
+        if (itemDefinitionId == Items.WEAPON_CROWBAR) {
+          durability = Math.floor(Math.random() * 2001);;
+          break;
+        }
         durability = 2000;
         break;
       case this.isArmor(itemDefinitionId):
@@ -5440,6 +5444,9 @@ export class ZoneServer2016 extends EventEmitter {
         break;
       case this.isHelmet(itemDefinitionId):
         durability = 100;
+        break;
+      case this.isConvey(itemDefinitionId):
+        durability = Math.floor(Math.random() * 5401);
         break;
     }
 
@@ -5511,6 +5518,18 @@ export class ZoneServer2016 extends EventEmitter {
       this.getItemDefinition(itemDefinitionId)?.DESCRIPTION_ID == 9114 ||
       this.getItemDefinition(itemDefinitionId)?.DESCRIPTION_ID == 9945 ||
       this.getItemDefinition(itemDefinitionId)?.DESCRIPTION_ID == 12898
+    );
+  }
+
+  /**
+   * Checks if an item with the specified itemDefinitionId is a convey.
+   *
+   * @param {number} itemDefinitionId - The itemDefinitionId to check.
+   * @returns {boolean} True if the item is a convey, false otherwise.
+   */
+  isConvey(itemDefinitionId: number): boolean {
+    return (
+      this.getItemDefinition(itemDefinitionId)?.DESCRIPTION_ID == 11895
     );
   }
 

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5434,7 +5434,7 @@ export class ZoneServer2016 extends EventEmitter {
     switch (true) {
       case this.isWeapon(itemDefinitionId):
         if (itemDefinitionId == Items.WEAPON_CROWBAR) {
-          durability = Math.floor(Math.random() * 2001);;
+          durability = Math.floor(Math.random() * 2001);
           break;
         }
         durability = 2000;
@@ -5528,9 +5528,7 @@ export class ZoneServer2016 extends EventEmitter {
    * @returns {boolean} True if the item is a convey, false otherwise.
    */
   isConvey(itemDefinitionId: number): boolean {
-    return (
-      this.getItemDefinition(itemDefinitionId)?.DESCRIPTION_ID == 11895
-    );
+    return this.getItemDefinition(itemDefinitionId)?.DESCRIPTION_ID == 11895;
   }
 
   /**


### PR DESCRIPTION
https://www.youtube.com/watch?v=aFpSNGow3QI& (11:08)

Conveys used to have durability (5400, video above ^) and would get damaged based upon what MaterialType the player was walking on. That's still a WIP, but for now add durability to them and also add randomized durability to crowbars and conveys, which was a feature back in 2016 (also in the video above).