### PR TITLE
Add ingameTime fields in config

### DIFF
--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -152,3 +152,8 @@ decay:
 smelting:
   burnTime: 120000 # consume fuel every 120 seconds
   smeltTime: 7000 # smelt 1 item every 7 seconds
+gametime:
+  timeFrozen: false # Froze ingameTime
+  nightTimeMultiplier: 2 # This way night time pass 2 times faster than daytime
+  timeMultiplier: 36 # 1 hour IRL = 36 hours ingame, so 20 min for a full day
+  baseTime: 6 # server ingameTime start at 6 AM, 18 = 6PM

--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -1542,10 +1542,10 @@ export const commands: Array<Command> = [
     name: "speedtime",
     permissionLevel: PermissionLevels.ADMIN,
     execute: (server: ZoneServer2016, client: Client, args: Array<string>) => {
-      server.inGameTimeManager.timeMultiplier = Number(args[0]);
+      server.inGameTimeManager.baseTimeMultiplier = Number(args[0]);
       server.sendChatText(
         client,
-        `Will force time to be ${server.inGameTimeManager.timeMultiplier}x faster on next sync...`,
+        `Will force time to be ${server.inGameTimeManager.baseTimeMultiplier}x faster on next sync...`,
         true
       );
     }

--- a/src/servers/ZoneServer2016/managers/configmanager.ts
+++ b/src/servers/ZoneServer2016/managers/configmanager.ts
@@ -327,5 +327,14 @@ export class ConfigManager {
     server.smeltingManager.burnTime = burnTime;
     server.smeltingManager.smeltTime = smeltTime;
     //#endregion
+    //
+    //#region gameTime
+    const { timeFrozen, timeMultiplier, nightTimeMultiplier, baseTime } =
+      this.config.gametime;
+    server.inGameTimeManager.time = baseTime * 3600;
+    server.inGameTimeManager.timeFrozenByConfig = timeFrozen;
+    server.inGameTimeManager.baseTimeMultiplier = timeMultiplier;
+    server.inGameTimeManager.nightTimeMultiplierValue = nightTimeMultiplier;
+    //#endregion
   }
 }

--- a/src/servers/ZoneServer2016/managers/gametimemanager.ts
+++ b/src/servers/ZoneServer2016/managers/gametimemanager.ts
@@ -24,12 +24,21 @@ const SEVEN_PM = 19 * 60 * 60;
 export class IngameTimeManager {
   private _updtTimeTimer!: NodeJS.Timeout;
   lastIngameTimeUpdate: TimeWrapper | null = null;
-  timeMultiplier = 36; // 1 hour IRL = 36 hours ingame, so 20 min a day
+  nightTimeMultiplier = 1;
   timeFrozen = true;
-  nightMultiplier = 1;
-  constructor(public time: number) {}
+
+  // Managed by config
+  timeFrozenByConfig!: boolean;
+  time!: number;
+  baseTimeMultiplier!: number;
+  nightTimeMultiplierValue!: number;
+  constructor() {}
 
   start() {
+    if (this.timeFrozenByConfig) {
+      this.timeFrozen = true;
+      return;
+    }
     this.timeFrozen = false;
     this._updtTimeTimer = setTimeout(() => {
       this.updateTime();
@@ -40,7 +49,7 @@ export class IngameTimeManager {
 
   getCycleSpeed() {
     if (this.timeFrozen) return 0;
-    return this.timeMultiplier * this.nightMultiplier * 0.97222;
+    return this.baseTimeMultiplier * this.nightTimeMultiplier * 0.97222;
   }
 
   updateTime() {
@@ -53,21 +62,23 @@ export class IngameTimeManager {
     if (
       currentSeconds >= FIVE_AM &&
       currentSeconds < SEVEN_PM &&
-      this.nightMultiplier !== 1
+      this.nightTimeMultiplier !== 1
     ) {
-      this.nightMultiplier = 1;
+      this.nightTimeMultiplier = 1;
     } else if (
       (currentSeconds < FIVE_AM || currentSeconds >= SEVEN_PM) &&
-      this.nightMultiplier !== 2
+      this.nightTimeMultiplier !== this.nightTimeMultiplierValue
     ) {
-      this.nightMultiplier = 2;
+      this.nightTimeMultiplier = this.nightTimeMultiplierValue;
     }
     const timeDifference =
       currentTime.getSeconds() - this.lastIngameTimeUpdate.getSeconds();
 
     this.time =
       (this.time +
-        toInt(timeDifference * this.timeMultiplier * this.nightMultiplier)) %
+        toInt(
+          timeDifference * this.baseTimeMultiplier * this.nightTimeMultiplier
+        )) %
       SECONDS_IN_A_DAY;
     this.lastIngameTimeUpdate = currentTime;
   }

--- a/src/servers/ZoneServer2016/managers/weathermanager.ts
+++ b/src/servers/ZoneServer2016/managers/weathermanager.ts
@@ -194,13 +194,13 @@ export class WeatherManager {
         this.weather = this.dynamicWeather(
           getCurrentServerTimeWrapper().getFull(),
           server._serverStartTime.getFull(),
-          server.inGameTimeManager.timeMultiplier
+          server.inGameTimeManager.baseTimeMultiplier
         );
         this.sendUpdateToAll(server);
         // FIXME: Needed to avoid black screen issue ? Why ? No idea.
         this.sendUpdateToAll(server);
         this.dynamicWorker.refresh();
-      }, 360000 / server.inGameTimeManager.timeMultiplier);
+      }, 360000 / server.inGameTimeManager.baseTimeMultiplier);
     }
   }
 

