### PR TITLE
Change weird syntax in character save

### DIFF
--- a/src/servers/ZoneServer2016/managers/worlddatamanager.ts
+++ b/src/servers/ZoneServer2016/managers/worlddatamanager.ts
@@ -582,11 +582,7 @@ export class WorldDataManager {
     const promises: Array<any> = [];
     for (let i = 0; i < characters.length; i++) {
       const character = characters[i];
-      promises.push(
-        this.saveCharacterData(character).then((ret: any) => {
-          return ret;
-        })
-      );
+      promises.push(this.saveCharacterData(character));
     }
     await Promise.all(promises);
   }


### PR DESCRIPTION
### TL;DR
Simplifies promise handling in the saveCharacterData loop by removing unnecessary wrapping.

### What changed?
The promise handling in the saveCharacterData loop was simplified by directly pushing the promise returned by saveCharacterData into the promises array, instead of wrapping it in a then block.

### How to test?
The change does not alter the behavior of the code. However, to ensure everything is working correctly, run the existing tests and verify that all functionalities related to saving character data are operating as expected.

### Why make this change?
The change was made to simplify the code. Unwrapping the promise handling makes the code easier to read and maintain without affecting its functionality.

---

