### PR TITLE
Move commandHandler to zoneserver

### DIFF
--- a/src/servers/ZoneServer2016/managers/pluginmanager.ts
+++ b/src/servers/ZoneServer2016/managers/pluginmanager.ts
@@ -400,9 +400,8 @@ export class PluginManager {
     server: ZoneServer2016,
     command: Command
   ) {
-    server._packetHandlers.commandHandler.commands[
-      flhash(command.name.toUpperCase())
-    ] = command;
+    server.commandHandler.commands[flhash(command.name.toUpperCase())] =
+      command;
     console.log(
       `[PluginManager] Plugin ${plugin.name} registered a command: /${command.name}`
     );

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -189,10 +189,7 @@ function getStanceFlags(num: number): StanceFlags {
 //const abilities = require("../../../data/2016/sampleData/abilities.json");
 
 export class ZonePacketHandlers {
-  commandHandler: CommandHandler;
-  constructor() {
-    this.commandHandler = new CommandHandler();
-  }
+  constructor() {}
 
   ClientIsReady(
     server: ZoneServer2016,
@@ -358,7 +355,7 @@ export class ZonePacketHandlers {
           command: "help"
         }
       );
-      Object.values(this.commandHandler.commands).forEach((command) => {
+      Object.values(server.commandHandler.commands).forEach((command) => {
         server.sendData<CommandAddWorldCommand>(
           client,
           "Command.AddWorldCommand",
@@ -414,7 +411,7 @@ export class ZonePacketHandlers {
     client: Client,
     packet: ReceivedPacket<CommandSpawnVehicle>
   ) {
-    this.commandHandler.executeInternalCommand(
+    server.commandHandler.executeInternalCommand(
       server,
       client,
       "vehicle",
@@ -857,14 +854,14 @@ export class ZonePacketHandlers {
     packet: ReceivedPacket<CommandExecuteCommand>
   ) {
     const hash = packet.data.commandHash ?? 0;
-    if (this.commandHandler.commands[hash]) {
-      const command = this.commandHandler.commands[hash];
+    if (server.commandHandler.commands[hash]) {
+      const command = server.commandHandler.commands[hash];
       if (command?.name == "!!h1custom!!") {
         this.handleCustomPacket(server, client, packet.data.arguments ?? "");
         return;
       }
     }
-    this.commandHandler.executeCommand(server, client, packet);
+    server.commandHandler.executeCommand(server, client, packet);
   }
   CommandInteractRequest(
     server: ZoneServer2016,
@@ -1518,7 +1515,7 @@ export class ZonePacketHandlers {
     client: Client,
     packet: ReceivedPacket<CharacterRespawn>
   ) {
-    this.commandHandler.executeInternalCommand(
+    server.commandHandler.executeInternalCommand(
       server,
       client,
       "respawn",
@@ -2991,14 +2988,14 @@ export class ZonePacketHandlers {
     client: Client,
     packet: ReceivedPacket<CommandRunSpeed>
   ) {
-    this.commandHandler.executeInternalCommand(server, client, "run", packet);
+    server.commandHandler.executeInternalCommand(server, client, "run", packet);
   }
   CommandSpectate(
     server: ZoneServer2016,
     client: Client,
     packet: ReceivedPacket<object>
   ) {
-    this.commandHandler.executeInternalCommand(
+    server.commandHandler.executeInternalCommand(
       server,
       client,
       "spectate",
@@ -3437,14 +3434,5 @@ export class ZonePacketHandlers {
         );
         break;
     }
-  }
-
-  async reloadCommandCache() {
-    delete require.cache[require.resolve("./handlers/commands/commandhandler")];
-    const CommandHandler = (
-      require("./handlers/commands/commandhandler") as any
-    ).CommandHandler;
-    this.commandHandler = new CommandHandler();
-    this.commandHandler.reloadCommands();
   }
 }


### PR DESCRIPTION


---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request updates the `PluginManager` and `ZonePacketHandlers` classes in the `ZoneServer2016` project to use the `server.commandHandler` instead of `this.commandHandler`.
> 
> ## What changed
> - Updated the `PluginManager` class to use `server.commandHandler` instead of `this.commandHandler`.
> - Updated the `ZonePacketHandlers` class to use `server.commandHandler` instead of `this.commandHandler`.
> - Added a new import statement for `CommandHandler` in `zoneserver.ts`.
> - Added a new method `reloadCommandCache` in `ZoneServer2016` to reload the command cache.
> 
> ## How to test
> 1. Pull the changes from this branch.
> 2. Run the application.
> 3. Test the functionality related to commands and plugins.
> 4. Verify that the commands and plugins are registered and executed correctly.
> 
> ## Why make this change
> - The change was made to ensure consistency and improve code readability by using `server.commandHandler` consistently across classes in the `ZoneServer2016` project.
> - The addition of the `reloadCommandCache` method allows for reloading the command cache, which can be useful for updating commands dynamically without restarting the server.
</details>