--- a/src/servers/ZoneServer2016/models/config.ts
+++ b/src/servers/ZoneServer2016/models/config.ts
@@ -48,6 +48,13 @@ interface WeatherConfig {
   dynamicEnabled: boolean;
 }
 
+interface GameTimeConfig {
+  timeFrozen: boolean;
+  nightTimeMultiplier: number;
+  baseTime: number;
+  timeMultiplier: number;
+}
+
 interface WorldObjectsConfig {
   vehicleSpawnCap: number;
   minAirdropSurvivors: number;
@@ -122,6 +129,7 @@ export interface Config {
   server: ServerConfig;
   fairplay: FairplayConfig;
   weather: WeatherConfig;
+  gametime: GameTimeConfig;
   worldobjects: WorldObjectsConfig;
   speedtree: SpeedTreeConfig;
   construction: ConstructionConfig;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -385,8 +385,7 @@ export class ZoneServer2016 extends EventEmitter {
   routinesLoopTimer?: NodeJS.Timeout;
   private _mongoClient?: MongoClient;
   rebootTimeTimer?: NodeJS.Timeout;
-  // 3600 * 6 = 6 hours so server always starts at 6am
-  inGameTimeManager: IngameTimeManager = new IngameTimeManager(3600 * 6);
+  inGameTimeManager: IngameTimeManager = new IngameTimeManager();
 
   /* MANAGED BY CONFIGMANAGER */
   proximityItemsDistance!: number;


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the game time management system to include new configurations for time freezing, night time multiplier, base time, and time multiplier.
> 
> ## What changed
> - Added new configurations for game time management in the `defaultconfig.yaml` file.
> - Updated the `commands.ts` file to reflect changes in the time multiplier command.
> - Modified the `configmanager.ts` file to handle new game time configurations.
> - Updated the `gametimemanager.ts` file to incorporate the new time management settings.
> - Adjusted the `weathermanager.ts` file to use the base time multiplier for weather updates.
> - Added a new `GameTimeConfig` interface in the `config.ts` file.
> - Updated the `zoneserver.ts` file to initialize the `IngameTimeManager` without a predefined start time.
> 
> ## How to test
> 1. Update the `defaultconfig.yaml` file with the new game time configurations.
> 2. Use the `speedtime` command in the game to set the base time multiplier.
> 3. Verify that the game time behaves according to the new configurations.
> 4. Check the weather updates in the game to ensure they are synchronized with the base time multiplier.
> 
> ## Why make this change
> - Introduces more flexibility in managing game time settings.
> - Allows for customization of time freezing, night time speed, base time, and overall time multiplier.
> - Enhances the gameplay experience by providing more control over in-game time progression.
</details>