### PR TITLE
remove saving of groupid

### DIFF
--- a/src/servers/ZoneServer2016/managers/worlddatamanager.ts
+++ b/src/servers/ZoneServer2016/managers/worlddatamanager.ts
@@ -482,7 +482,6 @@ export class WorldDataManager {
         _containers: loadedCharacter._containers || {},
         _resources: loadedCharacter._resources || {},
         mutedCharacters: loadedCharacter.mutedCharacters || [],
-        groupId: 0, //loadedCharacter.groupId || 0,
         metrics: loadedCharacter.metrics || {},
         playTime: loadedCharacter.playTime ?? 0,
         lastDropPlayTime: loadedCharacter.lastDropPlayTime ?? 0,
@@ -547,7 +546,6 @@ export class WorldDataManager {
       lastDropPlayTime: character.lastDropPlaytime,
       spawnGridData: character.spawnGridData,
       mutedCharacters: character.mutedCharacters,
-      groupId: 0, //character.groupId
       metrics: character.metrics
     };
     return saveData;

--- a/src/types/savedata.ts
+++ b/src/types/savedata.ts
@@ -71,7 +71,6 @@ export interface CharacterUpdateSaveData
   spawnGridData: number[];
   metrics: CharacterMetricsSaveData;
   mutedCharacters: string[];
-  groupId: number;
   playTime: number;
   lastDropPlayTime: number;
 }


### PR DESCRIPTION
### TL;DR
Removed unused `groupId` field from character save data

### What changed?
- Removed `groupId` field from character save data interfaces and related code
- Eliminated commented-out `groupId` assignments in the `WorldDataManager`

### How to test?
1. Load an existing character
2. Verify character data loads correctly without errors
3. Save character data and confirm it persists properly
4. Check that group functionality continues to work as expected

### Why make this change?
The `groupId` field was not being actively used in the codebase and was only present as commented-out code. Removing it helps maintain cleaner data structures and eliminates unused fields from the save data.