### PR TITLE
authorize explosion damages from projectiles

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2798,19 +2798,16 @@ export class ZoneServer2016 extends EventEmitter {
     // render distance is max client.chunkRenderDistance, could probably be lowered a lot
     // - meme
 
-    if (!sourceIsProjectile) {
-      // skip projectiles from damaging bases
-      for (const gridCell of this._grid) {
-        if (!isPosInRadius(400, gridCell.position, position)) {
-          continue;
-        }
-        for (const object of gridCell.objects) {
-          // explosives still chain explode on PvE
-          if (!(object instanceof ExplosiveEntity) && this.isPvE) continue;
+    for (const gridCell of this._grid) {
+      if (!isPosInRadius(400, gridCell.position, position)) {
+        continue;
+      }
+      for (const object of gridCell.objects) {
+        // explosives still chain explode on PvE
+        if (!(object instanceof ExplosiveEntity) && this.isPvE) continue;
 
-          // await is for ExplosiveEntity, ignore error
-          object.OnExplosiveHit(this, sourceEntity, client);
-        }
+        // await is for ExplosiveEntity, ignore error
+        object.OnExplosiveHit(this, sourceEntity, client);
       }
     }
 


### PR DESCRIPTION
### What changed?
Removed the `sourceIsProjectile` check that was preventing projectiles from damaging bases. This allows all damage sources, including projectiles, to affect base structures and trigger explosive chain reactions.

### How to test?
1. Join a server
2. Create a base structure
3. Fire projectiles at the base
4. Verify that projectiles now cause damage to the base structures
5. Test with explosive objects to ensure chain reactions still work as expected