### PR TITLE
Use process.uptime

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -131,7 +131,7 @@ export const commands: Array<Command> = [
         } = server;
         const serverVersion = require("../../../../../package.json").version;
         server.sendChatText(client, `h1z1-server V${serverVersion}`, true);
-        const uptimeMin = getCurrentServerTimeWrapper().getMinutes();
+        const uptimeMin = process.uptime() / 60;
 
         server.sendChatText(
           client,


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request modifies the way server uptime is calculated in the `commands.ts` file of the `ZoneServer2016` module. Instead of using a custom function, it now uses Node.js's built-in `process.uptime()` function.
> 
> ## What changed
> The line of code that calculates the server's uptime in minutes was changed. Previously, it was using a function called `getCurrentServerTimeWrapper().getMinutes()`. Now, it uses `process.uptime() / 60`.
> 
> ```diff
> - const uptimeMin = getCurrentServerTimeWrapper().getMinutes();
> + const uptimeMin = process.uptime() / 60;
> ```
> 
> ## How to test
> To test this change, you can run the server and use the command that displays the server's uptime. You should see the uptime displayed in minutes. You can also check the server logs to see if the uptime is being calculated correctly.
> 
> ## Why make this change
> The `process.uptime()` function in Node.js returns the number of seconds that the current Node.js process has been running. This is a more accurate and reliable way to calculate the server's uptime than the previous method. It also simplifies the code by removing the need for a custom function.
</details>