### PR TITLE
drop rewards for challenge completion

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -326,7 +326,10 @@ export class ChallengeManager {
     await this.challengesCollection.updateOne(query, {
       $set: { status: ChallengeStatus.DONE }
     });
-    this.affectChallenge(client);
+    this.server.rewardManager.dropReward(client);
+    setTimeout(() => {
+      this.affectChallenge(client);
+    }, 5000);
   }
 
   async affectChallenge(client: ZoneClient2016) {


### PR DESCRIPTION
### TL;DR
Added a reward drop and delay when completing challenges

### What changed?
- Added `dropReward` call when a challenge is completed
- Introduced a 5-second delay before affecting the next challenge

### How to test?
1. Complete any challenge in-game
2. Verify that rewards drop immediately
3. Confirm that the next challenge is assigned after a 5-second delay

### Why make this change?
To improve player experience by providing immediate rewards upon challenge completion and adding a brief pause before the next challenge begins, preventing challenge overlap and giving players time to collect their rewards.