### PR TITLE
Update assets hashs

### DIFF
--- a/data/2016/dataSources/AllowedFileHashes.json
+++ b/data/2016/dataSources/AllowedFileHashes.json
@@ -1025,7 +1025,8 @@
   },
   {
     "file_name": "Assets_256.pack",
-    "crc32_hash": "062ad019"
+    "crc32_hash": "34babd51",
+    "old_crc32_hash": "062ad019"
   },
   {
     "file_name": "Assets_257.pack",


### PR DESCRIPTION
### TL;DR
Updated CRC32 hash for Assets_256.pack file

### What changed?
Modified the CRC32 hash value for Assets_256.pack from `062ad019` to `34babd51` in the allowed file hashes configuration

### How to test?
1. Verify that Assets_256.pack loads correctly with the new hash
2. Confirm no file integrity errors are reported when loading Assets_256.pack
3. Ensure game assets dependent on Assets_256.pack display properly

### Why make this change?
The asset pack file was legitimately modified, requiring an update to its corresponding hash to maintain proper file validation and prevent false integrity check failures