### PR TITLE
Display an alert when an invited player is already in a group

### DIFF
--- a/src/servers/ZoneServer2016/managers/groupmanager.ts
+++ b/src/servers/ZoneServer2016/managers/groupmanager.ts
@@ -238,7 +238,13 @@ export class GroupManager {
       return;
     }
 
-    if (target.character.groupId != 0) return;
+    if (target.character.groupId != 0) {
+      server.sendAlert(
+        source,
+        `${target.character.name} is already in a group!`
+      );
+      return;
+    }
 
     if (source == target) {
       server.sendAlert(source, "You can't invite yourself to group!");


### PR DESCRIPTION
### TL;DR
Added an alert message when attempting to invite a player who is already in a group

### What changed?
Added a notification that informs players when they try to invite someone who is already in a group, displaying the target player's name in the message

### How to test?
1. Join a group with one character
2. Using another character, try to invite the grouped character
3. Verify you receive the message "[player name] is already in a group!"

### Why make this change?
Previously, attempting to invite a player who was already in a group would silently fail, providing no feedback to the player. This change improves user experience by clearly communicating why the invite action failed.