### PR TITLE
Remove server lag from ping calculation

### DIFF
--- a/src/servers/GatewayServer/gatewayserver.ts
+++ b/src/servers/GatewayServer/gatewayserver.ts
@@ -105,6 +105,10 @@ export class GatewayServer extends EventEmitter {
     return this._soeServer.getSoeClient(soeClientId)?.getNetworkStats();
   }
 
+  getServerNetworkStats(): string[] {
+    return this._soeServer.getNetworkStats();
+  }
+
   getSoeClientSessionId(soeClientId: string): number | undefined {
     return this._soeServer.getSoeClient(soeClientId)?.sessionId;
   }

--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -212,10 +212,12 @@ export const commands: Array<Command> = [
       client: Client,
       args: Array<string>
     ) => {
-      const stats = await server._gatewayServer.getSoeClientNetworkStats(
+      const stats = server._gatewayServer.getSoeClientNetworkStats(
         client.soeClientId
       );
       if (stats) {
+        const serverStats = server._gatewayServer.getServerNetworkStats();
+        stats.push(serverStats[0]);
         for (let index = 0; index < stats.length; index++) {
           const stat = stats[index];
           server.sendChatText(client, stat, index == 0);
@@ -231,11 +233,13 @@ export const commands: Array<Command> = [
       client: Client,
       args: Array<string>
     ) => {
-      const stats = await server._gatewayServer.getSoeClientNetworkStats(
+      const stats = server._gatewayServer.getSoeClientNetworkStats(
         client.soeClientId
       );
+      const serverStats = server._gatewayServer.getServerNetworkStats();
       if (stats) {
         server.sendChatText(client, stats[2], true);
+        server.sendChatText(client, serverStats[0], false);
       }
     }
   },


### PR DESCRIPTION
- [x] will test this on live before merging

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a new feature to monitor server lag and network statistics. It also modifies the existing commands to include these new stats.
> 
> ## What changed
> - Added a new method `getServerNetworkStats` in `GatewayServer` to fetch server network statistics.
> - In `SOEServer`, added properties to track event loop lag and calculate average lag. Also, added a new method `getNetworkStats` to return server lag.
> - Modified the existing commands in `ZoneServer2016` to include server stats along with client stats.
> 
> ## How to test
> - After pulling the changes, start the server and connect a client.
> - Use the modified commands to fetch network stats. It should now include server stats as well.
> 
> ## Why make this change
> This change helps in monitoring the server performance and network statistics in real-time. It can be useful in identifying any performance issues and optimizing the server.
</details>