### PR TITLE
Bugfix/EmptyBottleBeeBox

### DIFF
--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -268,6 +268,9 @@ export class SmeltingManager {
   ) {
     for (const a in container.items) {
       const item = container.items[a];
+      if (item.itemDefinitionId == Items.WATER_EMPTY 
+        && Object.keys(container.items).length == 1) 
+        continue;
       if (item.itemDefinitionId != Items.WATER_EMPTY) continue;
       if (subEntity.currentTicks >= subEntity.requiredTicks) {
         subEntity.currentTicks = 0;

--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -268,8 +268,10 @@ export class SmeltingManager {
   ) {
     for (const a in container.items) {
       const item = container.items[a];
-      if (item.itemDefinitionId == Items.WATER_EMPTY 
-        && Object.keys(container.items).length == 1) 
+      if (
+        item.itemDefinitionId == Items.WATER_EMPTY &&
+        Object.keys(container.items).length == 1
+      )
         continue;
       if (item.itemDefinitionId != Items.WATER_EMPTY) continue;
       if (subEntity.currentTicks >= subEntity.requiredTicks) {


### PR DESCRIPTION
Was reported by clever_reeeeee in the H1EMU discord. 

Empty water bottles were getting removed from containers despite having no honeycomb inside them at the time of removal, so this PR just adds a check for if the current item is an empty water bottle and if the container only contains that water bottle (container.items.length = 1) then continue out of the loop. 