### PR TITLE
Passenger Vehicle Keys

### DIFF
--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -591,7 +591,7 @@ export class Vehicle2016 extends BaseLootableEntity {
     for (const seatId in this.seats) {
       const seat = this.seats[seatId],
         passenger = seat ? server._characters[seat] : undefined;
-      
+
       if (passenger?.getItemById(Items.VEHICLE_KEY)) {
         return true;
       }

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -587,6 +587,18 @@ export class Vehicle2016 extends BaseLootableEntity {
     if (seat) return server._characters[seat];
   }
 
+  doesPassengersHaveKey(server: ZoneServer2016): boolean | undefined {
+    for (const seatId in this.seats) {
+      const seat = this.seats[seatId],
+        passenger = seat ? server._characters[seat] : undefined;
+      
+      if (passenger?.getItemById(Items.VEHICLE_KEY)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   startEngine(server: ZoneServer2016) {
     server.sendDataToAllWithSpawnedEntity(
       server._vehicles,
@@ -853,7 +865,8 @@ export class Vehicle2016 extends BaseLootableEntity {
   hasVehicleKey(server: ZoneServer2016): boolean {
     return (
       !!this.getItemById(Items.VEHICLE_KEY) ||
-      !!this.getDriver(server)?.getItemById(Items.VEHICLE_KEY)
+      !!this.getDriver(server)?.getItemById(Items.VEHICLE_KEY) ||
+      !!this.doesPassengersHaveKey(server)
     );
   }
 

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -866,7 +866,7 @@ export class Vehicle2016 extends BaseLootableEntity {
     return (
       !!this.getItemById(Items.VEHICLE_KEY) ||
       !!this.getDriver(server)?.getItemById(Items.VEHICLE_KEY) ||
-      !!this.doesPassengersHaveKey(server)
+      this.doesPassengersHaveKey(server)
     );
   }
 

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -587,7 +587,7 @@ export class Vehicle2016 extends BaseLootableEntity {
     if (seat) return server._characters[seat];
   }
 
-  doesPassengersHaveKey(server: ZoneServer2016): boolean | undefined {
+  doesPassengersHaveKey(server: ZoneServer2016): boolean {
     for (const seatId in this.seats) {
       const seat = this.seats[seatId],
         passenger = seat ? server._characters[seat] : undefined;

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -865,7 +865,6 @@ export class Vehicle2016 extends BaseLootableEntity {
   hasVehicleKey(server: ZoneServer2016): boolean {
     return (
       !!this.getItemById(Items.VEHICLE_KEY) ||
-      !!this.getDriver(server)?.getItemById(Items.VEHICLE_KEY) ||
       this.doesPassengersHaveKey(server)
     );
   }


### PR DESCRIPTION
In the September 28th, 2016 update, DBG added vehicle keys to cars. In this update, they also made it so vehicle keys can bypass hotwiring if: the driver has a key, the vehicles inventory has a key, or if any of the passengers have a key. This PR is to reflect the last change in particular, allowing any passenger with a vehicle key to bypass the hotwire function of the car. Also added the model for vehicle keys when dropped.

This PR changes - 

- Allows vehicle hotwire to be bypassed if any of the passengers have a vehicle key.
- Add model for vehicle key on drop

Known issue:
Not really an issue, but when a the driver doesn't have a key, but the passengers do, users will still get the alert "you must have a vehicle key or hotwire to operate". I believe it's some kind of built in H1Z1 function that checks if the driver has a vehicle key or not, and doesn't bother to check passengers.. Not really sure how to make the alert not send.