### PR TITLE
Fix a circular dependency on vehLight packet

### DIFF
--- a/src/servers/ZoneServer2016/entities/plane.ts
+++ b/src/servers/ZoneServer2016/entities/plane.ts
@@ -110,7 +110,8 @@ export class Plane extends Vehicle2016 {
         vehicleId: this.vehicleId
       },
       positionUpdate: {
-        ...this.positionUpdate
+        ...this.positionUpdate,
+        vehicle: undefined // To fix #1915
       }
     };
   }

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -346,7 +346,8 @@ export class Vehicle2016 extends BaseLootableEntity {
         vehicleId: this.vehicleId
       },
       positionUpdate: {
-        ...this.positionUpdate
+        ...this.positionUpdate,
+        vehicle: undefined // To fix #1915
       }
     };
   }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request addresses issue #1915 by ensuring that the `vehicle` property in the `positionUpdate` object is set to `undefined` in both the `Plane` and `Vehicle2016` classes.
> 
> ## What changed
> Changes were made in two files: `plane.ts` and `vehicle.ts`. In both files, the `vehicle` property in the `positionUpdate` object was set to `undefined`. This was done to prevent any potential issues or conflicts that could arise from this property being defined in these classes.
> 
> ```diff
> -        ...this.positionUpdate
> +        ...this.positionUpdate,
> +        vehicle: undefined // To fix #1915
> ```
> 
> ## How to test
> To test these changes, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Run the server and ensure that it starts without any errors.
> 3. Interact with a `Plane` or `Vehicle2016` entity and observe the `positionUpdate` object. The `vehicle` property should be `undefined`.
> 4. Check the server logs to ensure that no errors or warnings are being thrown related to these changes.
> 
> ## Why make this change
> This change was made to address issue #1915. By setting the `vehicle` property to `undefined`, we can prevent potential issues or conflicts that could arise from this property being defined in the `Plane` and `Vehicle2016` classes. This makes our code more robust and less prone to bugs in the future.
</details>