### PR TITLE
Add restricted building rulesets

### DIFF
--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -12,6 +12,7 @@ server:
   isPvE: false
   isHeadshotOnly: false
   isFirstPersonOnly: false
+  isNoBuildInPois: true
   baseConstructionDamage: 34000
 
 # Fairplay / anticheat config
@@ -102,7 +103,6 @@ speedtree:
   maxTreeHits: 20 # maximum hits it takes to chop a tree
 
 construction:
-  allowPOIPlacement: false
   allowStackedPlacement: false
   allowOutOfBoundsPlacement: false
   placementRange: 30

--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -103,6 +103,7 @@ speedtree:
   maxTreeHits: 20 # maximum hits it takes to chop a tree
 
 construction:
+  # allowPOIPlacement: false - deprecated in favor of isNoBuildInPOIs ^
   allowStackedPlacement: false
   allowOutOfBoundsPlacement: false
   placementRange: 30

--- a/src/servers/ZoneServer2016/managers/configmanager.ts
+++ b/src/servers/ZoneServer2016/managers/configmanager.ts
@@ -147,6 +147,7 @@ export class ConfigManager {
       isPvE,
       isHeadshotOnly,
       isFirstPersonOnly,
+      isNoBuildInPois,
       baseConstructionDamage
     } = this.config.server;
     server.proximityItemsDistance = proximityItemsDistance;
@@ -162,6 +163,7 @@ export class ConfigManager {
     server.isPvE = isPvE;
     server.isHeadshotOnly = isHeadshotOnly;
     server.isFirstPersonOnly = isFirstPersonOnly;
+    server.isNoBuildInPois = isNoBuildInPois;
     server.baseConstructionDamage = baseConstructionDamage;
     //#endregion
 
@@ -268,7 +270,6 @@ export class ConfigManager {
 
     //#region construction
     const {
-      allowPOIPlacement,
       allowStackedPlacement,
       allowOutOfBoundsPlacement,
       placementRange,
@@ -277,7 +278,6 @@ export class ConfigManager {
       playerFoundationBlockedPlacementRange,
       playerShackBlockedPlacementRange
     } = this.config.construction;
-    server.constructionManager.allowPOIPlacement = allowPOIPlacement;
     server.constructionManager.allowStackedPlacement = allowStackedPlacement;
     server.constructionManager.allowOutOfBoundsPlacement =
       allowOutOfBoundsPlacement;

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -75,7 +75,6 @@ export class ConstructionManager {
   ];
 
   /* MANAGED BY CONFIGMANAGER */
-  allowPOIPlacement!: boolean;
   allowStackedPlacement!: boolean;
   allowOutOfBoundsPlacement!: boolean;
   placementRange!: number;
@@ -347,13 +346,14 @@ export class ConstructionManager {
     return false;
   }
   detectPOIPlacement(
+    server: ZoneServer2016,
     itemDefinitionId: number,
     position: Float32Array,
     client: Client,
     isInsidePermissionedFoundation: boolean
   ): boolean {
     if (client.isDebugMode) return false;
-    if (this.allowPOIPlacement) return false;
+    if (!server.isNoBuildInPois) return false;
     if (this.overridePlacementItems.includes(itemDefinitionId)) return false;
     let useRange = true;
     let isInPoi = false;
@@ -428,6 +428,7 @@ export class ConstructionManager {
 
     if (
       this.detectPOIPlacement(
+        server,
         itemDefinitionId,
         position,
         client,

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -346,14 +346,12 @@ export class ConstructionManager {
     return false;
   }
   detectPOIPlacement(
-    server: ZoneServer2016,
     itemDefinitionId: number,
     position: Float32Array,
     client: Client,
     isInsidePermissionedFoundation: boolean
   ): boolean {
     if (client.isDebugMode) return false;
-    if (server.isNoBuildInPois) return false;
     if (this.overridePlacementItems.includes(itemDefinitionId)) return false;
     let useRange = true;
     let isInPoi = false;
@@ -426,9 +424,9 @@ export class ConstructionManager {
       return true;
     }
 
+    if (server.isNoBuildInPois) return false;
     if (
       this.detectPOIPlacement(
-        server,
         itemDefinitionId,
         position,
         client,

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -353,7 +353,7 @@ export class ConstructionManager {
     isInsidePermissionedFoundation: boolean
   ): boolean {
     if (client.isDebugMode) return false;
-    if (!server.isNoBuildInPois) return false;
+    if (server.isNoBuildInPois) return false;
     if (this.overridePlacementItems.includes(itemDefinitionId)) return false;
     let useRange = true;
     let isInPoi = false;

--- a/src/servers/ZoneServer2016/models/config.ts
+++ b/src/servers/ZoneServer2016/models/config.ts
@@ -29,6 +29,7 @@ interface ServerConfig {
   isPvE: boolean;
   isHeadshotOnly: boolean;
   isFirstPersonOnly: boolean;
+  isNoBuildInPois: boolean;
   baseConstructionDamage: number;
 }
 
@@ -95,7 +96,6 @@ interface SpeedTreeConfig {
 }
 
 interface ConstructionConfig {
-  allowPOIPlacement: boolean;
   allowStackedPlacement: boolean;
   allowOutOfBoundsPlacement: boolean;
   placementRange: number;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1753,7 +1753,7 @@ export class ZoneServer2016 extends EventEmitter {
             ruleset: "NoBuildNearPois",
             unknownString2: "",
             rulesets: []
-          },
+          }
         ]
       }
     );

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -403,6 +403,7 @@ export class ZoneServer2016 extends EventEmitter {
   isPvE!: boolean;
   isHeadshotOnly!: boolean;
   isFirstPersonOnly!: boolean;
+  isNoBuildInPois!: boolean;
   baseConstructionDamage!: number;
   crowbarHitRewardChance!: number;
   crowbarHitDamage!: number;
@@ -443,6 +444,7 @@ export class ZoneServer2016 extends EventEmitter {
     serverGameRules.push(this.isPvE ? "PvE" : "PvP");
     if (this.isFirstPersonOnly) serverGameRules.push("FirstPersonOnly");
     if (this.isHeadshotOnly) serverGameRules.push("Headshots");
+    if (this.isNoBuildInPois) serverGameRules.push("NoBuildNearPois");
     this.serverGameRules = serverGameRules.join(",");
 
     this._soloMode = false;
@@ -1744,7 +1746,14 @@ export class ZoneServer2016 extends EventEmitter {
             ruleset: "BattleRoyale",
             unknownString2: "",
             rulesets: []
-          }
+          },
+          {
+            RULESET_ID: 7,
+            RULESET_ID_: 7,
+            ruleset: "NoBuildNearPois",
+            unknownString2: "",
+            rulesets: []
+          },
         ]
       }
     );


### PR DESCRIPTION
So something that I remembered from 2016 was the "restricted building" ruleset image on the server select screen that basically told you if a server allowed you to build in pois or not. I miss the hammer and triangle picture so this is something I've tried to work on for a while but finally managed to get working 😂 I found it from decompiling the CharacterSelect.gfx actionscript file, there were some other gamemodes included in there too!

So this PR: 

- Adds restricted building ruleset & image to server select screen
- Add isNoBuildInPois config variable for building in poi and removed allowPOIPlacement