### PR TITLE
Add durability loss while walking in shoes

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -75,7 +75,6 @@ import { ConstructionParentEntity } from "./constructionparententity";
 import { ExplosiveEntity } from "./explosiveentity";
 import { BaseEntity } from "./baseentity";
 import { ProjectileEntity } from "./projectileentity";
-import { LoadoutItem } from "../classes/loadoutItem";
 const stats = require("../../../../data/2016/sampleData/stats.json");
 
 interface CharacterStates {

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1909,7 +1909,11 @@ export class Character2016 extends BaseFullCharacter {
       );
       if (!item || !itemDefinition) return;
 
-      server.damageItem(this, item, server.isBoot(item.itemDefinitionId) ? 1.2 : 0.4);
-    } 
+      server.damageItem(
+        this,
+        item,
+        server.isBoot(item.itemDefinitionId) ? 1.2 : 0.4
+      );
+    }
   }
 }

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -75,6 +75,7 @@ import { ConstructionParentEntity } from "./constructionparententity";
 import { ExplosiveEntity } from "./explosiveentity";
 import { BaseEntity } from "./baseentity";
 import { ProjectileEntity } from "./projectileentity";
+import { LoadoutItem } from "../classes/loadoutItem";
 const stats = require("../../../../data/2016/sampleData/stats.json");
 
 interface CharacterStates {
@@ -1896,5 +1897,12 @@ export class Character2016 extends BaseFullCharacter {
       entity: sourceEntity.characterId,
       damage: damage
     });
+  }
+
+  handleShoeDurability(server: ZoneServer2016) {
+    const item: LoadoutItem | undefined = this._loadout[LoadoutSlots.FEET];
+    if (!item) return;
+
+    server.damageItem(this, item, server.isBoot(item.itemDefinitionId) ? 0.5 : 0.25);
   }
 }

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1900,9 +1900,16 @@ export class Character2016 extends BaseFullCharacter {
   }
 
   handleShoeDurability(server: ZoneServer2016) {
-    const item: LoadoutItem | undefined = this._loadout[LoadoutSlots.FEET];
-    if (!item) return;
+    if (!this._loadout[LoadoutSlots.FEET]) return;
+    const itemGuid = this._loadout[LoadoutSlots.FEET].itemGuid;
+    if (itemGuid) {
+      const item = this.getInventoryItem(itemGuid);
+      const itemDefinition = server.getItemDefinition(
+        item?.itemDefinitionId ?? 0
+      );
+      if (!item || !itemDefinition) return;
 
-    server.damageItem(this, item, server.isBoot(item.itemDefinitionId) ? 0.5 : 0.25);
+      server.damageItem(this, item, server.isBoot(item.itemDefinitionId) ? 1.2 : 0.4);
+    } 
   }
 }

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -1665,6 +1665,9 @@ export class ZonePacketHandlers {
       // Check current interaction
       client.character.checkCurrentInteractionGuid();
 
+      // Handle shoe durability
+      client.character.handleShoeDurability(server);
+      
       // Timeout interaction lock UI
       if (
         client.character.lastInteractionRequestGuid &&

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -1667,7 +1667,7 @@ export class ZonePacketHandlers {
 
       // Handle shoe durability
       client.character.handleShoeDurability(server);
-      
+
       // Timeout interaction lock UI
       if (
         client.character.lastInteractionRequestGuid &&

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5734,6 +5734,8 @@ export class ZoneServer2016 extends EventEmitter {
         return 100;
       case this.isConvey(itemDefinitionId):
         return 5400;
+      case this.isBoot(itemDefinitionId):
+        return 14400;
       case this.isWeapon(itemDefinitionId):
       default:
         return 2000;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5724,7 +5724,7 @@ export class ZoneServer2016 extends EventEmitter {
       case this.isGeneric(itemDefinitionId) &&
         itemDefinitionId == Items.SKINNING_KNIFE:
         return 2000;
-      case this.isGeneric(itemDefinitionId) && !this.isConvey(itemDefinitionId):
+      case this.isGeneric(itemDefinitionId) && !this.isConvey(itemDefinitionId) && !this.isBoot(itemDefinitionId):
         return 0;
       case itemDefinitionId == Items.WEAPON_HATCHET_MAKESHIFT:
         return 250;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5724,7 +5724,9 @@ export class ZoneServer2016 extends EventEmitter {
       case this.isGeneric(itemDefinitionId) &&
         itemDefinitionId == Items.SKINNING_KNIFE:
         return 2000;
-      case this.isGeneric(itemDefinitionId) && !this.isConvey(itemDefinitionId) && !this.isBoot(itemDefinitionId):
+      case this.isGeneric(itemDefinitionId) &&
+        !this.isConvey(itemDefinitionId) &&
+        !this.isBoot(itemDefinitionId):
         return 0;
       case itemDefinitionId == Items.WEAPON_HATCHET_MAKESHIFT:
         return 250;


### PR DESCRIPTION
So currently shoes have durability, but no use for them. This PR adds durability loss to shoes when walking. 

Ideally, the damage given to the shoe should be based upon the materialType that the player is currently walking on, but this is good for now. 

From testing these were values that felt "fair" but could be adjusted of course.

Boots: 1.2 dmg per step - 12,000 steps 
Conveys : 0.4 dmg per step - 13,500 steps