### PR TITLE
Update Cabinet Cube spawn table

### DIFF
--- a/src/servers/ZoneServer2016/data/lootspawns.ts
+++ b/src/servers/ZoneServer2016/data/lootspawns.ts
@@ -2206,7 +2206,7 @@ export const containerLootSpawners: {
     ]
   },
   "Cabinets Cube": {
-    spawnChance: 100,
+    spawnChance: 80,
     maxItems: 1,
     items: [
       {
@@ -2243,102 +2243,6 @@ export const containerLootSpawners: {
       },
       {
         item: Items.CANNED_FOOD02,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD03,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD04,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD05,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD06,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD07,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD08,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD09,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD10,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD11,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD21,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD25,
-        weight: 30,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
-        item: Items.CANNED_FOOD26,
         weight: 30,
         spawnCount: {
           min: 1,


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the loot spawn chances and items in the "Cabinets Cube" section of the `lootspawns.ts` file. The spawn chance has been reduced from 100 to 80, and several canned food items have been removed from the loot spawn list.
> 
> ## What changed
> The spawn chance for the "Cabinets Cube" section has been reduced from 100 to 80. This means that there is now a 20% chance that no loot will spawn in these cabinets.
> 
> Additionally, a large number of canned food items have been removed from the loot spawn list for these cabinets. 
> 
> ## How to test
> To test these changes, you can spawn in a zone with "Cabinets Cube" and observe the loot that spawns in these cabinets. You should notice a more varied loot spawn, with a 20% chance of no loot spawning at all.
> 
</details>