### PR TITLE
Add vehicles damage unit tests for PVP&PVE

### DIFF
--- a/src/servers/ZoneServer2016/entities/vehicle.test.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.test.ts
@@ -1,0 +1,76 @@
+import test, { after } from "node:test";
+import { ZoneServer2016 } from "../zoneserver";
+import { Vehicle2016 } from "./vehicle";
+import { DamageInfo } from "types/zoneserver";
+import { getCurrentTimeWrapper } from "../../../utils/utils";
+import assert from "node:assert";
+
+test("Damage-pve", { timeout: 10000 }, async (t) => {
+  const zone = new ZoneServer2016(1117);
+  zone.isPvE = true;
+  await zone.start();
+  assert.equal(zone.isPvE, true);
+  const characterId = zone.generateGuid();
+  const transientId = zone.getTransientId(characterId);
+  const vehicle = new Vehicle2016(
+    characterId,
+    transientId,
+    1,
+    new Float32Array([0, 0, 0]),
+    new Float32Array([0, 0, 0]),
+    zone,
+    getCurrentTimeWrapper().getTruncatedU32(),
+    3
+  );
+  await t.test("Damage from entity", async () => {
+    const oldHealth = vehicle.getHealth();
+    const dmg = 10;
+    const damageInfo: DamageInfo = { entity: "idk", damage: dmg };
+    vehicle.damage(zone, damageInfo);
+    assert.equal(vehicle.getHealth(), oldHealth);
+  });
+  await t.test("Damage from collisions", async () => {
+    const oldHealth = vehicle.getHealth();
+    const dmg = 10;
+    const damageInfo: DamageInfo = { entity: "", damage: dmg };
+    vehicle.damage(zone, damageInfo);
+    assert.equal(vehicle.getHealth(), oldHealth - dmg);
+  });
+});
+
+test("Damage-pvp", { timeout: 10000 }, async (t) => {
+  const zone = new ZoneServer2016(1118);
+  await zone.start();
+  assert.equal(zone.isPvE, false);
+  const characterId = zone.generateGuid();
+  const transientId = zone.getTransientId(characterId);
+  const vehicle = new Vehicle2016(
+    characterId,
+    transientId,
+    1,
+    new Float32Array([0, 0, 0]),
+    new Float32Array([0, 0, 0]),
+    zone,
+    getCurrentTimeWrapper().getTruncatedU32(),
+    3
+  );
+  await t.test("Damage from entity", async () => {
+    const oldHealth = vehicle.getHealth();
+    const dmg = 10;
+    const damageInfo: DamageInfo = { entity: "idk", damage: dmg };
+    vehicle.damage(zone, damageInfo);
+    assert.equal(vehicle.getHealth(), oldHealth - dmg);
+  });
+  await t.test("Damage from collisions", async () => {
+    const oldHealth = vehicle.getHealth();
+    const dmg = 10;
+    const damageInfo: DamageInfo = { entity: "", damage: dmg };
+    vehicle.damage(zone, damageInfo);
+    assert.equal(vehicle.getHealth(), oldHealth - dmg);
+  });
+});
+after(() => {
+  setImmediate(() => {
+    process.exit(0);
+  });
+});


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces tests for the `Vehicle2016` class in the `ZoneServer2016` module. The tests cover damage handling in both PvE and PvP scenarios, including damage from entities and collisions.
> 
> ## What changed
> A new test file `vehicle.test.ts` was added to the `ZoneServer2016/entities` directory. This file contains two main tests: `Damage-pve` and `Damage-pvp`. Each test creates a new instance of `ZoneServer2016` and `Vehicle2016`, and then tests the `damage` method of the `Vehicle2016` class under different conditions.
> 
> ## How to test
> To run the tests, navigate to the project root directory and run the command `npm test`. Ensure that all tests pass. To specifically test the changes introduced in this pull request, you can use the command `npm test -- vehicle.test.ts`.
> 
> ## Why make this change
> These tests are important to ensure the correct functioning of the `Vehicle2016` class, particularly its ability to handle damage in different scenarios. By testing these features, we can catch and fix any potential bugs or issues, ensuring the reliability and robustness of our code.
</details>