### PR TITLE
Fix for vehicle collision dmg on small bumps

### DIFF
--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -702,7 +702,7 @@ export class ZonePacketHandlers {
       vehicle = characterId ? server._vehicles[characterId] : undefined,
       damage = Number((packet.data.damage || 0).toFixed(0));
 
-    if (!vehicle) return;
+    if (!vehicle || damage <= 100) return;
     vehicle.damage(server, { entity: "", damage: damage * 4 });
     //server.DTOhit(client, packet);
   }


### PR DESCRIPTION
So from testing, Vehicle Collision packets get sent very frequently when off-roading (depending on vehicle type), and with the change in #2394, these tend to snowball pretty quick. From testing, damage <= 100 got rid of the smaller damage values that get sent when off-roading