### PR TITLE
Deprecate furnace change

### DIFF
--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -186,14 +186,6 @@ export class SmeltingManager {
     );
   }*/
 
-  getBurnTime(item: BaseItem): number {
-    if (item.itemDefinitionId == Items.CHARCOAL) {
-      return (this.burnTime = 2400000);
-    } else {
-      return (this.burnTime = 120000);
-    }
-  }
-
   private checkFuel(
     server: ZoneServer2016,
     entity: LootableConstructionEntity
@@ -202,7 +194,6 @@ export class SmeltingManager {
     for (const a in container!.items) {
       const item = container!.items[a];
       if (entity.subEntity!.allowedFuel.includes(item.itemDefinitionId)) {
-        this.getBurnTime(item);
         server.removeContainerItem(entity, item, entity.getContainer(), 1);
         if (item.itemDefinitionId == Items.WOOD_LOG) {
           // give charcoal if wood log was burned


### PR DESCRIPTION
Okay, so several people are reporting that furnaces are still messed up, so for now just deprecate the recent furnace change to burnTime (keep smeltTime that shouldn't be causing issues) until more testing can be done.