### PR TITLE
Optimize NpcFoundationPermissionsManagerAddPermission

### DIFF
--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -2752,13 +2752,13 @@ export class ZonePacketHandlers {
       (!client.isAdmin || !client.isDebugMode)
     )
       return;
-      
+
     let targetClient = server.getClientByNameOrLoginSession(characterName);
 
     if (!targetClient) {
       targetClient = await server.getOfflineClientByName(characterName);
     }
-    
+
     if (!targetClient || !(targetClient instanceof Client)) {
       server.sendChatText(client, "Player not found.");
       return;

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -2737,7 +2737,7 @@ export class ZonePacketHandlers {
       }
     );
   }
-  NpcFoundationPermissionsManagerAddPermission(
+  async NpcFoundationPermissionsManagerAddPermission(
     server: ZoneServer2016,
     client: Client,
     packet: ReceivedPacket<NpcFoundationPermissionsManagerAddPermission>
@@ -2752,19 +2752,25 @@ export class ZonePacketHandlers {
       (!client.isAdmin || !client.isDebugMode)
     )
       return;
-    let characterId = "";
-    for (const a in server._characters) {
-      const character = server._characters[a];
-      if (character.name === packet.data.characterName) {
-        characterId = character.characterId;
-      }
+      
+    let targetClient = server.getClientByNameOrLoginSession(characterName);
+
+    if (!targetClient) {
+      targetClient = await server.getOfflineClientByName(characterName);
     }
+    
+    if (!targetClient || !(targetClient instanceof Client)) {
+      server.sendChatText(client, "Player not found.");
+      return;
+    }
+
+    let characterId = targetClient.character.characterId;
 
     // check existing characters in foundation permissions
     if (!characterId) {
       for (const a in foundation.permissions) {
         const permissions = foundation.permissions[a];
-        if (permissions.characterName === packet.data.characterName) {
+        if (permissions.characterName === characterName) {
           characterId = permissions.characterId;
         }
       }


### PR DESCRIPTION
So when you try to add someone to permissions on a foundation type, the characters name you enter is case sensitive and also doesn't work for offline players.

This PR changes - 

- NpcFoundationPermissionsManagerAddPermission to allow offline characters to be added and non case sensitivity names to be permitted. 

I've been struggling to get mongodb to work so I wasn't able to test if getOfflineClientByName works, but I based my logic upon the whisper command which does work (as far as I'm aware). 