### PR TITLE
Fix StartTimer packet being sent at every weapon fire

### DIFF
--- a/src/servers/ZoneServer2016/classes/zoneclient.ts
+++ b/src/servers/ZoneServer2016/classes/zoneclient.ts
@@ -60,7 +60,7 @@ export class ZoneClient2016 {
     distance: number;
     attacker: Client;
   };
-  hudTimer?: NodeJS.Timeout | null;
+  hudTimer?: NodeJS.Timeout | null = null;
   spawnedDTOs: any[] = [];
   spawnedEntities: Set<BaseEntity> = new Set();
   sentInteractionData: BaseEntity[] = [];

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -7432,7 +7432,12 @@ export class ZoneServer2016 extends EventEmitter {
   pUtilizeHudTimer = promisify(this.utilizeHudTimer);
 
   stopHudTimer(client: Client) {
+    if (client.hudTimer === null) {
+      // No timer running so nothing to do
+      return;
+    }
     this.utilizeHudTimer(client, 0, 0, 0, () => {
+      client.hudTimer = null;
       this.sendDataToAllWithSpawnedEntity(
         this._characters,
         client.character.characterId,
@@ -7441,10 +7446,10 @@ export class ZoneServer2016 extends EventEmitter {
           characterId: client.character.characterId
         }
       );
+      // TODO: this should be somewhere else
       const vehicle = this._vehicles[client.vehicle.mountedVehicle ?? ""];
       if (!vehicle) return;
       vehicle.removeHotwireEffect(this);
-      /*/*/
     });
   }
 
@@ -7466,6 +7471,7 @@ export class ZoneServer2016 extends EventEmitter {
     client.posAtTimerStart = client.character.state.position;
     client.hudTimer = setTimeout(() => {
       callback.apply(this);
+      client.hudTimer = null;
       this.sendDataToAllWithSpawnedEntity(
         this._characters,
         client.character.characterId,


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request includes changes to the `ZoneServer2016` and `ZoneClient2016` classes. It primarily focuses on the handling of the `hudTimer` property, ensuring that it is properly initialized and reset when necessary.
> 
> ## What changed
> - In `zoneclient.ts`, the `hudTimer` property is now initialized to `null`.
> - In `zoneserver.ts`, additional checks and actions have been added to the `stopHudTimer` method. If the `hudTimer` is `null`, the method will return early. After the timer is utilized, it is reset to `null`.
> - The `utilizeHudTimer` method in `zoneserver.ts` has also been updated to reset the `hudTimer` to `null` after the callback is applied.
> 
> ## How to test
> To test these changes, follow these steps:
> 1. Pull the changes from this branch into your local environment.
> 2. Run your test suite to ensure no existing functionality has been broken.
> 3. Specifically test the `stopHudTimer` and `utilizeHudTimer` methods in the `ZoneServer2016` class. Ensure that the `hudTimer` property is properly initialized and reset when these methods are called.
> 
> ## Why make this change
> These changes ensure that the `hudTimer` property is properly managed, preventing potential issues with uninitialized or stale timer values. This improves the robustness of the timer handling code and helps prevent potential bugs in the future.
</details>