### PR TITLE
/challenge command

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -80,6 +80,17 @@ export const commands: Array<Command> = [
     }
   },
   {
+    name: "challenge",
+    permissionLevel: PermissionLevels.DEFAULT,
+    execute: async (
+      server: ZoneServer2016,
+      client: Client,
+      args: Array<string>
+    ) => {
+      server.challengeManager.displayChallengeInfos(client);
+    }
+  },
+  {
     name: "stats",
     permissionLevel: PermissionLevels.DEFAULT,
     execute: async (


### PR DESCRIPTION
### TL;DR
Added a new `/challenge` command to display challenge information to players

### What changed?
Added a new command that allows players to view their challenge information by typing `/challenge` in the game chat. This command has default permission level access and calls the challenge manager to display relevant challenge details.

### How to test?
1. Launch the game client
2. Log in to the game
3. Type `/challenge` in the chat
4. Verify that challenge information is displayed correctly

### Why make this change?
To provide players with an easy way to access and view their current challenge progress and information directly through the chat interface, improving game accessibility and user experience.