### PR TITLE
add tan mil to world spawns

### DIFF
--- a/src/servers/ZoneServer2016/data/lootspawns.ts
+++ b/src/servers/ZoneServer2016/data/lootspawns.ts
@@ -2044,6 +2044,14 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
           min: 1,
           max: 1
         }
+      },
+      {
+        item: Items.BACKPACK_MILITARY_TAN,
+        weight: 25,
+        spawnCount: {
+          min: 1,
+          max: 1
+        }
       }
     ]
   },

--- a/src/servers/ZoneServer2016/data/lootspawns.ts
+++ b/src/servers/ZoneServer2016/data/lootspawns.ts
@@ -2047,7 +2047,7 @@ export const lootTables: { [lootSpawner: string]: LootSpawner } = {
       },
       {
         item: Items.BACKPACK_MILITARY_TAN,
-        weight: 25,
+        weight: 5,
         spawnCount: {
           min: 1,
           max: 1


### PR DESCRIPTION
https://www.youtube.com/watch?v=BeYQNMiKuO8 22:25 | 23:00 

Tan military backpacks used to spawn in the world just like 1000 bulk backpacks do now. Wasn't sure on weight amount, so I did 25 so it's 20% to spawn if spawnChance has been triggered.