### PR TITLE
Unallow server lag to be negative

### DIFF
--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -84,9 +84,11 @@ export class SOEServer extends EventEmitter {
   }
 
   getNetworkStats() {
-    return [
-      `Avg Server lag : ${Number(this.avgEventLoopLag.toFixed(1)) - 1}ms`
-    ];
+    const avgServerLag =
+      this.avgEventLoopLag > 1
+        ? Number(this.avgEventLoopLag.toFixed(1)) - 1
+        : 0;
+    return [`Avg Server lag : ${avgServerLag}ms`];
   }
 
   // return the client if found
@@ -343,9 +345,8 @@ export class SOEServer extends EventEmitter {
       case "Ack":
         const mostWaitedPacketTime = client.unAckData.get(packet.sequence);
         if (mostWaitedPacketTime) {
-          client.addPing(
-            Date.now() - mostWaitedPacketTime - this.currentEventLoopLag
-          );
+          const currentLag = this.currentEventLoopLag || 0;
+          client.addPing(Date.now() - mostWaitedPacketTime - currentLag);
         }
         client.outputStream.ack(packet.sequence, client.unAckData);
         break;


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `SOEServer` class to improve the calculation of average server lag and the handling of "Ack" packets.
> 
> ## What changed
> Two main changes were made in the `soeserver.ts` file:
> 
> 1. In the `getNetworkStats` method, the calculation of `avgServerLag` was modified. Now, if `this.avgEventLoopLag` is less than or equal to 1, `avgServerLag` is set to 0. This prevents negative values for server lag.
> 
> 2. In the handling of "Ack" packets, a new variable `currentLag` was introduced. This variable is set to `this.currentEventLoopLag` or 0 if `this.currentEventLoopLag` is undefined. This change ensures that `currentLag` is always a number and prevents potential errors when subtracting `this.currentEventLoopLag` from `Date.now() - mostWaitedPacketTime`.
> 
> ## How to test
> To test these changes, you can monitor the server's network stats and observe the handling of "Ack" packets. The average server lag should never be negative, and "Ack" packets should be processed without errors even if `this.currentEventLoopLag` is undefined.
> 
> ## Why make this change
> These changes improve the robustness of the server's network statistics and packet handling. By ensuring that server lag and packet processing times are always calculated correctly, we can provide more accurate and reliable network statistics. This can help with server monitoring and troubleshooting.
</details>