### PR TITLE
Lower vehicle decay rate

### DIFF
--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -131,7 +131,7 @@ decay:
   vacantFoundationTicks: 3 # destroy empty foundations after 1 hour
   griefFoundationTimer: 72 # destroy grief foundations after 3 days (72 hours)
   griefCheckSlotAmount: 4 # must have a minimum of 4 wall slots to avoid anti-grief
-  baseVehicleDamage: 6000 # 6% damage per 3 ticks
+  baseVehicleDamage: 2000 # 2% damage per 3 ticks (1 hour)
   maxVehiclesPerArea: 2 # the max amount of vehicles that can be in an area before they start taking more damage
   vehicleDamageRange: 25 # how large of a range to detect maxVehiclesPerArea
   dailyRepairMaterials:


### PR DESCRIPTION
So to follow-up with #1972, in the same screenshot DBG talks about how they lowered vehicle decay to quote: "decay their condition slowly over time. they [vehicles] will fully decay in a little over two days." 

This PR lowers the baseVehicleDamage to be 2000 which is a little over two days (50 hours to be exact). 

In my personal opinion too, I think vehicle decay was a little too quick before also. It was around ~15 hours even if you only had 1 car and it was full hp! Also I was wondering to maybe buff maxVehiclesPerArea by 1? If I'm not mistaken, in 2016 you could have 3 cars but once you had 4 then the vehicle decay would ramp up, but I could be remembering wrong 