### PR TITLE
add h1emu crate in rotation

### DIFF
--- a/src/servers/ZoneServer2016/managers/rewardmanager.ts
+++ b/src/servers/ZoneServer2016/managers/rewardmanager.ts
@@ -30,15 +30,15 @@ export class RewardManager {
     this.rewards = [
       {
         itemId: AccountItems.REWARD_CRATE_MARAUDER,
-        dropChances: 25
+        dropChances: 20
       },
       {
         itemId: AccountItems.REWARD_CRATE_SHOWDOWN,
-        dropChances: 25
+        dropChances: 20
       },
       {
         itemId: AccountItems.REWARD_CRATE_INVITATIONAL,
-        dropChances: 25
+        dropChances: 20
       },
       {
         itemId: AccountItems.REWARD_CRATE_INFERNAL,
@@ -50,7 +50,7 @@ export class RewardManager {
       },
       {
         itemId: AccountItems.REWARD_CRATE_PREDATOR,
-        dropChances: 25
+        dropChances: 20
       },
       {
         itemId: AccountItems.REWARD_CRATE_EZW,
@@ -86,7 +86,7 @@ export class RewardManager {
       },
       {
         itemId: AccountItems.REWARD_CRATE_H1EMU,
-        dropChances: 0
+        dropChances: 20
       },
       {
         itemId: AccountItems.REWARD_CRATE_H1EMUEX,


### PR DESCRIPTION
### TL;DR
Adjusted drop chances for various reward crates and enabled the H1EMU crate

### What changed?
- Reduced drop chances from 25 to 20 for Marauder, Showdown, Invitational, and Predator crates
- Enabled H1EMU crate by changing its drop chance from 0 to 20

### How to test?
1. Launch the game
2. Play matches to earn reward crates
3. Verify the H1EMU crate can now be obtained
4. Confirm the adjusted drop rates for affected crates are working as intended

### Why make this change?
To balance the reward distribution system and introduce the H1EMU crate into the active reward pool, providing players with more variety in their potential rewards.