### PR TITLE
TrapEntity damage

### DIFF
--- a/src/servers/ZoneServer2016/entities/trapentity.ts
+++ b/src/servers/ZoneServer2016/entities/trapentity.ts
@@ -99,7 +99,7 @@ export class TrapEntity extends BaseSimpleNpc {
                 "Character.UpdateSimpleProxyHealth",
                 this.pGetSimpleProxyHealth()
               );
-              this.health -= 1000;
+              if (!this.worldOwned) this.health -= 1000;
             }
           }
 
@@ -211,7 +211,7 @@ export class TrapEntity extends BaseSimpleNpc {
                 "Character.UpdateSimpleProxyHealth",
                 this.pGetSimpleProxyHealth()
               );
-              this.health -= 1000;
+              if (!this.worldOwned) this.health -= 1000;
             }
           }
 
@@ -262,6 +262,7 @@ export class TrapEntity extends BaseSimpleNpc {
   }
 
   damage(server: ZoneServer2016, damageInfo: DamageInfo) {
+    if (this.worldOwned) return;
     this.health -= damageInfo.damage;
     server.sendDataToAllWithSpawnedEntity(
       server._traps,


### PR DESCRIPTION
#1988 was nice that the logic already existed for it 😅 was just never implemented.

This PR makes:
- World spawned trap entities not be able to receive damage