### PR TITLE
Make /dev lag ending artificial lag after 20seconds

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/dev.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/dev.ts
@@ -57,7 +57,11 @@ const dev: any = {
     console.log(WorldObjectManager.itemSpawnersChances);
   },
   lag: function (server: ZoneServer2016, client: Client, args: Array<string>) {
-    setInterval(() => {
+    const startTime = Date.now();
+    const interval = setInterval(() => {
+      if (Date.now() - startTime > 20000) {
+        clearInterval(interval);
+      }
       for (let i = 0; i < 1_000_000_000; i++) {
         // do nothing but hold the event loop
         const a = i;


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a change to the `lag` function in the `dev.ts` file. The change ensures that the function only runs for a maximum of 20 seconds.
> 
> ## What changed
> The `lag` function was previously set to run indefinitely. This change introduces a time limit to the function. The function now checks the elapsed time since it started running and stops after 20 seconds.
> 
> ```diff
> - setInterval(() => {
> + const startTime = Date.now();
> + const interval = setInterval(() => {
> +   if (Date.now() - startTime > 20000) {
> +     clearInterval(interval);
> +   }
> ```
> 
> ## How to test
> To test this change, you can call the `lag` function and observe that it stops running after 20 seconds. You can also check the console logs to see the start and end times of the function.
> 
> ## Why make this change
> This change is necessary to prevent the `lag` function from running indefinitely, which could potentially cause performance issues. By limiting the function to run for a maximum of 20 seconds, we ensure that it does not hold the event loop for too long.
</details>