### PR TITLE
fill dew collectors while raining

### DIFF
--- a/src/servers/ZoneServer2016/managers/smeltingmanager.ts
+++ b/src/servers/ZoneServer2016/managers/smeltingmanager.ts
@@ -118,6 +118,45 @@ export class SmeltingManager {
     }, this.burnTime);
   }
 
+  public fillDewCollectors(server: ZoneServer2016) {
+    for (const a in this._collectingEntities) {
+      const entity = this.getTrueEntity(server, this._collectingEntities[a]);
+      if (!entity) {
+        delete this._smeltingEntities[a];
+        continue;
+      }
+      const subEntity = entity.subEntity;
+      if (!(subEntity instanceof CollectingEntity)) {
+        delete this._smeltingEntities[a];
+        continue;
+      }
+      const container = entity.getContainer();
+      if (!container) {
+        delete this._smeltingEntities[a];
+        continue;
+      }
+      if (entity.itemDefinitionId === Items.DEW_COLLECTOR) {
+        for (const a in container.items) {
+          const item = container.items[a];
+          if (item.itemDefinitionId != Items.WATER_EMPTY) continue;
+
+          if (!server.removeContainerItem(entity, item, container, 1)) {
+            return;
+          }
+          const reward = getRewardId(entity.itemDefinitionId);
+          if (reward) {
+            entity.lootContainerItem(
+              server,
+              server.generateItem(reward),
+              1,
+              false
+            );
+          }
+        }
+      }
+    }
+  }
+
   public checkCollectors(server: ZoneServer2016) {
     for (const a in this._collectingEntities) {
       const entity = this.getTrueEntity(server, this._collectingEntities[a]);

--- a/src/servers/ZoneServer2016/managers/weathermanager.ts
+++ b/src/servers/ZoneServer2016/managers/weathermanager.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../utils/utils";
 import { ZoneClient2016 as Client } from "../classes/zoneclient";
 import { ZoneServer2016 } from "../zoneserver";
+import EventEmitter from "node:events";
 //const debug = require("debug")("dynamicWeather");
 
 const localWeatherTemplates = require("../../../../data/2016/dataSources/weather.json");
@@ -83,7 +84,7 @@ function adjustNumber(
   return currentNumber; // Return the updated number
 }
 
-export class WeatherManager {
+export class WeatherManager extends EventEmitter {
   weatherChoosen = false;
   fog = 0; // density
   currentSeason = "summer";
@@ -560,6 +561,7 @@ export class WeatherManager {
       this.rain = 0.1;
       this.rainRampupTime = 1;
       this.moveGPtoDesiredValue();
+      this.emit("raining");
     } else if (currentHour > Math.min(...this.rainingHours)) {
       this.rain = 0;
       this.rainRampupTime = 0;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -511,6 +511,10 @@ export class ZoneServer2016 extends EventEmitter {
     this.enableWorldSaves =
       process.env.ENABLE_SAVES?.toLowerCase() == "false" ? false : true;
 
+    /* Managers events */
+    this.weatherManager.on("raining", () => {
+      this.smeltingManager.fillDewCollectors(this);
+    });
     /** Determines what rulesets are used. */
     const serverGameRules = [];
     serverGameRules.push(this.isPvE ? "PvE" : "PvP");


### PR DESCRIPTION
### TL;DR
Added functionality to automatically fill dew collectors with water when it rains.
It fill up to 6 bottle per ingame hour of raining.

### What changed?
- Added a new `fillDewCollector` method to the `SmeltingManager` class
- Extended `WeatherManager` to emit a "raining" event when rain starts
- Connected the weather and smelting managers in `ZoneServer` to trigger dew collector filling when it rains

### How to test?
1. Place a dew collector in the game world
2. Add empty water bottles to the collector's inventory
3. Wait for rain to start
4. Verify that empty water bottles are automatically converted to filled water bottles

### Why make this change?
To automate the dew collector functionality, making it more realistic and convenient for players by automatically collecting water during rainfall instead of requiring manual interaction.