### PR TITLE
fix placement model position

### DIFF
--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -2039,7 +2039,7 @@ export class ZonePacketHandlers {
     } else {
       final = new Float32Array([euler[2], 0, 0, 0]);
     }
-    if (Number(final[0].toFixed(2)) === 0.0) {
+    if (Math.abs(final[0]) < 0.01) {
       final[0] = 0;
     }
     const modelId = server.getItemDefinition(


### PR DESCRIPTION
### TL;DR
Improved rotation angle comparison precision in zone packet handling

### What changed?
Replaced direct float comparison (`Number(final[0].toFixed(2)) === 0.0`) with a more precise absolute value check (`Math.abs(final[0]) < 0.01`) for rotation angle validation

### How to test?
1. Place or rotate objects in-game that have small rotation angles
2. Verify that objects with rotation angles less than 0.01 are properly set to 0
3. Confirm that objects with rotation angles greater than 0.01 maintain their original rotation values

### Why make this change?
Using absolute value comparison with a small threshold is more reliable for floating-point number comparisons than direct equality checks after rounding. This prevents potential floating-point precision issues and provides more accurate rotation handling.