### PR TITLE
Fix load construction unit test

### DIFF
--- a/src/servers/ZoneServer2016/managers/worlddatamanager.test.ts
+++ b/src/servers/ZoneServer2016/managers/worlddatamanager.test.ts
@@ -163,9 +163,15 @@ async function worldSaveUnitTests(t: any, mongoAddress: string) {
 
     assert.deepStrictEqual(loadedConstructions?.length, constructionNb);
     removeMongoDbId(loadedConstructions);
+    // sort per characterId since mongo mangle the order
+    loadedConstructions.sort((a, b) => {
+      return a.characterId.localeCompare(b.characterId);
+    });
+    world.constructions.sort((a, b) => {
+      return a.characterId.localeCompare(b.characterId);
+    });
 
-    // FIXME: this could be the resolution of #1467
-    // assert.deepStrictEqual(loadedConstructions, world.constructions);
+    assert.deepStrictEqual(loadedConstructions, world.constructions);
   });
   await t.test("load world constructions", async () => {
     const loadedWorldConstructions =


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request fixes the issue where the order of loaded constructions was not consistent due to MongoDB's handling of data. It introduces a sorting mechanism based on the characterId to ensure the order is consistent.
> 
> ## What changed
> The main change is in the `worldSaveUnitTests` function in the `worlddatamanager.test.ts` file. After loading the constructions, they are now sorted by `characterId` before being compared for equality. This ensures that the order of constructions is consistent, regardless of how MongoDB returns the data.
> 
> ## How to test
> To test this change, run the unit tests for the `worlddatamanager.test.ts` file. The test should now pass, showing that the loaded constructions and the world constructions are equal, even if MongoDB returns the data in a different order.
> 
> ## Why make this change
> This change is necessary to ensure that the tests for the `worlddatamanager` are reliable and consistent. Previously, the test could fail if MongoDB returned the data in a different order, even if the data was correct. By sorting the data before comparing it, we ensure that the test only fails if the data is incorrect, not if it is in a different order.
</details>