### PR TITLE
add old_crc32_hash option

### DIFF
--- a/src/servers/ZoneServer2016/managers/fairplaymanager.ts
+++ b/src/servers/ZoneServer2016/managers/fairplaymanager.ts
@@ -44,6 +44,7 @@ import {
 } from "../models/enums";
 import { ZoneServer2016 } from "../zoneserver";
 import { FileHash } from "types/shared";
+import { server } from "typescript";
 
 const encryptedData = require("../../../../data/2016/encryptedData/encryptedData.json"),
   fairPlayData = require("../../../../data/2016/encryptedData/fairPlayData.json"),
@@ -736,8 +737,13 @@ export class FairPlayManager {
   }
 
   validateFile(file1: FileHash, file2: FileHash) {
+    if (file1.file_name != file2.file_name) {
+      return false;
+    }
     return (
-      file1.file_name == file2.file_name && file1.crc32_hash == file2.crc32_hash
+      file1.crc32_hash == file2.crc32_hash ||
+      file1.old_crc32_hash == file2.crc32_hash ||
+      file2.old_crc32_hash == file1.crc32_hash
     );
   }
 
@@ -760,45 +766,45 @@ export class FairPlayManager {
       validatedHashes: Array<FileHash> = [];
 
     // check if all default / required packs are found in game files
-    for (const value of hashes) {
-      if (!value) continue;
+    for (const serverValue of hashes) {
+      if (!serverValue) continue;
       let received: FileHash | undefined;
       if (
         receivedHashes.find((clientValue) => {
           received = clientValue;
-          return this.validateFile(value, clientValue);
+          return this.validateFile(serverValue, clientValue);
         })
       ) {
-        validatedHashes.push(value);
+        validatedHashes.push(serverValue);
         continue;
       }
       console.log(
-        `${client.loginSessionId} (${client.character.name}) failed asset integrity check due to missing or invalid file ${value.file_name} received: ${received?.crc32_hash} expected: ${value.crc32_hash}`
+        `${client.loginSessionId} (${client.character.name}) failed asset integrity check due to missing or invalid file ${serverValue.file_name} received: ${received?.crc32_hash} expected: ${serverValue.crc32_hash}`
       );
       server.kickPlayerWithReason(
         client,
-        `Failed asset integrity check - Missing or invalid file: ${value.file_name}`
+        `Failed asset integrity check - Missing or invalid file: ${serverValue.file_name}`
       );
       return;
     }
 
-    for (const value of receivedHashes) {
+    for (const clientValue of receivedHashes) {
       if (
-        validatedHashes.find((clientValue) =>
-          this.validateFile(value, clientValue)
+        validatedHashes.find((serverValue) =>
+          this.validateFile(clientValue, serverValue)
         ) ||
-        this.allowedPacks.find((clientValue) =>
-          this.validateFile(value, clientValue)
+        this.allowedPacks.find((serverValue) =>
+          this.validateFile(clientValue, serverValue)
         )
       ) {
         continue;
       }
       console.log(
-        `Unauthorized file on client: ${client.loginSessionId} - ${value.file_name}: ${value.crc32_hash}`
+        `Unauthorized file on client: ${client.loginSessionId} - ${clientValue.file_name}: ${clientValue.crc32_hash}`
       );
       server.kickPlayerWithReason(
         client,
-        `Failed asset integrity check - Unauthorized file: ${value.file_name}`
+        `Failed asset integrity check - Unauthorized file: ${clientValue.file_name}`
       );
       return;
     }

--- a/src/servers/ZoneServer2016/managers/fairplaymanager.ts
+++ b/src/servers/ZoneServer2016/managers/fairplaymanager.ts
@@ -44,7 +44,6 @@ import {
 } from "../models/enums";
 import { ZoneServer2016 } from "../zoneserver";
 import { FileHash } from "types/shared";
-import { server } from "typescript";
 
 const encryptedData = require("../../../../data/2016/encryptedData/encryptedData.json"),
   fairPlayData = require("../../../../data/2016/encryptedData/fairPlayData.json"),

--- a/src/types/shared.ts
+++ b/src/types/shared.ts
@@ -36,6 +36,7 @@ export type json = any;
 export interface FileHash {
   file_name: string,
   crc32_hash: string;
+  old_crc32_hash?: string;
 }
 
 interface FileHashList {


### PR DESCRIPTION
### TL;DR
Added support for legacy file hash validation in the fair play system.

### What changed?
- Added `old_crc32_hash` as an optional property to the `FileHash` interface
- Modified `validateFile` function to accept both current and legacy hash values when comparing files
- Renamed parameters in `validateFile` for better clarity (`file1`/`file2` → `serverFile`/`clientFile`)
- Added explicit filename comparison check before hash validation

### How to test?
1. Launch the game client with files that have legacy hash values
2. Verify that the fair play system accepts both current and legacy hash values
3. Confirm that no false positives occur during file validation

### Why make this change?
Some legitimate game files may have different hash values due to previous versions or patches. This change prevents false positives in the fair play system by accepting both current and legacy hash values while maintaining security.