### PR TITLE
Add playtime manager

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -102,6 +102,7 @@ export class Character2016 extends BaseFullCharacter {
   resourcesUpdater?: any;
   factionId = 2;
   isInInventory: boolean = false;
+  playTime: number = 0;
   set godMode(state: boolean) {
     this.characterStates.invincibility = state;
   }

--- a/src/servers/ZoneServer2016/managers/playtimemanager.test.ts
+++ b/src/servers/ZoneServer2016/managers/playtimemanager.test.ts
@@ -1,0 +1,73 @@
+// ======================================================================
+//
+//   GNU GENERAL PUBLIC LICENSE
+//   Version 3, 29 June 2007
+//   copyright (C) 2020 - 2021 Quentin Gruber
+//   copyright (C) 2021 - 2024 H1emu community
+//
+//   https://github.com/QuentinGruber/h1z1-server
+//   https://www.npmjs.com/package/h1z1-server
+//
+//   Based on https://github.com/psemu/soe-network
+// ======================================================================
+
+import test, { after } from "node:test";
+import { ZoneServer2016 } from "../zoneserver";
+import {
+  createFakeCharacter,
+  createFakeZoneClient
+} from "../../../utils/test.utils";
+import assert from "node:assert";
+
+process.env.FORCE_DISABLE_WS = "true";
+const isMongoTests = process.env.MONGO_TESTS === "true";
+test("PlayTimeManager", { timeout: 10000 }, async (t) => {
+  t.mock.timers.enable({ apis: ["setInterval"] });
+  const zone = new ZoneServer2016(0);
+  await zone.start();
+  const char = createFakeCharacter(zone);
+  await t.test("PlayTime incrementation", () => {
+    for (let i = 1; i <= 60; i++) {
+      t.mock.timers.tick(60_000);
+
+      assert.strictEqual(char.playTime, i, "Playtime doesn't update well!");
+    }
+  });
+});
+test(
+  "PlayTimeManager-mongo",
+  { timeout: 10000, skip: !isMongoTests },
+  async (t) => {
+    t.mock.timers.enable({ apis: ["setInterval"] });
+    const zone = new ZoneServer2016(
+      0,
+      Buffer.from("fake"),
+      "mongodb://localhost:27017"
+    );
+    await zone.start();
+    const char = createFakeCharacter(zone);
+    const client = createFakeZoneClient(zone, char);
+    await t.test("PlayTime incrementation", () => {
+      for (let i = 1; i <= 60; i++) {
+        t.mock.timers.tick(60_000);
+
+        assert.strictEqual(char.playTime, i, "Playtime doesn't update well!");
+      }
+    });
+    await t.test("PlayTimeSave", async () => {
+      await zone.saveWorld();
+      await zone.fetchCharacterData(client);
+      assert.strictEqual(
+        client.character.playTime,
+        char.playTime,
+        "Playtime doesn't save well!"
+      );
+    });
+  }
+);
+
+after(() => {
+  setImmediate(() => {
+    process.exit(0);
+  });
+});

--- a/src/servers/ZoneServer2016/managers/playtimemanager.ts
+++ b/src/servers/ZoneServer2016/managers/playtimemanager.ts
@@ -1,0 +1,42 @@
+// ======================================================================
+//
+//   GNU GENERAL PUBLIC LICENSE
+//   Version 3, 29 June 2007
+//   copyright (C) 2020 - 2021 Quentin Gruber
+//   copyright (C) 2021 - 2024 H1emu community
+//
+//   https://github.com/QuentinGruber/h1z1-server
+//   https://www.npmjs.com/package/h1z1-server
+//
+//   Based on https://github.com/psemu/soe-network
+// ======================================================================
+
+import { ZoneServer2016 } from "../zoneserver";
+
+export class PlayTimeManager {
+  interval!: NodeJS.Timeout;
+  server!: ZoneServer2016;
+
+  updatePlaytime() {
+    const chars = Object.values(this.server._characters);
+    for (const char of chars) {
+      char.playTime += 1;
+    }
+  }
+
+  init(server: ZoneServer2016) {
+    this.server = server;
+    this.start();
+  }
+
+  start() {
+    // if somehow it was already running
+    if (this.interval) {
+      this.stop();
+    }
+    this.interval = setInterval(this.updatePlaytime.bind(this), 60_000);
+  }
+  stop() {
+    clearInterval(this.interval);
+  }
+}

--- a/src/servers/ZoneServer2016/managers/worlddatamanager.ts
+++ b/src/servers/ZoneServer2016/managers/worlddatamanager.ts
@@ -470,6 +470,7 @@ export class WorldDataManager {
         _containers: loadedCharacter._containers || {},
         _resources: loadedCharacter._resources || {},
         mutedCharacters: loadedCharacter.mutedCharacters || [],
+        playTime: loadedCharacter.playTime ?? 0,
         status: 1,
         worldSaveVersion: this.worldSaveVersion
       };
@@ -526,6 +527,7 @@ export class WorldDataManager {
       characterId: character.characterId,
       rotation: Array.from(character.state.lookAt),
       isRespawning: character.isRespawning,
+      playTime: character.playTime,
       spawnGridData: character.spawnGridData,
       mutedCharacters: character.mutedCharacters
     };
@@ -570,7 +572,8 @@ export class WorldDataManager {
           $set: {
             ...characterSaveData
           }
-        }
+        },
+        { upsert: true }
       );
     }
   }

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -245,6 +245,7 @@ import { WaterSource } from "./entities/watersource";
 import { WebSocket } from "ws";
 import { CommandHandler } from "./handlers/commands/commandhandler";
 import { AccountInventoryManager } from "./managers/accountinventorymanager";
