### PR TITLE
Fix melee damage while respawning

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1047,7 +1047,8 @@ export class Character2016 extends BaseFullCharacter {
       oldHealth = this._resources[ResourceIds.HEALTH];
     if (!client) return;
 
-    if (this.isGodMode() || !this.isAlive || this.isRespawning || damage <= 25) return;
+    if (this.isGodMode() || !this.isAlive || this.isRespawning || damage <= 25)
+      return;
     if (damageInfo.causeBleed) {
       if (randomIntFromInterval(0, 100) < damage / 100 && damage > 500) {
         this._resources[ResourceIds.BLEEDING] += 41;

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1038,7 +1038,6 @@ export class Character2016 extends BaseFullCharacter {
   async damage(server: ZoneServer2016, damageInfo: DamageInfo) {
     if (
       server.isPvE &&
-      this.isRespawning &&
       damageInfo.hitReport?.characterId &&
       server._characters[damageInfo.hitReport?.characterId]
     )
@@ -1048,7 +1047,7 @@ export class Character2016 extends BaseFullCharacter {
       oldHealth = this._resources[ResourceIds.HEALTH];
     if (!client) return;
 
-    if (this.isGodMode() || !this.isAlive || damage <= 25) return;
+    if (this.isGodMode() || !this.isAlive || this.isRespawning || damage <= 25) return;
     if (damageInfo.causeBleed) {
       if (randomIntFromInterval(0, 100) < damage / 100 && damage > 500) {
         this._resources[ResourceIds.BLEEDING] += 41;

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1038,6 +1038,7 @@ export class Character2016 extends BaseFullCharacter {
   async damage(server: ZoneServer2016, damageInfo: DamageInfo) {
     if (
       server.isPvE &&
+      this.isRespawning &&
       damageInfo.hitReport?.characterId &&
       server._characters[damageInfo.hitReport?.characterId]
     )
@@ -1618,7 +1619,7 @@ export class Character2016 extends BaseFullCharacter {
   }
 
   OnMeleeHit(server: ZoneServer2016, damageInfo: DamageInfo) {
-    if (server.isPvE) return;
+    if (server.isPvE || this.isRespawning) return;
     let damage = damageInfo.damage / 2;
     let bleedingChance = 5;
     switch (damageInfo.meleeType) {


### PR DESCRIPTION
Someone did this to me on wipe, super cringe stuff (sadly AMD didn't clip it, I wish it did). Essentially while a player is respawning, you can melee their corpse and when the player respawns, they will be low hp or nearly dead.. So this PR fixes that by adding checks to the OnMeleeHit and Damage functions in the character class to see if a player is currently respawning