### PR TITLE
Add some type safety to commandHandler

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commandhandler.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commandhandler.ts
@@ -19,6 +19,8 @@ import { commands } from "./commands";
 import { internalCommands } from "./internalcommands";
 import { DB_COLLECTIONS } from "../../../../utils/enums";
 import { Collection } from "mongodb";
+import { CommandExecuteCommand } from "types/zone2016packets";
+import { ReceivedPacket } from "types/shared";
 
 export class CommandHandler {
   readonly commands: { [hash: number]: Command } = {};
@@ -51,7 +53,11 @@ export class CommandHandler {
     });
   }
 
-  executeCommand(server: ZoneServer2016, client: Client, packet: any) {
+  executeCommand(
+    server: ZoneServer2016,
+    client: Client,
+    packet: ReceivedPacket<CommandExecuteCommand>
+  ) {
     if (
       !server.hookManager.checkHook(
         "OnClientExecuteCommand",
@@ -63,11 +69,17 @@ export class CommandHandler {
       return;
     }
     const hash = packet.data.commandHash;
-    if (this.commands[hash]) {
-      const command = this.commands[hash],
-        args: string[] = command.keepCase
+    if (hash && this.commands[hash]) {
+      const command = this.commands[hash];
+      let args: string[];
+      if (packet.data.arguments) {
+        args = command.keepCase
           ? packet.data.arguments.split(" ")
           : packet.data.arguments.toLowerCase().split(" ");
+      } else {
+        args = [];
+      }
+
       if (!this.clientHasCommandPermission(server, client, command)) {
         server.sendChatText(client, "You don't have access to that.");
         return;


### PR DESCRIPTION


---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the `executeCommand` method in the `CommandHandler` class. It improves the handling of command arguments and adds type checking for the packet parameter.
> 
> ## What changed
> The `executeCommand` method now checks if the `hash` and `arguments` properties exist in the `packet.data` object before proceeding. This prevents potential runtime errors when these properties are undefined. 
> 
> The `packet` parameter's type has been changed to `ReceivedPacket<CommandExecuteCommand>`, providing better type safety.
> 
> The `args` variable is now declared with `let` and is assigned an empty array if `packet.data.arguments` is undefined. This ensures `args` is always an array, simplifying the code that follows.
> 
> ## How to test
> To test these changes, you can use the following steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Run your test suite to ensure no existing functionality is broken.
> 3. Manually test the `executeCommand` method with various inputs, including packets with undefined `hash` or `arguments` properties.
> 
> ## Why make this change
> These changes improve the robustness and readability of the `executeCommand` method. By checking for undefined properties and ensuring `args` is always an array, we prevent potential runtime errors. The added type checking for the `packet` parameter improves type safety, making the code easier to understand and less prone to bugs.
</details>