### PR TITLE
get group id from /groups collection directly

### DIFF
--- a/src/servers/ZoneServer2016/managers/groupmanager.ts
+++ b/src/servers/ZoneServer2016/managers/groupmanager.ts
@@ -93,6 +93,20 @@ export class GroupManager {
           .findOne<Group>({ serverId: server._worldId, groupId });
   }
 
+  async getGroupId(
+    server: ZoneServer2016,
+    client: Client
+  ): Promise<number | null> {
+    if (server._soloMode) return null;
+
+    const collection = server._db.collection(DB_COLLECTIONS.GROUPS);
+    const result = await collection.findOne(
+      { serverId: server._worldId, members: client.character.characterId },
+      { projection: { groupId: 1, _id: 0 } }
+    );
+    return result ? result.groupId : null;
+  }
+
   async deleteGroup(server: ZoneServer2016, groupId: number) {
     if (server._soloMode) {
       delete this.soloGroups[groupId];

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1645,7 +1645,8 @@ export class ZoneServer2016 extends EventEmitter {
     client.character.spawnGridData = savedCharacter.spawnGridData;
     client.character.mutedCharacters = savedCharacter.mutedCharacters || [];
     client.character.metrics = savedCharacter.metrics || {};
-    client.character.groupId = 0; //savedCharacter.groupId || 0;
+    client.character.groupId =
+      (await this.groupManager.getGroupId(this, client)) ?? 0;
     client.character.playTime = savedCharacter.playTime || 0;
     client.character.lastDropPlaytime = savedCharacter.lastDropPlayTime || 0;
 


### PR DESCRIPTION
### TL;DR
Added functionality to retrieve and restore a player's group membership when logging in.

### What changed?
- Added a new `getGroupId` method to the GroupManager class that queries the database for a player's group membership
- Modified character loading to restore the player's group ID from the database instead of defaulting to 0

### How to test?
1. Create a group with multiple players
2. Have one player log out
3. When they log back in, verify they are still part of the same group
4. Test in both solo and multiplayer modes to ensure proper behavior

### Why make this change?
Players were losing their group membership upon logging out and back in, as the group ID was being reset to 0. This change maintains group persistence across login sessions, improving the multiplayer experience.