### PR TITLE
Allow refueling to 100, but not exceed

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6791,12 +6791,6 @@ export class ZoneServer2016 extends EventEmitter {
       );
       return;
     }
-    const vehicle = this._vehicles[vehicleGuid];
-    if (vehicle._resources[ResourceIds.FUEL] + fuelValue > 10000) {
-      // Prevent players from overfilling their car to reserve fuel.
-      this.sendAlert(client, "Fuel level is not low enough to refuel");
-      return;
-    }
     this.utilizeHudTimer(client, nameId, timeout, animationId, () => {
       this.refuelVehiclePass(client, character, item, vehicleGuid, fuelValue);
     });
@@ -7100,7 +7094,7 @@ export class ZoneServer2016 extends EventEmitter {
     const vehicle = this._vehicles[vehicleGuid];
     vehicle._resources[ResourceIds.FUEL] += fuelValue;
     // check if refuel amount is over 100, if so adjust to 100 to prevent over-fueling.
-    if (vehicle._resources[ResourceIds.FUEL] > 10000) {
+    if (vehicle._resources[ResourceIds.FUEL] >= 10000) {
       vehicle._resources[ResourceIds.FUEL] = 10000;
     }
     this.updateResourceToAllWithSpawnedEntity(

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6791,6 +6791,12 @@ export class ZoneServer2016 extends EventEmitter {
       );
       return;
     }
+    const vehicle = this._vehicles[vehicleGuid];
+    if (vehicle._resources[ResourceIds.FUEL] >= 10000) {
+      // prevent players from wasting fuel while being at 100%
+      this.sendAlert(client, "Fuel tank is full!");
+      return;
+    }
     this.utilizeHudTimer(client, nameId, timeout, animationId, () => {
       this.refuelVehiclePass(client, character, item, vehicleGuid, fuelValue);
     });


### PR DESCRIPTION
#1979, when the resourceids.fuel + fuelValue is over or equal to 10000, adjust the fuel level to be 10000 to prevent the fuel resource from being broken