### PR TITLE
Properly calculate ping

### DIFF
--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -91,7 +91,10 @@ export class SOEServer extends EventEmitter {
     const resendedSequences: Set<number> = new Set();
     for (const [sequence, time] of client.unAckData) {
       // if the packet is too old then we resend it
-      if (time + this._resendTimeout + client.avgPing < currentTime) {
+      if (
+        time + this._resendTimeout + this._waitTimeMs + client.avgPing <
+        currentTime
+      ) {
         const dataCache = client.outputStream.getDataCache(sequence);
         if (dataCache) {
           client.stats.packetResend++;
@@ -177,10 +180,7 @@ export class SOEServer extends EventEmitter {
     for (let index = 0; index < queue.packets.length; index++) {
       const packet = queue.packets[index];
       if (packet.isReliable) {
-        client.unAckData.set(
-          packet.sequence as number,
-          Date.now() + this._waitTimeMs
-        );
+        client.unAckData.set(packet.sequence as number, Date.now());
       }
     }
   }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the SOEServer class to improve packet handling. It changes the way packets are resent and how unacknowledged data is stored.
> 
> ## What changed
> The main changes are in the `SOEServer` class. 
> 
> 1. The condition for resending packets has been updated. Previously, a packet was resent if its timestamp plus the resend timeout and the client's average ping was less than the current time. Now, an additional wait time (`this._waitTimeMs`) is added to the condition.
> 
> 2. The way unacknowledged data is stored has been simplified. Previously, the timestamp when the data was stored was added to the current time plus a wait time. Now, only the current time is stored.
> 
> ## How to test
> To test these changes, you can simulate packet transmission and observe the behavior of the server. You should notice that packets are resent based on the new condition and that unacknowledged data is stored with the new method.
> 
> ## Why make this change
> These changes are made to improve the efficiency and reliability of the server. By adjusting the condition for resending packets, we can ensure that packets are not unnecessarily resent. By simplifying the way unacknowledged data is stored, we can reduce the complexity of the code and make it easier to maintain.
</details>