### PR TITLE
DTO explosive damages

### DIFF
--- a/src/servers/ZoneServer2016/entities/destroyable.ts
+++ b/src/servers/ZoneServer2016/entities/destroyable.ts
@@ -13,10 +13,11 @@
 import { ZoneServer2016 } from "../zoneserver";
 import { ZoneClient2016 } from "../classes/zoneclient";
 import { DamageInfo } from "../../../types/zoneserver";
-import { eul2quat } from "../../../utils/utils";
+import { eul2quat, getDistance } from "../../../utils/utils";
 import { Effects, ModelIds } from "../models/enums";
 import { AddLightweightNpc, AddSimpleNpc } from "types/zone2016packets";
 import { BaseSimpleNpc } from "./basesimplenpc";
+import { BaseEntity } from "./baseentity";
 
 function getDestroyedModels(actorModelId: ModelIds): number[] {
   switch (actorModelId) {
@@ -235,6 +236,19 @@ export class Destroyable extends BaseSimpleNpc {
       },
       attachedObject: {}
     };
+  }
+
+  OnExplosiveHit(server: ZoneServer2016, sourceEntity: BaseEntity): void {
+    const distance = getDistance(
+      sourceEntity.state.position,
+      this.state.position
+    );
+    if (distance > 5) return;
+
+    this.damage(server, {
+      entity: sourceEntity.characterId,
+      damage: this.health
+    });
   }
 
   /* eslint-disable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
### TL;DR
Added explosive damage handling to destroyable entities

### What changed?
Added a new `OnExplosiveHit` method to the Destroyable class that allows destroyable objects to take damage from explosive sources within a 5-unit radius. When hit, the object takes damage equal to its full health, effectively destroying it.

### How to test?
1. Place a destroyable object in the game world
2. Trigger an explosive effect near the object (within 5 units)
3. Verify that the object is destroyed when within range
4. Verify that objects outside the 5-unit radius remain intact

### Why make this change?
To implement proper interaction between explosives and destructible objects in the game world, creating more dynamic and realistic environmental destruction mechanics.