### PR TITLE
Handle unknown HudIndicator

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -7988,24 +7988,32 @@ export class ZoneServer2016 extends EventEmitter {
       },
       unknownData2: {}
     });
-    client.character.resourceHudIndicators.forEach((typeName: string) => {
-      const indicator = this._hudIndicators[typeName];
-      this.sendData(client, "Effect.AddUiIndicator", {
-        characterId: client.character.characterId,
-        hudElementGuid: this.generateGuid(),
-        unknownData1: {
-          hudElementId: indicator.nameId
-        },
-        hudElementData: {
-          nameId: indicator.nameId,
-          descriptionId: indicator.descriptionId,
-          imageSetId: indicator.imageSetId
-        },
-        unknownData3: {},
-        unknownData4: {},
-        unknownData5: {}
-      });
-    });
+    client.character.resourceHudIndicators.forEach(
+      (typeName: string, index) => {
+        const indicator = this._hudIndicators[typeName];
+        if (!indicator) {
+          // to help identifying the issue
+          console.log(`Unknown hud indicator: ${typeName} removing it`);
+          client.character.resourceHudIndicators.splice(index, 1);
+          return;
+        }
+        this.sendData(client, "Effect.AddUiIndicator", {
+          characterId: client.character.characterId,
+          hudElementGuid: this.generateGuid(),
+          unknownData1: {
+            hudElementId: indicator.nameId
+          },
+          hudElementData: {
+            nameId: indicator.nameId,
+            descriptionId: indicator.descriptionId,
+            imageSetId: indicator.imageSetId
+          },
+          unknownData3: {},
+          unknownData4: {},
+          unknownData5: {}
+        });
+      }
+    );
     for (const a in client.character.hudIndicators) {
       const indicator =
         this._hudIndicators[client.character.hudIndicators[a].typeName];


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a check for unknown HUD indicators in the `ZoneServer2016` class. If an unknown HUD indicator is found, it is removed and a console log is generated for debugging purposes.
> 
> ## What changed
> The `forEach` loop that iterates over `client.character.resourceHudIndicators` now includes a check for unknown HUD indicators. If an unknown indicator is found, it is removed from the `resourceHudIndicators` array and a console log is generated with the name of the unknown indicator. 
> 
> ## How to test
> To test this change, you can add an unknown HUD indicator to the `resourceHudIndicators` array of a character and observe the console log when the `ZoneServer2016` class is run. The unknown indicator should be removed from the array.
> 
> ## Why make this change
> This change helps to prevent errors that could occur when trying to send data for an unknown HUD indicator. It also provides useful debugging information by logging the name of the unknown indicator.
</details>