### PR TITLE
Make wrench consistent with July 2016 update

### DIFF
--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -1198,7 +1198,7 @@ export class Vehicle2016 extends BaseLootableEntity {
     }
 
     if (this._resources[ResourceIds.CONDITION] < 100000) {
-      this.damage(server, { ...damageInfo, damage: -5000 });
+      this.damage(server, { ...damageInfo, damage: -2000 });
       server.damageItem(client, weapon, 100);
     }
   }

--- a/src/servers/ZoneServer2016/models/enums.ts
+++ b/src/servers/ZoneServer2016/models/enums.ts
@@ -921,7 +921,8 @@ export enum WeaponDefinitionIds {
   WEAPON_M9 = 1401,
   WEAPON_1911 = 2,
   WEAPON_CROWBAR = 9,
-  WEAPON_HAMMER = 1396
+  WEAPON_HAMMER = 1396,
+  WEAPON_WRENCH = 1415
 }
 
 export enum Skins_Shirt {

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5458,6 +5458,9 @@ export class ZoneServer2016 extends EventEmitter {
       case WeaponDefinitionIds.WEAPON_PURGE:
         durability = 1000;
         break;
+      case WeaponDefinitionIds.WEAPON_WRENCH:
+        durability = 2500;
+        break;
       case WeaponDefinitionIds.WEAPON_HAMMER:
       case WeaponDefinitionIds.WEAPON_CROWBAR:
       case WeaponDefinitionIds.WEAPON_308:
@@ -6768,12 +6771,6 @@ export class ZoneServer2016 extends EventEmitter {
       );
       return;
     }
-    const vehicle = this._vehicles[vehicleGuid];
-    if (vehicle._resources[ResourceIds.FUEL] + fuelValue > 10000) {
-      // Prevent players from overfilling their car to reserve fuel.
-      this.sendAlert(client, "Fuel level is not low enough to refuel");
-      return;
-    }
     this.utilizeHudTimer(client, nameId, timeout, animationId, () => {
       this.refuelVehiclePass(client, character, item, vehicleGuid, fuelValue);
     });
@@ -7076,6 +7073,7 @@ export class ZoneServer2016 extends EventEmitter {
       return;
     const vehicle = this._vehicles[vehicleGuid];
     vehicle._resources[ResourceIds.FUEL] += fuelValue;
+    // check if refuel amount is over 100, if so adjust to 100 to prevent over-fueling.
     if (vehicle._resources[ResourceIds.FUEL] > 10000) {
       vehicle._resources[ResourceIds.FUEL] = 10000;
     }

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6771,6 +6771,12 @@ export class ZoneServer2016 extends EventEmitter {
       );
       return;
     }
+    const vehicle = this._vehicles[vehicleGuid];
+    if (vehicle._resources[ResourceIds.FUEL] + fuelValue > 10000) {
+      // Prevent players from overfilling their car to reserve fuel.
+      this.sendAlert(client, "Fuel level is not low enough to refuel");
+      return;
+    }
     this.utilizeHudTimer(client, nameId, timeout, animationId, () => {
       this.refuelVehiclePass(client, character, item, vehicleGuid, fuelValue);
     });


### PR DESCRIPTION
![2bcb2c526fd74a3050d7bd99166ca96c](https://github.com/QuentinGruber/h1z1-server/assets/49224688/861390ce-11c3-4f1e-ba2d-8c5942e0cc7a)

In the July 7th, 2016 update facepunch added Anti-Vehicle hoarding measures to prevent players from excessively storing cars.  Currently on H1EMU, wrenches have 2k durability and repair the vehicle 5% per swing for a maximum of 100%. In the Anti-Hoarding update, wrenches had 2.5k durability and repaired the vehicle by 2% per swing for a maximum of 50%. This PR is to make the wrench more in-line with that update.

This PR changes - 

- Modified wrench to have 2.5k durability and repair a vehicle by 2% per swing
- Fixed a bug where you couldn't refuel a vehicle if the fuel amount was between 76-99%.