### PR TITLE
Add challenges logics

### DIFF
--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -35,6 +35,7 @@ import {
 import { CommandInteractionString } from "types/zone2016packets";
 import { EntityType } from "h1emu-ai";
 import { BaseEntity } from "./baseentity";
+import { ChallengeType } from "../managers/challengemanager";
 
 export class Npc extends BaseFullCharacter {
   health: number;
@@ -177,6 +178,11 @@ export class Npc extends BaseFullCharacter {
       this.flags.knockedOut = 1;
       server.worldObjectManager.createLootbag(server, this);
       if (client) {
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.ZOMBIE,
+          1
+        );
         if (!server._soloMode) {
           logClientActionToMongo(
             server._db.collection(DB_COLLECTIONS.KILLS),

--- a/src/servers/ZoneServer2016/managers/speedtreemanager.ts
+++ b/src/servers/ZoneServer2016/managers/speedtreemanager.ts
@@ -16,6 +16,7 @@ import { loadJson, randomIntFromInterval } from "../../../utils/utils";
 import { ZoneClient2016 as Client } from "../classes/zoneclient";
 import { Items, TreeIds } from "../models/enums";
 import { ZoneServer2016 } from "../zoneserver";
+import { ChallengeType } from "./challengemanager";
 
 export class SpeedTreeManager {
   /** HashMap of destroyed trees,
@@ -88,6 +89,11 @@ export class SpeedTreeManager {
             server.generateItem(Items.WEAPON_BRANCH)
           );
         }
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.BLACKBERRIES,
+          1
+        );
         destroy = true;
         count = randomIntFromInterval(
           this.minBlackberryHarvest,
@@ -146,6 +152,11 @@ export class SpeedTreeManager {
           }; // add a new tree key with random level of hitpoints
         }
         if (this._speedTreesCounter[objectId].hitPoints-- == 0) {
+          server.challengeManager.registerChallengeProgression(
+            client,
+            ChallengeType.WOOD,
+            1
+          );
           destroy = true;
           delete this._speedTreesCounter[objectId]; // If out of health destroy tree and delete its key
           itemDefId = Items.WOOD_LOG;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -256,7 +256,7 @@ import { AiManager } from "h1emu-ai";
 import { clearInterval, setInterval } from "node:timers";
 import { NavManager } from "../../utils/recast";
 import { ProjectileEntity } from "./entities/projectileentity";
-import { ChallengeManager } from "./managers/challengemanager";
+import { ChallengeManager, ChallengeType } from "./managers/challengemanager";
 
 const spawnLocations2 = require("../../../data/2016/zoneData/Z1_gridSpawns.json"),
   deprecatedDoors = require("../../../data/2016/sampleData/deprecatedDoors.json"),
@@ -2497,6 +2497,16 @@ export class ZoneServer2016 extends EventEmitter {
     if (!client.character.isAlive) return;
     if (!this.hookManager.checkHook("OnPlayerDeath", client, damageInfo))
       return;
+
+    const killerClient = this.getClientByCharId(damageInfo.entity);
+    if (killerClient) {
+      this.challengeManager.registerChallengeProgression(
+        killerClient,
+        ChallengeType.PLAYERS,
+        1
+      );
+    }
+
     for (const a in client.character._characterEffects) {
       const characterEffect = client.character._characterEffects[a];
       if (characterEffect.endCallback)


### PR DESCRIPTION
### TL;DR
Added challenge progression tracking for killing zombies, players, harvesting blackberries, and chopping trees.

### What changed?
- Added challenge progression tracking when players kill zombies
- Added challenge progression tracking when players kill other players
- Added challenge progression tracking when players harvest blackberries
- Added challenge progression tracking when players chop down trees

### How to test?
1. Kill a zombie and verify challenge progress increases
2. Kill another player and verify challenge progress increases
3. Harvest blackberries from bushes and verify challenge progress increases
4. Chop down trees and verify challenge progress increases

### Why make this change?
To implement a challenge system that tracks player progression across various in-game activities, providing players with goals and achievements to work towards during gameplay.