### PR TITLE
Fix metric survive time

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2294,6 +2294,8 @@ export class ZoneServer2016 extends EventEmitter {
         this.aiManager.remove_entity(client.character.h1emu_ai_id);
       }
       client.isLoading = true; // stop anything from acting on character
+      // "shift" time played prior to logging out
+      client.character.metrics.startedSurvivingTP += (Date.now() - Number(client.character.lastLoginDate));
 
       clearTimeout(client.character?.resourcesUpdater);
       try {

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2295,7 +2295,8 @@ export class ZoneServer2016 extends EventEmitter {
       }
       client.isLoading = true; // stop anything from acting on character
       // "shift" time played prior to logging out
-      client.character.metrics.startedSurvivingTP += (Date.now() - Number(client.character.lastLoginDate));
+      client.character.metrics.startedSurvivingTP +=
+        Date.now() - Number(client.character.lastLoginDate);
 
       clearTimeout(client.character?.resourcesUpdater);
       try {


### PR DESCRIPTION
Currently startedSurvivingTP will display times during when the player was logged off, leading to bigger than intended times. This PR fixes that by "shifting" the time to prevent offline time being tracked in startedSurvivingTP