### PR TITLE
disable snare poi placement

### DIFF
--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -70,7 +70,6 @@ export class ConstructionManager {
   overridePlacementItems: Array<number> = [
     Items.IED,
     Items.LANDMINE,
-    Items.SNARE,
     Items.SEED_CORN,
     Items.SEED_WHEAT
   ];


### PR DESCRIPTION
In #1387, Avcio disable punji's inside of POIs (I'm assuming because they can't be broken and cause clutter) and people are doing the same with snares from what I've noticed (same issue you can't melee/shoot or break snares in any way), so disable their POI placement.