### PR TITLE
Disable the destruction of glitched wood fences

### DIFF
--- a/src/servers/ZoneServer2016/entities/destroyable.ts
+++ b/src/servers/ZoneServer2016/entities/destroyable.ts
@@ -17,6 +17,7 @@ import { eul2quat } from "../../../utils/utils";
 import { Effects, ModelIds } from "../models/enums";
 import { AddLightweightNpc, AddSimpleNpc } from "types/zone2016packets";
 import { BaseSimpleNpc } from "./basesimplenpc";
+import { MAX_UINT32 } from "../../../utils/constants";
 
 function getDestroyedModels(actorModelId: ModelIds): number[] {
   switch (actorModelId) {
@@ -47,7 +48,8 @@ function getMaxHealth(actorModelId: ModelIds): number {
     case ModelIds.FENCES_WOOD_PLANKS_GREY_1X1:
     case ModelIds.FENCES_WOOD_PLANKS_GREY_POSTS_1X2:
     case ModelIds.FENCES_WOOD_PLANKS_GREY_GAP_1X1:
-      return 7500;
+      // temp hack so it can't be destroyed ( or you really wanted to )
+      return MAX_UINT32;
     default:
       return 5000;
   }


### PR DESCRIPTION


---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a temporary hack to prevent certain models from being destroyed by setting their maximum health to the maximum value of a 32-bit unsigned integer.
> 
> ## What changed
> The maximum health for the following models: `FENCES_WOOD_PLANKS_GREY_1X1`, `FENCES_WOOD_PLANKS_GREY_POSTS_1X2`, and `FENCES_WOOD_PLANKS_GREY_GAP_1X1` has been changed from `7500` to `MAX_UINT32` (the maximum value of a 32-bit unsigned integer). This change effectively makes these models indestructible, unless you really want to destroy them.
> 
> ## How to test
> To test this change, you can try to destroy the aforementioned models in the game. You should find that they are now indestructible.
> 
> ## Why make this change
> This change was made as a temporary solution to prevent these models from being destroyed. This could be useful in scenarios where these models are used as part of the game's infrastructure and should not be destructible by players.
</details>