### PR TITLE
Hammer cooldown for repairing constructions

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -197,6 +197,7 @@ export class Character2016 extends BaseFullCharacter {
     abilityHitLocation: "",
     characterId: ""
   };
+  lastRepairTime: number = 0;
   constructor(
     characterId: string,
     transientId: number,

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -2454,6 +2454,12 @@ export class ConstructionManager {
     entity: ConstructionEntity,
     weaponItem: LoadoutItem
   ) {
+
+    if (client.character.lastRepairTime && Date.now() - client.character.lastRepairTime < 1000) {
+      server.sendChatText(client, "Cooldown on repairing.");
+      return;
+    }
+
     let accumulatedItemDamage = 0;
     server.sendCompositeEffectToAllInRange(
       15,
@@ -2487,6 +2493,7 @@ export class ConstructionManager {
     }
     server.damageItem(client, weaponItem, Math.ceil(accumulatedItemDamage / 4));
     client.character.lastMeleeHitTime = Date.now();
+    client.character.lastRepairTime = Date.now();
   }
 
   private fullyRepairFreeplaceEntities(

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -2454,8 +2454,10 @@ export class ConstructionManager {
     entity: ConstructionEntity,
     weaponItem: LoadoutItem
   ) {
-
-    if (client.character.lastRepairTime && Date.now() - client.character.lastRepairTime < 1000) {
+    if (
+      client.character.lastRepairTime &&
+      Date.now() - client.character.lastRepairTime < 1000
+    ) {
       server.sendChatText(client, "Cooldown on repairing.");
       return;
     }

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2306,6 +2306,23 @@ export class ZoneServer2016 extends EventEmitter {
 
     const sourceEntity = this.getEntity(npcTriggered),
       sourceIsVehicle = sourceEntity instanceof Vehicle2016;
+
+    // explode nearby explosives first
+    for (const explosive in this._explosives) {
+      const explosiveObj = this._explosives[explosive];
+      if (explosiveObj.characterId != npcTriggered) {
+        if (getDistance(position, explosiveObj.state.position) < 2) {
+          await scheduler.wait(100);
+          if (this._spawnedItems[explosiveObj.characterId]) {
+            const object = this._spawnedItems[explosiveObj.characterId];
+            this.deleteEntity(explosiveObj.characterId, this._spawnedItems);
+            delete this.worldObjectManager.spawnedLootObjects[object.spawnerId];
+          }
+          if (!explosiveObj.detonated) explosiveObj.detonate(this, client);
+        }
+      }
+    }
+
     if (!this.isPvE) {
       for (const characterId in this._characters) {
         const character = this._characters[characterId];
@@ -2508,20 +2525,6 @@ export class ZoneServer2016 extends EventEmitter {
             constructionObject.state.position,
             itemDefinitionId
           );
-        }
-      }
-    }
-    for (const explosive in this._explosives) {
-      const explosiveObj = this._explosives[explosive];
-      if (explosiveObj.characterId != npcTriggered) {
-        if (getDistance(position, explosiveObj.state.position) < 2) {
-          await scheduler.wait(100);
-          if (this._spawnedItems[explosiveObj.characterId]) {
-            const object = this._spawnedItems[explosiveObj.characterId];
-            this.deleteEntity(explosiveObj.characterId, this._spawnedItems);
-            delete this.worldObjectManager.spawnedLootObjects[object.spawnerId];
-          }
-          if (!explosiveObj.detonated) explosiveObj.detonate(this, client);
         }
       }
     }


### PR DESCRIPTION
https://www.youtube.com/watch?v=WpSL7cDjQRs&t=429s (3:05, other parts of the vids he shows him hammering too)

So currently, a common thing players like to do when getting raided is to have multiple people melee spamming hammers on the base so explosives like ethanol/biofuel have less of a chance to destroy the construction - not a problem with IEDs b/c you can light multiple of them at once (the math to determine if a construction will be repaired or not while in the middle of exploding is completely random, it's based upon timing, server lag, whole bunch of other shit etc.) 

Anyways, this is super boring gameplay to just have people sitting there spamming to repair the base than actually defending it... So this PR adds a 1 second delay between repair times to prevent this kind of gameplay.

I also moved the logic pertaining to exploding nearby explosives up to speed up the exploding times of eth/bio by a small amount.