### PR TITLE
add a special killfeed message when someone kill in godmode

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2665,6 +2665,11 @@ export class ZoneServer2016 extends EventEmitter {
 
   sendKillFeed(client: Client, damageInfo: DamageInfo) {
     if (client.character.characterId === damageInfo.entity) return;
+    const killerClient = this.getClientByCharId(damageInfo.entity);
+    let isInGodMode = false;
+    if (killerClient) {
+      isInGodMode = killerClient.character.isGodMode();
+    }
     this.sendDataToAllWithSpawnedEntity<CharacterKilledBy>(
       this._characters,
       client.character.characterId,
@@ -2672,7 +2677,8 @@ export class ZoneServer2016 extends EventEmitter {
 
       {
         killer: damageInfo.entity,
-        killed: client.character.characterId
+        killed: client.character.characterId,
+        isCheater: isInGodMode
       }
     );
   }


### PR DESCRIPTION
### TL;DR
Added godmode detection to kill feed messages

### What changed?
Added a check to determine if a killer is in godmode when sending kill feed messages. This information is now included in the kill feed packet through the `isCheater` flag.

### How to test?
1. Enable godmode on a character
2. Kill another player
3. Verify that the kill feed indicates the kill was performed with godmode enabled

### Why make this change?
To provide transparency when players are killed by others using godmode, helping identify potential cheating or abuse of admin privileges in the game.