### PR TITLE
Creating typing for multideath

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
@@ -756,8 +756,16 @@ export function packPositionUpdateData(obj: any) {
   return data;
 }
 
-export function packMultiStateDeathData(obj: any) {
-  const isRagdoll = obj["unknown6"] && obj["unknown6"] > 0;
+export interface MultiDeathData {
+  characterId: string;
+  unknown4: number;
+  unknown5: number;
+  flag: number;
+  managerCharacterId: string;
+}
+
+export function packMultiStateDeathData(obj: MultiDeathData) {
+  const isRagdoll = obj.flag && obj.flag > 0;
   let offset = 0;
   const data = Buffer.allocUnsafe(isRagdoll ? 19 : 11);
   for (let j = 0; j < 8; j++) {
@@ -771,7 +779,7 @@ export function packMultiStateDeathData(obj: any) {
   offset += 1;
   data.writeUInt8(obj["unknown5"], offset);
   offset += 1;
-  data.writeUInt8(obj["unknown6"], offset);
+  data.writeUInt8(obj.flag, offset);
   offset += 1;
 
   if (isRagdoll) {

--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -196,7 +196,7 @@ export class Npc extends BaseFullCharacter {
             server.sendData(c, "Character.StartMultiStateDeath", {
               data: {
                 characterId: this.characterId,
-                unknown6: 128,
+                flag: 128,
                 managerCharacterId: c.character.characterId
               }
             });
@@ -208,7 +208,7 @@ export class Npc extends BaseFullCharacter {
             server.sendData(c, "Character.StartMultiStateDeath", {
               data: {
                 characterId: this.characterId,
-                unknown6: 0
+                flag: 0
               }
             });
           }

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2546,7 +2546,7 @@ export class ZoneServer2016 extends EventEmitter {
         {
           data: {
             characterId: client.character.characterId,
-            unknown6: 128,
+            flag: 128,
             managerCharacterId: client.character.characterId
           }
         }
@@ -2560,7 +2560,7 @@ export class ZoneServer2016 extends EventEmitter {
             {
               data: {
                 characterId: client.character.characterId,
-                unknown6: 128,
+                flag: 128,
                 managerCharacterId: iteratedClient.character.characterId
               }
             }


### PR DESCRIPTION
### TL;DR
Renamed `unknown6` to `flag` in death packet data and added TypeScript interface for better type safety.

### What changed?
- Created new `MultiDeathData` interface to define the structure of death packet data
- Renamed the ambiguous `unknown6` parameter to more descriptive `flag` in both shared protocol and NPC entity code
- Updated references to use the new interface and parameter name

### How to test?
1. Kill an NPC in-game
2. Verify death animations still trigger correctly
3. Check both ragdoll (flag=128) and non-ragdoll (flag=0) death states work as expected

### Why make this change?
Improves code readability and maintainability by:
- Providing clear type definitions for death packet data
- Using more meaningful parameter names that better describe their purpose
- Making the relationship between the flag value and ragdoll behavior more explicit