### PR TITLE
Recipe system rework

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -384,7 +384,6 @@ export class Character2016 extends BaseFullCharacter {
   }
 
   pGetRecipes(server: ZoneServer2016): any[] {
-    // todo: change to per-character recipe lists
     const recipeKeys = Object.keys(this.recipes);
 
     const recipes: Array<any> = [];

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -36,6 +36,7 @@ import {
   DamageRecord,
   HealType,
   positionUpdate,
+  Recipe,
   StanceFlags
 } from "../../../types/zoneserver";
 import {
@@ -68,6 +69,7 @@ import {
   EXTERNAL_CONTAINER_GUID,
   LOADOUT_CONTAINER_ID
 } from "../../../utils/constants";
+import { recipes } from "../data/Recipes";
 const stats = require("../../../../data/2016/sampleData/stats.json");
 
 interface CharacterStates {
@@ -284,6 +286,11 @@ export class Character2016 extends BaseFullCharacter {
     characterId: ""
   };
   lastRepairTime: number = 0;
+  /** HashMap of all recipes on a server
+   * uses recipeId (number) for indexing
+   */
+  recipes: { [recipeId: number]: Recipe } = recipes;
+
   constructor(
     characterId: string,
     transientId: number,
@@ -374,6 +381,51 @@ export class Character2016 extends BaseFullCharacter {
       }, 1000);
     };
     this.materialType = MaterialTypes.FLESH;
+  }
+
+  pGetRecipes(server: ZoneServer2016): any[] {
+    // todo: change to per-character recipe lists
+    const recipeKeys = Object.keys(this.recipes);
+
+    const recipes: Array<any> = [];
+    let i = 0;
+    for (const recipe of Object.values(this.recipes)) {
+      const recipeDef = server.getItemDefinition(Number(recipeKeys[i]));
+      i++;
+      if (!recipeDef) continue;
+      recipes.push({
+        recipeId: recipeDef.ID,
+        itemDefinitionId: recipeDef.ID,
+        nameId: recipeDef.NAME_ID,
+        iconId: recipeDef.IMAGE_SET_ID,
+        unknownDword1: 0, // idk
+        descriptionId: recipeDef.DESCRIPTION_ID,
+        unknownDword2: 1, // idk
+        bundleCount: recipe.bundleCount || 1,
+        membersOnly: false, // could be used for admin-only recipes?
+        filterId: recipe.filterId,
+        components: recipe.components
+          .map((component: any) => {
+            const componentDef = server.getItemDefinition(
+              component.itemDefinitionId
+            );
+            if (!componentDef) return true;
+            return {
+              unknownDword1: 0, // idk
+              nameId: componentDef.NAME_ID,
+              iconId: componentDef.IMAGE_SET_ID,
+              unknownDword2: 0, // idk
+              requiredAmount: component.requiredAmount,
+              unknownQword1: "0x0", // idk
+              unknownDword3: 0, // idk
+              itemDefinitionId: componentDef.ID
+            };
+          })
+          .filter((component) => component !== true)
+      });
+    }
+
+    return recipes;
   }
 
   startResourceUpdater(client: ZoneClient2016, server: ZoneServer2016) {
@@ -907,7 +959,7 @@ export class Character2016 extends BaseFullCharacter {
           items: this.pGetInventoryItems(server)
           //unknownDword1: 2355
         },
-        recipes: server.pGetRecipes(), // todo: change to per-character recipe lists
+        recipes: this.pGetRecipes(server),
         stats: this.getStats(),
         loadoutSlots: this.pGetLoadoutSlots(),
         equipmentSlots: this.pGetEquipment() as any,

--- a/src/servers/ZoneServer2016/managers/craftmanager.ts
+++ b/src/servers/ZoneServer2016/managers/craftmanager.ts
@@ -170,7 +170,8 @@ export class CraftManager {
       const remainingItems = component.requiredAmount * recipeCount;
       // if component isn't found at all
       if (!this.componentsDataSource[component.itemDefinitionId]) {
-        const componentRecipe = server._recipes[component.itemDefinitionId],
+        const componentRecipe =
+            client.character.recipes[component.itemDefinitionId],
           componentBundleCount = componentRecipe?.bundleCount || 1;
         if (!componentRecipe) {
           debug(
@@ -212,7 +213,8 @@ export class CraftManager {
         this.componentsDataSource[component.itemDefinitionId].stackCount <
         remainingItems
       ) {
-        const componentRecipe = server._recipes[component.itemDefinitionId],
+        const componentRecipe =
+            client.character.recipes[component.itemDefinitionId],
           componentBundleCount = componentRecipe?.bundleCount || 1;
         if (!componentRecipe) {
           debug(
@@ -356,7 +358,7 @@ export class CraftManager {
     if (this.craftLoopCount > this.maxCraftLoopCount) {
       return false;
     }
-    const recipe = server._recipes[recipeId],
+    const recipe = client.character.recipes[recipeId],
       bundleCount = recipe?.bundleCount || 1, // the amount of an item crafted from 1 recipe (ex. crafting 1 stick recipe gives you 2)
       craftCount = recipeCount * bundleCount; // the actual amount of items to craft
     if (!recipe) return false;
@@ -434,7 +436,7 @@ export class CraftManager {
       1000 * recipeCount,
       0
     );
-    const r = server._recipes[recipeId];
+    const r = client.character.recipes[recipeId];
     for (const component of r.components) {
       const inventory = this.getInventoryDataSource(client.character);
       let remainingItems = component.requiredAmount * recipeCount,

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -64,7 +64,6 @@ import {
   ItemDefinition,
   modelData,
   PropInstance,
-  Recipe,
   ScreenEffect,
   UseOption
 } from "../../types/zoneserver";
@@ -131,7 +130,6 @@ import {
   FetchedWorldData,
   WorldDataManager
 } from "./managers/worlddatamanager";
-import { recipes } from "./data/Recipes";
 import { UseOptions } from "./data/useoptions";
 import {
   CONNECTION_REJECTION_FLAGS,
@@ -393,10 +391,6 @@ export class ZoneServer2016 extends EventEmitter {
   profileDefinitionsCache?: Buffer;
   _containerDefinitions: { [containerDefinitionId: number]: any } =
     containerDefinitions;
-  /** HashMap of all recipes on a server - To be moved to players soon,
-   * uses recipeId (number) for indexing
-   */
-  _recipes: { [recipeId: number]: Recipe } = recipes;
   lastItemGuid: bigint = 0x3000000000000000n;
   private readonly _transientIdGenerator = generateTransientId();
   enableWorldSaves: boolean;
@@ -1205,51 +1199,6 @@ export class ZoneServer2016 extends EventEmitter {
     }
 
     return proximityItems;
-  }
-
-  pGetRecipes(): any[] {
-    // todo: change to per-character recipe lists
-    const recipeKeys = Object.keys(this._recipes);
-
-    const recipes: Array<any> = [];
-    let i = 0;
-    for (const recipe of Object.values(this._recipes)) {
-      const recipeDef = this.getItemDefinition(Number(recipeKeys[i]));
-      i++;
-      if (!recipeDef) continue;
-      recipes.push({
-        recipeId: recipeDef.ID,
-        itemDefinitionId: recipeDef.ID,
-        nameId: recipeDef.NAME_ID,
-        iconId: recipeDef.IMAGE_SET_ID,
-        unknownDword1: 0, // idk
-        descriptionId: recipeDef.DESCRIPTION_ID,
-        unknownDword2: 1, // idk
-        bundleCount: recipe.bundleCount || 1,
-        membersOnly: false, // could be used for admin-only recipes?
-        filterId: recipe.filterId,
-        components: recipe.components
-          .map((component: any) => {
-            const componentDef = this.getItemDefinition(
-              component.itemDefinitionId
-            );
-            if (!componentDef) return true;
-            return {
-              unknownDword1: 0, // idk
-              nameId: componentDef.NAME_ID,
-              iconId: componentDef.IMAGE_SET_ID,
-              unknownDword2: 0, // idk
-              requiredAmount: component.requiredAmount,
-              unknownQword1: "0x0", // idk
-              unknownDword3: 0, // idk
-              itemDefinitionId: componentDef.ID
-            };
-          })
-          .filter((component) => component !== true)
-      });
-    }
-
-    return recipes;
   }
 
   async sendCharacterData(client: Client) {


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ### TL;DR
> This pull request updates the `Character2016` class to include a `recipes` property and a `pGetRecipes` method, moves recipe handling from `ZoneServer2016` to `Character2016`, and updates `CraftManager` to use character recipes instead of server recipes.
> 
> ### What changed
> - Added a `recipes` property to the `Character2016` class to store all recipes on a server.
> - Implemented a `pGetRecipes` method in the `Character2016` class to retrieve recipes based on the server.
> - Updated `CraftManager` to use character recipes (`client.character.recipes`) instead of server recipes (`server._recipes`).
> 
> ### How to test
> 1. Ensure the `Character2016` class now includes a `recipes` property.
> 2. Verify that the `pGetRecipes` method in the `Character2016` class correctly retrieves recipes.
> 3. Test the `CraftManager` functionality to confirm it now uses character recipes.
> 
> ### Why make this change
> - By moving recipe handling from the server to the character level, the code becomes more modular and follows better separation of concerns.
> - Storing recipes at the character level allows for more flexibility and customization, especially in scenarios where different characters may have access to different recipes.
> - This change improves code organization and maintainability by centralizing recipe management within the `Character2016` class.
</details>