### PR TITLE
Minor bumjick loot adjustment

### DIFF
--- a/src/servers/ZoneServer2016/data/lootspawns.ts
+++ b/src/servers/ZoneServer2016/data/lootspawns.ts
@@ -1266,7 +1266,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
         weight: 15,
         spawnCount: {
           min: 1,
-          max: 1
+          max: 2
         }
       },
       {
@@ -1274,7 +1274,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
         weight: 15,
         spawnCount: {
           min: 1,
-          max: 1
+          max: 2
         }
       },
       {
@@ -1291,6 +1291,14 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
         spawnCount: {
           min: 1,
           max: 1
+        }
+      },
+      {
+        item: Items.AMMO_308,
+        weight: 5,
+        spawnCount: {
+          min: 1,
+          max: 3
         }
       }
     ]


### PR DESCRIPTION
https://www.youtube.com/watch?v=n-MGIG72jFA

Was watching some old JS videos, and came across this one about bumjick. In the video, he is looting 308 ammo, as-well the corn/wheat seeds up to 2. H1EMU's bumjick isn't like that currently so wanted to update it :D