### PR TITLE
Fix for explosive damage inside secured shelters

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2309,7 +2309,7 @@ export class ZoneServer2016 extends EventEmitter {
             character.state.position,
             position,
             1.5
-          )
+          ) && !client?.character.isHidden
         ) {
           const distance = getDistance(position, character.state.position);
           const damage = 50000 / distance;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2309,7 +2309,8 @@ export class ZoneServer2016 extends EventEmitter {
             character.state.position,
             position,
             1.5
-          ) && !client?.character.isHidden
+          ) &&
+          !client?.character.isHidden
         ) {
           const distance = getDistance(position, character.state.position);
           const damage = 50000 / distance;


### PR DESCRIPTION
Currently players can kill each other through walls with explosives, so add a check for a player being inside a secured shelter before damaging the player. Players can still be damaged through walls if the door isn't secured, so there'll have to be a future update for this, but for now this is a solid change.