### PR TITLE
Reduce serverLag calculation cpu usage

### DIFF
--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -58,9 +58,10 @@ export class SOEServer extends EventEmitter {
     });
     // To support node 18 that we use for h1z1-server binaries
     try {
+      const intervalTime = 100;
       const obs = new PerformanceObserver((list) => {
         const entry = list.getEntries()[0];
-        this.currentEventLoopLag = Math.floor(entry.duration * 0.98);
+        this.currentEventLoopLag = Math.floor(entry.duration) - intervalTime;
         // calculate the average of the last 100 values
         // if the array is full then we remove the first value
         if (this.eventLoopLagValues.length > 100) {
@@ -77,7 +78,7 @@ export class SOEServer extends EventEmitter {
         performance.mark("B");
         performance.measure("A to B", "A", "B");
         performance.mark("A");
-      }, 0);
+      }, intervalTime);
     } catch (e) {
       console.log("PerformanceObserver not available");
     }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request modifies the `SOEServer` class to improve the calculation of event loop lag. It introduces a constant interval time and adjusts the calculation of the current event loop lag.
> 
> ## What changed
> The main changes are in the `SOEServer` class in the `soeserver.ts` file. 
> 
> - A constant `intervalTime` of 100 was introduced.
> - The calculation of `this.currentEventLoopLag` was adjusted to subtract `intervalTime` from the floor value of `entry.duration`.
> - The interval for the performance measurement was changed from 0 to 100.
> 
> ```diff
> +      const intervalTime = 100;
>        const obs = new PerformanceObserver((list) => {
>          const entry = list.getEntries()[0];
> -        this.currentEventLoopLag = Math.floor(entry.duration * 0.98);
> +        this.currentEventLoopLag = Math.floor(entry.duration) - intervalTime;
> ...
> -      }, 0);
> +      }, 100);
> ```
> 
> ## How to test
> To test these changes, run the server and observe the event loop lag values. They should be calculated correctly and the performance measurement should run at an interval of 100.
> 
> ## Why make this change
> This change improves the accuracy of the event loop lag calculation by taking into account a constant interval time. This makes the measurement more consistent and reliable. The change in the interval for the performance measurement also ensures that the measurement is not run too frequently, which could potentially impact performance.
</details>