### PR TITLE
Faster decay free place

### DIFF
--- a/src/servers/ZoneServer2016/data/lootspawns.ts
+++ b/src/servers/ZoneServer2016/data/lootspawns.ts
@@ -3345,14 +3345,6 @@ export const containerLootSpawners: {
         }
       },
       {
-        item: Items.WOOD_PLANK,
-        weight: 20,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
-      {
         item: Items.CLOTH,
         weight: 15,
         spawnCount: {
@@ -3382,14 +3374,6 @@ export const containerLootSpawners: {
     spawnChance: 50,
     maxItems: 1,
     items: [
-      {
-        item: Items.WOOD_PLANK,
-        weight: 50,
-        spawnCount: {
-          min: 1,
-          max: 1
-        }
-      },
       {
         item: Items.CANNED_FOOD01,
         weight: 10,

--- a/src/servers/ZoneServer2016/entities/crate.ts
+++ b/src/servers/ZoneServer2016/entities/crate.ts
@@ -149,8 +149,9 @@ export class Crate extends BaseSimpleNpc {
 
     // 20% chance to spawn wood planks, 60% if it's a crowbar
     const woodPlanksChance = Math.floor(Math.random() * 100) + 1;
-    const spawnChanceWoodPlank = weapon.itemDefinitionId == Items.WEAPON_CROWBAR ? 60: 20; 
-    
+    const spawnChanceWoodPlank =
+      weapon.itemDefinitionId == Items.WEAPON_CROWBAR ? 60 : 20;
+
     if (woodPlanksChance < spawnChanceWoodPlank) {
       const woodPlankItem = server.worldObjectManager.createLootEntity(
         server,

--- a/src/servers/ZoneServer2016/entities/crate.ts
+++ b/src/servers/ZoneServer2016/entities/crate.ts
@@ -17,7 +17,7 @@ import { randomIntFromInterval, isPosInRadius } from "../../../utils/utils";
 import { containerLootSpawners } from "../data/lootspawns";
 import { getRandomItem } from "../managers/worldobjectmanager";
 import { BaseSimpleNpc } from "./basesimplenpc";
-import { Effects } from "../models/enums";
+import { Effects, Items } from "../models/enums";
 import { CharacterRemovePlayer } from "../../../types/zone2016packets";
 
 export function getActorModelId(actorModel: string): number {
@@ -135,7 +135,42 @@ export class Crate extends BaseSimpleNpc {
       this.pGetSimpleProxyHealth()
     );
     if (this.health > 0) return;
+
+    this.generateWoodPlanks(server, damageInfo);
     this.destroy(server);
+  }
+
+  generateWoodPlanks(server: ZoneServer2016, damageInfo: DamageInfo) {
+    const client = server.getClientByCharId(damageInfo.entity);
+    if (!client) return;
+
+    const weapon = client.character.getEquippedWeapon();
+    if (!weapon) return;
+
+    // 20% chance to spawn wood planks, 60% if it's a crowbar
+    const woodPlanksChance = Math.floor(Math.random() * 100) + 1;
+    const spawnChanceWoodPlank = weapon.itemDefinitionId == Items.WEAPON_CROWBAR ? 60: 20; 
+    
+    if (woodPlanksChance < spawnChanceWoodPlank) {
+      const woodPlankItem = server.worldObjectManager.createLootEntity(
+        server,
+        server.generateItem(Items.WOOD_PLANK),
+        new Float32Array([
+          this.state.position[0],
+          this.actorModelId == 9088
+            ? this.state.position[1] + 0.1
+            : this.state.position[1],
+          this.state.position[2],
+          1
+        ]),
+        new Float32Array([0, 0, 0, 0])
+      );
+      if (!woodPlankItem) return;
+      server.executeFuncForAllReadyClientsInRange((c) => {
+        c.spawnedEntities.add(woodPlankItem);
+        server.addLightweightNpc(c, woodPlankItem);
+      }, woodPlankItem);
+    }
   }
 
   destroy(server: ZoneServer2016): boolean {

--- a/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
+++ b/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
@@ -268,7 +268,11 @@ export class LootableConstructionEntity extends BaseLootableEntity {
     }
   }
 
-  async handleBeeboxSwarm(server: ZoneServer2016, client: ZoneClient2016, dictionary: EntityDictionary<BaseEntity>, damageInfo: DamageInfo) {
+  async handleBeeboxSwarm(server: ZoneServer2016, damageInfo: DamageInfo) {
+    const client = server.getClientByCharId(damageInfo.entity);
+    const dictionary = server.getEntityDictionary(this.characterId);
+    if (!client || !dictionary) return;
+    
     server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
       dictionary,
       this.characterId,
@@ -308,21 +312,11 @@ export class LootableConstructionEntity extends BaseLootableEntity {
   }
 
   OnMeleeHit(server: ZoneServer2016, damageInfo: DamageInfo) {
-    const client = server.getClientByCharId(damageInfo.entity);
-    const dictionary = server.getEntityDictionary(this.characterId);
-    if (!client || !dictionary) return;
-
     if (
       this.itemDefinitionId == Items.BEE_BOX &&
       damageInfo.weapon != Items.WEAPON_HAMMER_DEMOLITION
     ) {
-      this.handleBeeboxSwarm(server, client, dictionary, damageInfo);
-    }
-
-    if (dictionary == server._worldLootableConstruction || server._worldSimpleConstruction) {
-      if (this.itemDefinitionId == Items.FURNACE || Items.BARBEQUE) {
-        
-      }
+      this.handleBeeboxSwarm(server, damageInfo);
     }
      
     server.constructionManager.OnMeleeHit(server, damageInfo, this);

--- a/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
+++ b/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
@@ -272,7 +272,7 @@ export class LootableConstructionEntity extends BaseLootableEntity {
     const client = server.getClientByCharId(damageInfo.entity);
     const dictionary = server.getEntityDictionary(this.characterId);
     if (!client || !dictionary) return;
-    
+
     server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
       dictionary,
       this.characterId,
@@ -308,7 +308,7 @@ export class LootableConstructionEntity extends BaseLootableEntity {
         expirationTime: Date.now() + 5000
       };
       server.sendHudIndicators(client);
-    }  
+    }
   }
 
   OnMeleeHit(server: ZoneServer2016, damageInfo: DamageInfo) {
@@ -318,7 +318,7 @@ export class LootableConstructionEntity extends BaseLootableEntity {
     ) {
       this.handleBeeboxSwarm(server, damageInfo);
     }
-     
+
     server.constructionManager.OnMeleeHit(server, damageInfo, this);
   }
 }

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -2527,41 +2527,23 @@ export class ConstructionManager {
     weaponItem: LoadoutItem
   ) {
     switch (entity.itemDefinitionId) {
-      case Items.FURNACE:
-      case Items.BARBEQUE:
-      case Items.STORAGE_BOX:
-      case Items.WEAPON_WRENCH:
-      case Items.FOUNDATION_STAIRS:
+      case Items.CAMPFIRE:
+      case Items.DEW_COLLECTOR:
+      case Items.BEE_BOX:
+      case Items.ANIMAL_TRAP:
         return;
     }
+    let worldFreeplaceMultiplier = 1;
+    const dictionary = server.getEntityDictionary(entity.characterId);
 
-    const permission = entity.getHasPermission(
-      server,
-      client.character.characterId,
-      ConstructionPermissionIds.DEMOLISH
-    );
-
-    if (!permission) {
-      this.placementError(
-        server,
-        client,
-        ConstructionErrors.DEMOLISH_PERMISSION
-      );
-      return;
+    if (dictionary == server._worldSimpleConstruction || server._worldLootableConstruction && !entity.parentObjectCharacterId) {
+      worldFreeplaceMultiplier = 2;
     }
 
-    if (entity.canUndoPlacement(server, client)) {
-      // give back item only if can undo
-      client.character.lootItem(
-        server,
-        server.generateItem(entity.itemDefinitionId)
-      );
-      entity.destroy(server);
-    }
-
+    // 8 melee hits for entities with parents, 4 for freeplace world entities
     entity.damage(server, {
-      entity: "Server.DemoHammer",
-      damage: entity.maxHealth / 3 + 10
+      entity: "",
+      damage: entity.maxHealth / (8 / worldFreeplaceMultiplier)
     });
     server.damageItem(client, weaponItem, 50);
   }

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -2536,7 +2536,10 @@ export class ConstructionManager {
     let worldFreeplaceMultiplier = 1;
     const dictionary = server.getEntityDictionary(entity.characterId);
 
-    if (dictionary == server._worldSimpleConstruction || server._worldLootableConstruction && !entity.parentObjectCharacterId) {
+    if (
+      dictionary == server._worldSimpleConstruction ||
+      (server._worldLootableConstruction && !entity.parentObjectCharacterId)
+    ) {
       worldFreeplaceMultiplier = 2;
     }
 

--- a/src/servers/ZoneServer2016/managers/decaymanager.ts
+++ b/src/servers/ZoneServer2016/managers/decaymanager.ts
@@ -164,7 +164,8 @@ export class DecayManager {
     entity:
       | LootableConstructionEntity
       | ConstructionDoor
-      | ConstructionChildEntity
+      | ConstructionChildEntity,
+    freeplaceDecayMultiplier: number = 1
   ) {
     if (entity.isDecayProtected) {
       entity.isDecayProtected = false;
@@ -173,7 +174,7 @@ export class DecayManager {
 
     entity.damage(server, {
       entity: "Server.DecayManager",
-      damage: entity.maxHealth / this.ticksToFullDecay
+      damage: entity.maxHealth / (this.ticksToFullDecay / freeplaceDecayMultiplier)
     });
   }
 
@@ -243,10 +244,10 @@ export class DecayManager {
     }
 
     for (const a in server._worldLootableConstruction) {
-      this.decayDamage(server, server._worldLootableConstruction[a]);
+      this.decayDamage(server, server._worldLootableConstruction[a], this.worldFreeplaceDecayMultiplier);
     }
     for (const a in server._worldSimpleConstruction) {
-      this.decayDamage(server, server._worldSimpleConstruction[a]);
+      this.decayDamage(server, server._worldSimpleConstruction[a], this.worldFreeplaceDecayMultiplier);
     }
     for (const a in server._constructionSimple) {
       const simple = server._constructionSimple[a];

--- a/src/servers/ZoneServer2016/managers/decaymanager.ts
+++ b/src/servers/ZoneServer2016/managers/decaymanager.ts
@@ -174,7 +174,8 @@ export class DecayManager {
 
     entity.damage(server, {
       entity: "Server.DecayManager",
-      damage: entity.maxHealth / (this.ticksToFullDecay / freeplaceDecayMultiplier)
+      damage:
+        entity.maxHealth / (this.ticksToFullDecay / freeplaceDecayMultiplier)
     });
   }
 
@@ -244,10 +245,18 @@ export class DecayManager {
     }
 
     for (const a in server._worldLootableConstruction) {
-      this.decayDamage(server, server._worldLootableConstruction[a], this.worldFreeplaceDecayMultiplier);
+      this.decayDamage(
+        server,
+        server._worldLootableConstruction[a],
+        this.worldFreeplaceDecayMultiplier
+      );
     }
     for (const a in server._worldSimpleConstruction) {
-      this.decayDamage(server, server._worldSimpleConstruction[a], this.worldFreeplaceDecayMultiplier);
+      this.decayDamage(
+        server,
+        server._worldSimpleConstruction[a],
+        this.worldFreeplaceDecayMultiplier
+      );
     }
     for (const a in server._constructionSimple) {
       const simple = server._constructionSimple[a];


### PR DESCRIPTION
https://www.youtube.com/watch?v=gCDJL4-oxnw (2:48)

So in 2016, wood planks had an additional chance to spawn inside wooden crates on top of the selected item (so 2 items). Currently on H1EMU, wood planks are apart of the loot tables so that was updated to be removed and into it's own area to generate on top of the base item from the crate. 

Also in #1665 and in H1Z1 2016, crowbars did significant damage to "metal objects" and were the primary way to remove freeplaced entities in the world. Currently I set it to 8 melee hits on objects with parents and 4 melee hits on objects without parents (so world placed essentially). I also added a 2x decay multiplier to world freeplaced entities so they'll decay in 7 ticks so ~7 days.

I moved the logic for bee box retaliation to its own function to provide some clarity for OnMeleeHit inside of LootableConstructionEntity.