### PR TITLE
Lootspawns 2.1

### DIFF
--- a/src/servers/ZoneServer2016/data/lootspawns.ts
+++ b/src/servers/ZoneServer2016/data/lootspawns.ts
@@ -220,7 +220,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
     ]
   },
   "ItemSpawner_Weapon_Bat01.adr": {
-    spawnChance: 20,
+    spawnChance: 10,
     items: [
       {
         item: Items.WEAPON_BAT_WOOD,
@@ -311,7 +311,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
     ]
   },
   "ItemSpawner_Weapon_Bat02.adr": {
-    spawnChance: 20,
+    spawnChance: 10,
     items: [
       {
         item: Items.WEAPON_BAT_ALUM,
@@ -474,6 +474,19 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
     items: [
       {
         item: Items.HELMET_MOTORCYCLE,
+        weight: 100,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      }
+    ]
+  },
+  "ItemSpawner_Clothes_Helmet_Tactical_ChipsScratches.adr": {
+    spawnChance: 10,
+    items: [
+      {
+        item: Items.DEFAULT_TACTICAL_HELMET,
         weight: 100,
         spawnCount: {
           min: 1,
@@ -672,7 +685,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
         }
       },
       {
-        item: Items.WATER_PURE,
+        item: Items.WATER_DIRTY,
         weight: 15,
         spawnCount: {
           min: 1,
@@ -769,7 +782,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
       },
       {
         item: Items.WEAPON_BAT_WOOD,
-        weight: 15,
+        weight: 10,
         spawnCount: {
           min: 1,
           max: 1
@@ -777,7 +790,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
       },
       {
         item: Items.WEAPON_BAT_ALUM,
-        weight: 15,
+        weight: 10,
         spawnCount: {
           min: 1,
           max: 1
@@ -1057,7 +1070,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
         }
       },
       {
-        item: Items.WATER_PURE,
+        item: Items.WATER_DIRTY,
         weight: 10,
         spawnCount: {
           min: 1,
@@ -1194,6 +1207,30 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
       },
       {
         item: Items.EMERGENCY_RADIO,
+        weight: 7,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.GROUND_COFFEE,
+        weight: 15,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.SUGAR,
+        weight: 10,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.CANNED_FOOD26,
         weight: 7,
         spawnCount: {
           min: 1,
@@ -2072,16 +2109,24 @@ export const containerLootSpawners: {
           min: 2,
           max: 10
         }
+      },
+      {
+        item: Items.AMMO_12GA,
+        weight: 20,
+        spawnCount: {
+          min: 1,
+          max: 6
+        }
       }
     ]
   },
   Locker: {
-    spawnChance: 100,
+    spawnChance: 60,
     maxItems: 1,
     items: [
       {
         item: Items.BACKPACK_MILITARY_TAN,
-        weight: 35,
+        weight: 25,
         spawnCount: {
           min: 1,
           max: 1
@@ -2097,7 +2142,15 @@ export const containerLootSpawners: {
       },
       {
         item: Items.KEVLAR_DEFAULT,
-        weight: 35,
+        weight: 25,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.DEFAULT_TACTICAL_HELMET,
+        weight: 25,
         spawnCount: {
           min: 1,
           max: 1
@@ -3427,6 +3480,82 @@ export const containerLootSpawners: {
       }
     ]
   },
+  Washer: {
+    spawnChance: 10,
+    maxItems: 2,
+    items: [
+      {
+        item: Items.SHIRT_DEFAULT,
+        weight: 30,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.PANTS_DEFAULT,
+        weight: 20,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.BASIC_HOODIE,
+        weight: 10,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.CLOTH,
+        weight: 5,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      }
+    ]
+  },
+  Dryer: {
+    spawnChance: 10,
+    maxItems: 2,
+    items: [
+      {
+        item: Items.SHIRT_DEFAULT,
+        weight: 30,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.PANTS_DEFAULT,
+        weight: 20,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.BASIC_HOODIE,
+        weight: 10,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      },
+      {
+        item: Items.CLOTH,
+        weight: 5,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
+      }
+    ]
+  },
   // used for crate props
   Crate_buffed: {
     spawnChance: 60,
@@ -3457,7 +3586,7 @@ export const containerLootSpawners: {
         }
       },
       {
-        item: Items.WATER_PURE,
+        item: Items.WATER_DIRTY,
         weight: 10,
         spawnCount: {
           min: 1,
@@ -3479,7 +3608,7 @@ export const containerLootSpawners: {
         }
       },
       {
-        item: Items.WATER_PURE,
+        item: Items.WATER_DIRTY,
         weight: 10,
         spawnCount: {
           min: 1,

--- a/src/servers/ZoneServer2016/entities/lootableprop.ts
+++ b/src/servers/ZoneServer2016/entities/lootableprop.ts
@@ -118,6 +118,16 @@ function getContainerAndTime(entity: LootableProp) {
       entity.searchTime = 500;
       entity.lootSpawner = "Fridge";
       break;
+    case ModelIds.WASHER:
+      entity.containerId = Items.CONTAINER_WASHING_MACHINE;
+      entity.searchTime = 500;
+      entity.lootSpawner = "Washer";
+      break;
+    case ModelIds.DRYER:
+      entity.containerId = Items.CONTAINER_DRYER;
+      entity.searchTime = 500;
+      entity.lootSpawner = "Dryer";
+      break;
     case ModelIds.OTTOMAN_01:
     case ModelIds.OTTOMAN_02:
       entity.containerId = Items.CONTAINER_OTTOMAN;
@@ -180,16 +190,6 @@ function getContainerAndTime(entity: LootableProp) {
       entity.containerId = Items.CONTAINER_STORAGE;
       entity.searchTime = 500;
       entity.lootSpawner = "Dresser";
-      break;
-    case ModelIds.WASHER:
-      entity.containerId = Items.CONTAINER_WASHING_MACHINE;
-      entity.searchTime = 500;
-      entity.lootSpawner = "Washer_Dryer";
-      break;
-    case ModelIds.DRYER:
-      entity.containerId = Items.CONTAINER_DRYER;
-      entity.searchTime = 500;
-      entity.lootSpawner = "Washer_Dryer";
       break;
     case ModelIds.FURNACE:
       entity.containerId = Items.CONTAINER_FURNACE;


### PR DESCRIPTION
Further reduced bats in residential spawns.
Add surgar, coffee & Deebs Nuts n more in store spawns.
Replaced all Purified water spawns with dirty water.
Added chance to spawn default Tactical Helmets to lockers
Added chance to spawn Shotgun ammo in Weapons locker.
Slightly reduced and evened out backpack and kevlar spawns.
Fixed washer & dryer loot spawns. (Clothing)