### PR TITLE
remove binaries building

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -95,18 +95,3 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm i
       - run: npm test
-  test-binaries:
-    name: Test Binaries
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 20.12.2
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20.12.2
-      - run: npm i --omit=dev
-      - run: npm i -g pkg@5.8.0
-      - run: pkg --compress GZip -t node18-win-x64 ./bin/2015/h1emuServer.js --output ./bin/h1emuServer-2015-${{ github.ref }}.exe
-      - run: pkg --compress GZip -t node18-win-x64 ./bin/2016/h1emuServer.js --output ./bin/h1emuServer-2016-${{ github.ref }}.exe
-      - run: ./bin/h1emuServer-2015-${{ github.ref }}.exe --test
-      - run: ./bin/h1emuServer-2016-${{ github.ref }}.exe --test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,61 +36,6 @@ jobs:
           draft: false
           prerelease: false
 
-  build-binaries:
-    name: Create Binaries
-    needs: create-release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 20.12.2
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20.12.2
-      - uses: olegtarasov/get-tag@v2.1
-        id: tagName
-      - run: npm i --omit=dev
-      - run: npm i -g pkg@5.8.0
-      - run: pkg --compress GZip -t node18-win-x64 ./bin/shared/loginServer.js --output ./bin/loginServer-2015-${{ steps.tagName.outputs.tag }}.exe
-      - run: pkg --compress GZip -t node18-win-x64 ./bin/2015/zoneServer.js --output ./bin/zoneServer-2015-${{ steps.tagName.outputs.tag }}.exe
-      - run: pkg --compress GZip -t node18-win-x64 ./bin/2015/h1emuServer.js --output ./bin/h1emuServer-2015-${{ steps.tagName.outputs.tag }}.exe
-      - run: pkg --compress GZip -t node18-win-x64 ./bin/2016/zoneServer.js --output ./bin/zoneServer-2016-${{ steps.tagName.outputs.tag }}.exe
-      - run: pkg --compress GZip -t node18-win-x64 ./bin/2016/h1emuServer.js --output ./bin/h1emuServer-2016-${{ steps.tagName.outputs.tag }}.exe
-      - name: Upload h1emuServer-2015 to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./bin/h1emuServer-2015-${{ steps.tagName.outputs.tag }}.exe
-          asset_name: h1emuServer-2015-${{ steps.tagName.outputs.tag }}.exe
-          tag: ${{ github.ref }}
-      - name: Upload zoneServer-2015 to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./bin/zoneServer-2015-${{ steps.tagName.outputs.tag }}.exe
-          asset_name: zoneServer-2015-${{ steps.tagName.outputs.tag }}.exe
-          tag: ${{ github.ref }}
-      - name: Upload loginServer-2015 to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./bin/loginServer-2015-${{ steps.tagName.outputs.tag }}.exe
-          asset_name: loginServer-2015-${{ steps.tagName.outputs.tag }}.exe
-          tag: ${{ github.ref }}
-      - name: Upload h1emuServer-2016 to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./bin/h1emuServer-2016-${{ steps.tagName.outputs.tag }}.exe
-          asset_name: h1emuServer-2016-${{ steps.tagName.outputs.tag }}.exe
-          tag: ${{ github.ref }}
-      - name: Upload zoneServer-2016 to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./bin/zoneServer-2016-${{ steps.tagName.outputs.tag }}.exe
-          asset_name: zoneServer-2016-${{ steps.tagName.outputs.tag }}.exe
-          tag: ${{ github.ref }}
-
   build-docker-images:
     name: Create and push docker images
     needs: create-release
@@ -117,3 +62,4 @@ jobs:
       - run: sudo docker image push h1emu/login-server:latest
       - run: sudo docker image push h1emu/zone-server:latest
       - run: sudo docker image push h1emu/zone-server-2016:latest
+

--- a/package.json
+++ b/package.json
@@ -56,8 +56,6 @@
     "build-tests": "npx tsc -p tsconfigs/tsconfig-tests.json",
     "build-benchs": "npx tsc -p ./benchmarks/tsconfig.json",
     "build-docker-images": "npx ts-node ./docker/buildDocker.ts",
-    "build-binaries-win": "cd ./bin/ && build.bat",
-    "build-binaries-unix": "chmod +x ./bin/build.sh && ./bin/build.sh",
     "test-mongo": "npm run build && npm run build-tests && MONGO_TESTS='true' node --test",
     "test": "npm run build && npm run build-tests && node --test",
     "postinstall": "npm run build",

--- a/src/servers/LoginZoneConnection/shared/baselzconnection.ts
+++ b/src/servers/LoginZoneConnection/shared/baselzconnection.ts
@@ -17,7 +17,6 @@ import { LZConnectionClient } from "./lzconnectionclient";
 import dgram, { RemoteInfo } from "node:dgram";
 
 const debug = require("debug")("LZConnection");
-process.env.isBin && require("../../shared/workers/udpServerWorker.js");
 
 export abstract class BaseLZConnection extends EventEmitter {
   _serverPort?: number;

--- a/src/servers/ZoneServer2016/managers/configmanager.ts
+++ b/src/servers/ZoneServer2016/managers/configmanager.ts
@@ -15,12 +15,7 @@ import * as fs from "fs";
 import * as yaml from "js-yaml";
 import { Config } from "../models/config";
 import { ZoneServer2016 } from "../zoneserver";
-import * as path from "node:path";
 import { copyFile } from "../../../utils/utils";
-
-process.env.isBin &&
-  require("js-yaml") &&
-  path.join(__dirname, "../../../../data/2016/sampleData/defaultconfig.yaml");
 
 function fileExists(filePath: string): boolean {
   try {

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -14,7 +14,6 @@
 const debugName = "ZoneServer",
   debug = require("debug")(debugName);
 
-process.env.isBin && require("./managers/worlddatamanagerthread");
 import { EventEmitter } from "node:events";
 import { H1Z1Protocol } from "../../protocols/h1z1protocol";
 import { LoginConnectionManager } from "../LoginZoneConnection/loginconnectionmanager";


### PR DESCRIPTION
pkg is old now and doesn't support node >18 and was pretty much garbage. we will use https://nodejs.org/docs/latest/api/single-executable-applications.html when it's ready