+import { PlayTimeManager } from "./managers/playtimemanager";
 
 const spawnLocations2 = require("../../../data/2016/zoneData/Z1_gridSpawns.json"),
   deprecatedDoors = require("../../../data/2016/sampleData/deprecatedDoors.json"),
@@ -391,6 +392,7 @@ export class ZoneServer2016 extends EventEmitter {
   fairPlayManager: FairPlayManager;
   pluginManager: PluginManager;
   configManager: ConfigManager;
+  playTimeManager: PlayTimeManager;
 
   _ready: boolean = false;
 
@@ -484,6 +486,7 @@ export class ZoneServer2016 extends EventEmitter {
     this.fairPlayManager = new FairPlayManager();
     this.pluginManager = new PluginManager();
     this.commandHandler = new CommandHandler();
+    this.playTimeManager = new PlayTimeManager();
     /* CONFIG MANAGER MUST BE INSTANTIATED LAST ! */
     this.configManager = new ConfigManager(this, process.env.CONFIG_PATH);
     this.enableWorldSaves =
@@ -981,6 +984,7 @@ export class ZoneServer2016 extends EventEmitter {
         hairModel: characterModelData.hairModel,
         gender: characterData.payload.gender,
         status: 1,
+        playTime: 0,
         worldSaveVersion: this.worldSaveVersion
       };
       const collection = this._db.collection(DB_COLLECTIONS.CHARACTERS);
@@ -1532,6 +1536,7 @@ export class ZoneServer2016 extends EventEmitter {
     client.character.hairModel = savedCharacter.hairModel || "";
     client.character.spawnGridData = savedCharacter.spawnGridData;
     client.character.mutedCharacters = savedCharacter.mutedCharacters || [];
+    client.character.playTime = savedCharacter.playTime || 0;
 
     let newCharacter = false;
     if (
@@ -1575,6 +1580,7 @@ export class ZoneServer2016 extends EventEmitter {
 
   private async setupServer() {
     this.weatherManager.init();
+    this.playTimeManager.init(this);
     this.initModelsDataSource();
     this.worldDataManager = (await spawn(
       new Worker("./managers/worlddatamanagerthread")

--- a/src/types/savedata.ts
+++ b/src/types/savedata.ts
@@ -70,6 +70,7 @@ export interface CharacterUpdateSaveData
   isRespawning: boolean;
   spawnGridData: number[];
   mutedCharacters: string[];
+  playTime: number;
 }
 
 export interface FullCharacterSaveData


### PR DESCRIPTION
This PR introduces a new PlayTimeManager to track the playtime for characters. It includes changes to character entities, the world data manager, and the zone server to support playtime tracking. Additionally, it adds unit tests to ensure the PlayTimeManager works correctly with and without MongoDB. The changes also update the character save and load methods to include playtime.

---

