### PR TITLE
Lower 1000 bulk backpack spawns

### DIFF
--- a/src/servers/ZoneServer2016/data/lootspawns.ts
+++ b/src/servers/ZoneServer2016/data/lootspawns.ts
@@ -798,7 +798,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
       },
       {
         item: Items.BACKPACK_BLUE_ORANGE,
-        weight: 15,
+        weight: 8,
         spawnCount: {
           min: 1,
           max: 1
@@ -2035,7 +2035,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
 
   // #region MISC
   "ItemSpawner_BackpackOnGround001.adr": {
-    spawnChance: 15,
+    spawnChance: 8,
     items: [
       {
         item: Items.BACKPACK_BLUE_ORANGE,
@@ -2214,7 +2214,7 @@ export const containerLootSpawners: {
       },
       {
         item: Items.BACKPACK_BLUE_ORANGE,
-        weight: 15,
+        weight: 10,
         spawnCount: {
           min: 1,
           max: 1


### PR DESCRIPTION
https://www.youtube.com/watch?v=aSiOyJaMd4c
https://www.youtube.com/watch?v=Yzmb_plgkus
https://www.youtube.com/watch?v=LxzQ96HI5sM
https://www.reddit.com/r/h1z1/comments/4x2x4z/just_survive_loot/
 
Used these sources as well as some of my old knowledge from playing the old H1Z1 in 2016. The 1000 backpacks should be more rare than they are now. You can confidently find one majority of the time, but that wasn't common in 2016. I vividly remember players would use framed backpacks as their main backpack source, not the blue and orange that is common now.

This values felt decent, but could be nerfed more 