### PR TITLE
Fix and disable white motorcycle helmet

### DIFF
--- a/src/servers/ZoneServer2016/models/enums.ts
+++ b/src/servers/ZoneServer2016/models/enums.ts
@@ -2441,6 +2441,6 @@ export enum DefaultSkinsBackpack {
 export enum DefaultSkinsMotorHelmet {
   // BLACK_MOTORCYCLE_HELMET = 2168 - skin is light blue
   GRAY_MOTOR_HELMET = 2169,
-  WHITE_MOTOR_HELMET = 2171,
+  // WHITE_MOTOR_HELMET = 2171, skin is light red
   DEFAULT_RED_MOTOR_HELMET = 2170
 }


### PR DESCRIPTION
Didn't realize when pushing #2401 that the white helmet is messed up too. When you equip it, the skin is light red, so disable it until it's fixed (also didn't have a world model, so added that)