### PR TITLE
Fix an issue while reloading commands

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commandhandler.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commandhandler.ts
@@ -153,9 +153,9 @@ export class CommandHandler {
 
   reloadCommands() {
     delete require.cache[require.resolve("./commands")];
-    delete require.cache[require.resolve("./internalCommands")];
+    delete require.cache[require.resolve("./internalcommands")];
     const commands = require("./commands").commands,
-      internalCommands = require("./internalCommands").internalCommands;
+      internalCommands = require("./internalcommands").internalCommands;
     this.indexCommands(commands, internalCommands);
   }
 }


### PR DESCRIPTION


---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request fixes a case sensitivity issue in the `commandhandler.ts` file. The file name `internalCommands` has been changed to `internalcommands` to match the actual file name.
> 
> ## What changed
> In the `commandhandler.ts` file, the `require.resolve` method was previously trying to resolve `./internalCommands`, which does not exist. This has been corrected to `./internalcommands`.
> 
> ## How to test
> To test this change, you can try to run the `reloadCommands` function in the `CommandHandler` class. If the function runs without any errors, it means that the `require.resolve` method is now correctly resolving the `internalcommands` file.
> 
> ## Why make this change
> This change is necessary because the `require.resolve` method is case-sensitive. If the file name does not match exactly, it will not be able to resolve the file and will throw an error. This change ensures that the `require.resolve` method can correctly resolve the `internalcommands` file, preventing any potential errors.
</details>