### PR TITLE
Use bigints to write characterIds in custom pack

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
@@ -768,12 +768,8 @@ export function packMultiStateDeathData(obj: MultiDeathData) {
   const isRagdoll = obj.flag && obj.flag > 0;
   let offset = 0;
   const data = Buffer.allocUnsafe(isRagdoll ? 19 : 11);
-  for (let j = 0; j < 8; j++) {
-    data.writeUInt8(
-      parseInt(obj["characterId"].substr(2 + (7 - j) * 2, 2), 16),
-      offset + j
-    );
-  }
+  const characterIdBI = BigInt(obj.characterId);
+  data.writeBigUInt64LE(characterIdBI, offset);
   offset += 8;
   data.writeUInt8(obj["unknown4"], offset);
   offset += 1;
@@ -783,12 +779,8 @@ export function packMultiStateDeathData(obj: MultiDeathData) {
   offset += 1;
 
   if (isRagdoll) {
-    for (let j = 0; j < 8; j++) {
-      data.writeUInt8(
-        parseInt(obj["managerCharacterId"].substr(2 + (7 - j) * 2, 2), 16),
-        offset + j
-      );
-    }
+    const managerCharacterIdBI = BigInt(obj.managerCharacterId);
+    data.writeBigUInt64LE(managerCharacterIdBI, offset);
     offset += 8;
   }
   return data;


### PR DESCRIPTION
### TL;DR
Improved death animation packet handling by introducing proper typing and more efficient character ID processing

### What changed?
- Added `MultiDeathData` interface to properly type death animation data
- Replaced manual character ID parsing with `BigInt` operations
- Renamed `unknown6` parameter to more descriptive `flag`
- Updated NPC death handling to use the new flag parameter name

### How to test?
1. Kill NPCs in-game
2. Verify death animations still work correctly
3. Check both ragdoll (flag = 128) and non-ragdoll (flag = 0) death animations

### Why make this change?
The previous implementation used unclear parameter names and inefficient character ID parsing. This change improves code readability and maintainability while potentially offering better performance through the use of native BigInt operations.