### PR TITLE
Use randomInt from node:crypto

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -33,6 +33,7 @@ import { Resolver } from "node:dns";
 import { ZoneClient2016 } from "servers/ZoneServer2016/classes/zoneclient";
 import * as crypto from "crypto";
 import { ZoneClient } from "servers/ZoneServer2015/classes/zoneclient";
+import { randomInt } from "node:crypto";
 
 const startTime = Date.now();
 
@@ -403,7 +404,9 @@ export function getDifference(s1: string, s2: string) {
  */
 export const randomIntFromInterval = (min: number, max: number) => {
   // min and max included
-  return Math.floor(Math.random() * (max - min + 1) + min);
+  // old code
+  // return Math.floor(Math.random() * (max - min + 1) + min);
+  return randomInt(min, max);
 };
 
 /**


### PR DESCRIPTION
### TL;DR
Replaced Math.random() with Node's crypto.randomInt() for generating random numbers

### What changed?
Updated the `randomIntFromInterval` utility function to use the more cryptographically secure `randomInt` from Node's crypto module instead of Math.random()

### How to test?
1. Call `randomIntFromInterval` with min and max values
2. Verify numbers are generated within the specified range
3. Run multiple times to ensure randomness is maintained

### Why make this change?
Math.random() is not cryptographically secure and can be predictable. Using crypto.randomInt() provides better randomization and security for generating random numbers, which is important for any security-sensitive operations or when true randomness is required.