### PR TITLE
Display reward notification after case unboxing

### DIFF
--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -447,9 +447,12 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
   async lootAccountItem(
     server: ZoneServer2016,
     client: ZoneClient2016,
-    item: BaseItem,
+    item?: BaseItem,
     sendUpdate: boolean = false
   ) {
+    if (!item) {
+      return;
+    }
     await server.accountInventoriesManager.addAccountItem(
       client.loginSessionId,
       item

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -3290,12 +3290,14 @@ export class ZonePacketHandlers {
         });
 
         if (reward > 0 && itemSubData.unknownBoolean1 == 0)
-          client.character.lootItem(
-            server,
-            server.generateAccountItem(reward),
-            1,
-            false
-          );
+          setTimeout(() => {
+            client.character.lootAccountItem(
+              server,
+              client,
+              server.generateAccountItem(reward),
+              true
+            );
+          }, 12_000);
         break;
       case ItemUseOptions.APPLY_SKIN:
         const oitem = client.character.getInventoryItem(
@@ -3390,8 +3392,9 @@ export class ZonePacketHandlers {
           0,
           () => {
             if (!server.removeInventoryItem(client.character, item)) return;
-            client.character.lootItem(
+            client.character.lootAccountItem(
               server,
+              client,
               server.generateAccountItem(bagReward)
             );
           }


### PR DESCRIPTION

### TL;DR

Refactored `lootAccountItem` method to handle optional items and updated zone packet handlers to use this method with timeout adjustments.

### What changed?

- Modified `lootAccountItem` method in `BaseFullCharacter` to handle optional `item` parameter and return early if the item is not provided.
- Updated `zonepackethandlers.ts` to replace `lootItem` with `lootAccountItem` and introduced a 12-second timeout before calling the method.

### How to test?

1. Run the server and ensure that the changes do not introduce any runtime errors.
2. Test looting functionality in various scenarios to ensure the method handles optional items correctly.
2. Verify timeout handling in the looting process.

### Why make this change?

This change was made to improve the robustness of the looting functionality by ensuring that it can handle cases where no item is provided. The timeout adjustment ensures that the looting process is appropriately delayed.

---

