### PR TITLE
Give proper transientId to destroyables

### DIFF
--- a/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
+++ b/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
@@ -721,7 +721,7 @@ export class WorldObjectManager {
         const characterId = generateRandomGuid();
         const obj = new Crate(
           characterId,
-          1, // need transient generated for Interaction Replication
+          server.getTransientId(characterId), // need transient generated for Interaction Replication
           getActorModelId(propType.actorDefinition),
           new Float32Array(propInstance.position),
           new Float32Array([
@@ -743,7 +743,7 @@ export class WorldObjectManager {
         const characterId = generateRandomGuid();
         const obj = new Destroyable(
           characterId,
-          1, // need transient generated for Interaction Replication
+          server.getTransientId(characterId), // need transient generated for Interaction Replication
           propInstance.modelId,
           new Float32Array(propInstance.position),
           new Float32Array([


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the `WorldObjectManager` class in the `ZoneServer2016` server to generate a transient ID for interaction replication when creating `Crate` and `Destroyable` objects.
> 
> ## What changed
> The `WorldObjectManager` class was previously using a hardcoded value of `1` for the transient ID when creating `Crate` and `Destroyable` objects. This pull request changes this to use the `getTransientId` method of the `server` object, passing in the `characterId` as an argument.
> 
> ## How to test
> To test this change, you can create `Crate` and `Destroyable` objects in the `ZoneServer2016` server and check that the transient ID is correctly generated and used for interaction replication.
> 
> ## Why make this change
> This change is necessary to ensure that each `Crate` and `Destroyable` object has a unique transient ID for interaction replication. This will prevent potential issues with interaction replication that could occur if multiple objects have the same transient ID.
</details>