### PR TITLE
Fix branch giving broken metal item on destruction

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -3137,7 +3137,7 @@ export class ZoneServer2016 extends EventEmitter {
     item.currentDurability -= damage;
     if (item.currentDurability <= 0) {
       this.removeInventoryItem(character, item);
-      if (this.isWeapon(item.itemDefinitionId)) {
+      if (this.isWeapon(item.itemDefinitionId) && item.itemDefinitionId != Items.WEAPON_BRANCH) {
         character.lootContainerItem(
           this,
           this.generateItem(Items.BROKEN_METAL_ITEM)

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -3137,7 +3137,10 @@ export class ZoneServer2016 extends EventEmitter {
     item.currentDurability -= damage;
     if (item.currentDurability <= 0) {
       this.removeInventoryItem(character, item);
-      if (this.isWeapon(item.itemDefinitionId) && item.itemDefinitionId != Items.WEAPON_BRANCH) {
+      if (
+        this.isWeapon(item.itemDefinitionId) &&
+        item.itemDefinitionId != Items.WEAPON_BRANCH
+      ) {
         character.lootContainerItem(
           this,
           this.generateItem(Items.BROKEN_METAL_ITEM)


### PR DESCRIPTION
Reported by: purple in the discord

So branches would give you a "broken metal item" when they broke, which shouldn't happen.. obviously.. cause it's a wooden branch lol