### PR TITLE
Update h1z1-dataschema version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/ws": "8.5.10",
         "debug": "4.3.5",
         "h1emu-core": "1.2.8",
-        "h1z1-dataschema": "1.7.1",
+        "h1z1-dataschema": "1.7.2",
         "js-yaml": "4.1.0",
         "mongodb": "6.7.0",
         "threads": "1.7.0",
@@ -1132,9 +1132,9 @@
       "integrity": "sha512-wxJzTuZXQ54GcUZpkgk32K1e2dQ86sBCkZXw1QayQvMAcbIGEICFL1ZWLiZDk2xekJfLFVNSfWBwnUOjmiklJw=="
     },
     "node_modules/h1z1-dataschema": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/h1z1-dataschema/-/h1z1-dataschema-1.7.1.tgz",
-      "integrity": "sha512-1gBpN9CFHO1sp0Ur1hpgYRK/Qja+XC3H8DHn1bsAywaHzVFEg2RI0l5QNTLCx4vfMxuLM+xpaYnwnh6ZFWWS0A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/h1z1-dataschema/-/h1z1-dataschema-1.7.2.tgz",
+      "integrity": "sha512-u+85W0BwWgv3xlPcBerbwKU0FDsSZGncrveJD3UIk/kevbjvD+r+JhV90H4WbT1eH92UgujkJ6gQkRxvGTy2vw==",
       "dependencies": {
         "h1z1-buffer": "^1.0.2"
       }
@@ -1200,12 +1200,20 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
       "optional": true,
-      "peer": true
+      "peer": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1274,6 +1282,14 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -1775,17 +1791,18 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -1796,6 +1813,14 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/ws": "8.5.10",
     "debug": "4.3.5",
     "h1emu-core": "1.2.8",
-    "h1z1-dataschema": "1.7.1",
+    "h1z1-dataschema": "1.7.2",
     "js-yaml": "4.1.0",
     "mongodb": "6.7.0",
     "threads": "1.7.0",


### PR DESCRIPTION
Update dependencies in the package.json and package-lock.json. Upgrades included: 'h1z1-dataschema' from 1.7.1 to 1.7.2, replaces 'ip' with 'ip-address' version 9.0.5, upgrades 'socks' from 2.7.1 to 2.8.3, added new dependencies 'jsbn' version 1.1.0 and 'sprintf-js' version 1.1.3.

---

