### PR TITLE
o number of dto to serverinfO

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -127,7 +127,8 @@ export const commands: Array<Command> = [
           _clients: clients,
           _npcs: npcs,
           _spawnedItems: objects,
-          _vehicles: vehicles
+          _vehicles: vehicles,
+          _destroyables: dto
         } = server;
         const serverVersion = require("../../../../../package.json").version;
         server.sendChatText(client, `h1z1-server V${serverVersion}`, true);
@@ -149,6 +150,7 @@ export const commands: Array<Command> = [
           client,
           `items : ${_.size(objects)} | vehicles : ${_.size(vehicles)}`
         );
+        server.sendChatText(client, `dto: ${_.size(dto)}`);
       }
     }
   },


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds a new feature to the server command handler that allows it to count and display the number of destroyable objects in the game.
> 
> ## What changed
> A new line of code was added to the server command handler in the `commands.ts` file. This line of code counts the number of destroyable objects (dto) and sends this information as a chat text to the client.
> 
> ## How to test
> To test this change, you can use the server command handler to request the number of destroyable objects. The server should respond with a chat text displaying the number of these objects.
> 
> ## Why make this change
> This change was made to provide more information to the client about the game state. By knowing the number of destroyable objects, the client can make more informed decisions about their gameplay strategy.
</details>