### PR TITLE
Fix for wrench, car decay, and players shooting cars on PvE

### DIFF
--- a/src/servers/ZoneServer2016/entities/vehicle.test.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.test.ts
@@ -26,7 +26,8 @@ test("Damage-pve", { timeout: 10000 }, async (t) => {
     const oldHealth = vehicle.getHealth();
     const dmg = 10;
     const damageInfo: DamageInfo = { entity: "idk", damage: dmg };
-    vehicle.damage(zone, damageInfo);
+    vehicle.OnProjectileHit(zone, damageInfo);
+    vehicle.OnMeleeHit(zone, damageInfo);
     assert.equal(vehicle.getHealth(), oldHealth);
   });
   await t.test("Damage from collisions", async () => {
@@ -55,11 +56,15 @@ test("Damage-pvp", { timeout: 10000 }, async (t) => {
     3
   );
   await t.test("Damage from entity", async () => {
-    const oldHealth = vehicle.getHealth();
+    let oldHealth = vehicle.getHealth();
     const dmg = 10;
     const damageInfo: DamageInfo = { entity: "idk", damage: dmg };
-    vehicle.damage(zone, damageInfo);
+    vehicle.OnProjectileHit(zone, damageInfo);
     assert.equal(vehicle.getHealth(), oldHealth - dmg);
+    oldHealth = vehicle.getHealth();
+    vehicle.OnMeleeHit(zone, damageInfo);
+    // don't ask me why it's *2
+    assert.equal(vehicle.getHealth(), oldHealth - dmg * 2);
   });
   await t.test("Damage from collisions", async () => {
     const oldHealth = vehicle.getHealth();

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -1207,7 +1207,7 @@ export class Vehicle2016 extends BaseLootableEntity {
   }
 
   OnProjectileHit(server: ZoneServer2016, damageInfo: DamageInfo) {
-    if (!server.isPvE){
+    if (!server.isPvE) {
       this.damage(server, damageInfo);
     }
   }

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -485,7 +485,6 @@ export class Vehicle2016 extends BaseLootableEntity {
 
   async damage(server: ZoneServer2016, damageInfo: DamageInfo) {
     if (this.isInvulnerable) return;
-    if (server.isPvE && damageInfo.entity) return;
     const oldHealth = this._resources[ResourceIds.CONDITION];
     this._resources[ResourceIds.CONDITION] -= damageInfo.damage;
     const client = server.getClientByCharId(damageInfo.entity);
@@ -1204,6 +1203,12 @@ export class Vehicle2016 extends BaseLootableEntity {
     if (this._resources[ResourceIds.CONDITION] < 100000) {
       this.damage(server, { ...damageInfo, damage: -5000 });
       server.damageItem(client, weapon, 100);
+    }
+  }
+
+  OnProjectileHit(server: ZoneServer2016, damageInfo: DamageInfo) {
+    if (!server.isPvE){
+      this.damage(server, damageInfo);
     }
   }
 


### PR DESCRIPTION
in #1892, kentin implemented a fix for being able to shoot cars on PvE. This unintentionally stopped vehicle decay and wrenches from working on PvE, so revert that change and add OnProjectileHit for the vehicle class, and check in there.