### PR TITLE
fill one bottle per hour raining

### DIFF
--- a/src/servers/ZoneServer2016/managers/weathermanager.ts
+++ b/src/servers/ZoneServer2016/managers/weathermanager.ts
@@ -97,6 +97,7 @@ export class WeatherManager extends EventEmitter {
   cloudWeight3 = 0.01;
   temperature = 80;
   rain = 0;
+  lastRainingHour = -1;
   rainRampupTime = 0;
   globalPrecipation = 0;
   desiredGlobalPrecipation = 0;
@@ -558,17 +559,23 @@ export class WeatherManager extends EventEmitter {
       this.rainingHours.includes(currentHour) &&
       Math.max(...this.rainingHours) >= currentHour
     ) {
+      // fill one bottle per rain hour
+      if (this.lastRainingHour === -1 || this.lastRainingHour !== currentHour) {
+        this.lastRainingHour = currentHour;
+        this.emit("raining");
+      }
       this.rain = 0.1;
       this.rainRampupTime = 1;
       this.moveGPtoDesiredValue();
-      this.emit("raining");
     } else if (currentHour > Math.min(...this.rainingHours)) {
       this.rain = 0;
+      this.lastRainingHour = -1;
       this.rainRampupTime = 0;
       this.desiredGlobalPrecipation = 0;
       this.moveGPtoDesiredValue();
     } else if (this.rainingHours.length == 0 && !this.lastDayWasRainy) {
       this.rain = 0;
+      this.lastRainingHour = -1;
       this.rainRampupTime = 0;
       this.desiredGlobalPrecipation = 0;
       this.moveGPtoDesiredValue();


### PR DESCRIPTION
### TL;DR
Fixed rain bottle collection to trigger once per rain hour instead of continuously.

### What changed?
Added a `lastRainingHour` tracking variable to ensure the "raining" event only emits once per hour during rainy periods. Previously, the event would emit continuously while it was raining, leading to potential issues with rain bottle collection.

### How to test?
1. Enter a zone during rainy weather
2. Verify that rain bottles can only be collected once per hour
3. Confirm that rain bottles reset properly when moving to a new hour
4. Check that rain state properly resets when leaving rainy periods

### Why make this change?
The previous implementation allowed for continuous rain bottle collection during rainy hours, which wasn't the intended behavior. This change ensures players can only collect one rain bottle per hour during rainy periods, maintaining better game balance and intended mechanics.