### PR TITLE
Adapt scale on placement ( usefull for barricades )

### DIFF
--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -579,6 +579,7 @@ export class ConstructionManager {
     modelId: number,
     position: Float32Array,
     rotation: Float32Array,
+    scale: Float32Array,
     parentObjectCharacterId: string,
     BuildingSlot: string
   ) {
@@ -693,6 +694,7 @@ export class ConstructionManager {
         modelId,
         position,
         rotation,
+        scale,
         parentObjectCharacterId,
         BuildingSlot,
         freeplaceParentCharacterId
@@ -714,6 +716,7 @@ export class ConstructionManager {
     modelId: number,
     position: Float32Array,
     rotation: Float32Array,
+    scale: Float32Array,
     parentObjectCharacterId: string,
     BuildingSlot: string,
     freeplaceParentCharacterId?: string
@@ -914,6 +917,7 @@ export class ConstructionManager {
           modelId,
           position,
           rotation,
+          scale,
           freeplaceParentCharacterId ?? "",
           itemDefinitionId
         );
@@ -1754,6 +1758,7 @@ export class ConstructionManager {
     modelId: number,
     position: Float32Array,
     rotation: Float32Array,
+    scale: Float32Array,
     parentObjectCharacterId: string,
     itemDefinitionId: number
   ) {
@@ -1770,6 +1775,8 @@ export class ConstructionManager {
         parentObjectCharacterId,
         ""
       );
+
+    construction.scale = scale;
 
     const parent = construction.getParent(server);
     if (parent) {

--- a/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
+++ b/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
@@ -637,6 +637,7 @@ export class WorldObjectManager {
               propType.modelId,
               new Float32Array(propInstance.position),
               new Float32Array(fixEulerOrder(propInstance.rotation)),
+              new Float32Array([1, 1, 1, 1]),
               server._serverGuid,
               Items.WORKBENCH
             );

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -2055,6 +2055,8 @@ export class ZonePacketHandlers {
       );
       return;
     }
+
+    const scale = packet.data.scale || new Float32Array([1, 1, 1, 1]);
     server.constructionManager.placement(
       server,
       client,
@@ -2062,6 +2064,7 @@ export class ZonePacketHandlers {
       modelId,
       packet.data.position2,
       final,
+      scale,
       packet.data.parentObjectCharacterId || "",
       packet.data.BuildingSlot || ""
     );


### PR DESCRIPTION
### TL;DR
Added scale parameter support for construction placement

### What changed?
- Added scale parameter to construction placement methods
- Implemented default scale value of [1, 1, 1, 1] for existing construction objects
- Modified construction manager to handle scale values during object creation
- Updated world object manager to include scale parameter when creating props

### How to test?
1. Place construction objects in-game
2. Verify objects appear with correct scaling
3. Test existing props and workbenches to ensure they maintain default 1:1 scale
4. Validate that custom scale values are properly applied when specified

### Why make this change?
To support dynamic scaling of construction objects, allowing for more flexible and diverse building options. This enhancement enables proper size adjustments during object placement while maintaining compatibility with existing construction systems through default scaling values.