### PR TITLE
Allow every members of a group to invite new ones

### DIFF
--- a/src/servers/ZoneServer2016/managers/groupmanager.ts
+++ b/src/servers/ZoneServer2016/managers/groupmanager.ts
@@ -262,10 +262,10 @@ export class GroupManager {
       delete this.pendingInvites[target.character.characterId];
       return;
     }
-    if (group && group.leader != source.character.characterId) {
-      server.sendAlert(source, "You are not the group leader!");
-      return;
-    }
+    // if (group && group.leader != source.character.characterId) {
+    //   server.sendAlert(source, "You are not the group leader!");
+    //   return;
+    // }
 
     this.pendingInvites[target.character.characterId] =
       source.character.groupId;


### PR DESCRIPTION
### TL;DR
Removed group leader validation check when inviting players to a group

### What changed?
Commented out the code block that validates whether a player is the group leader before allowing them to send group invites

### How to test?
1. Join a group as a non-leader member
2. Attempt to invite another player to the group
3. Verify that you can now send invites regardless of leader status

### Why make this change?
To allow all group members to invite other players to their group, rather than restricting this functionality to only the group leader. This creates a more collaborative group management experience.