### PR TITLE
npcs explosive damages

### DIFF
--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -34,6 +34,7 @@ import {
 } from "../models/enums";
 import { CommandInteractionString } from "types/zone2016packets";
 import { EntityType } from "h1emu-ai";
+import { BaseEntity } from "./baseentity";
 
 export class Npc extends BaseFullCharacter {
   health: number;
@@ -238,6 +239,21 @@ export class Npc extends BaseFullCharacter {
       this.onReadyCallback(client);
       delete this.onReadyCallback;
     }
+  }
+
+  OnExplosiveHit(server: ZoneServer2016, sourceEntity: BaseEntity): void {
+    let damage = this.health + this.health / 2;
+
+    const distance = getDistance(
+      sourceEntity.state.position,
+      this.state.position
+    );
+    if (distance > 5) return;
+    if (distance > 1) damage /= distance;
+    this.damage(server, {
+      entity: sourceEntity.characterId,
+      damage: damage
+    });
   }
 
   OnProjectileHit(server: ZoneServer2016, damageInfo: DamageInfo) {


### PR DESCRIPTION
### TL;DR
Added explosive damage handling for NPCs

### What changed?
Added a new `OnExplosiveHit` method to the NPC class that calculates and applies explosive damage based on distance from the explosion source. The damage scales with the NPC's health and decreases with distance from the explosion.

### How to test?
1. Spawn an NPC in the game
2. Place an explosive near the NPC
3. Detonate the explosive
4. Verify that:
   - NPCs within 5 units take damage
   - Damage decreases with distance
   - No damage is dealt beyond 5 units
   - Base damage is 150% of the NPC's health

### Why make this change?
To implement proper explosive damage handling for NPCs, making the game more realistic and providing appropriate damage scaling based on proximity to explosions.