### PR TITLE
Fix shortcircuit log for ragdolls

### DIFF
--- a/src/protocols/h1z1protocol.ts
+++ b/src/protocols/h1z1protocol.ts
@@ -477,6 +477,11 @@ export class H1Z1Protocol {
             offset = 2;
             break;
           }
+          case 0xce: {
+            packet = H1Z1Packets.Packets[0xce];
+            offset = 3;
+            break;
+          }
           default: {
             console.error(`unknown packet use flag 3 : ${opCode}`);
             [packet, offset] = this.resolveOpcode(opCode, data);


### PR DESCRIPTION
### TL;DR
Added support for packet opcode 0xce in H1Z1 protocol

### What changed?
Added a new case handler for opcode 0xce in the H1Z1Protocol class with an offset of 3 bytes

### How to test?
1. Run the game client
2. Verify packets with opcode 0xce are properly handled
3. Check logs to ensure no unknown packet errors for 0xce

### Why make this change?
This addition enables proper handling of a previously unsupported packet type, preventing it from falling through to the default error case and improving protocol compatibility