### PR TITLE
Admin command to force expire challenges

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -80,6 +80,17 @@ export const commands: Array<Command> = [
     }
   },
   {
+    name: "expirechallenges",
+    permissionLevel: PermissionLevels.ADMIN,
+    execute: async (
+      server: ZoneServer2016,
+      client: Client,
+      args: Array<string>
+    ) => {
+      server.challengeManager.expireChallenges();
+    }
+  },
+  {
     name: "challenge",
     permissionLevel: PermissionLevels.DEFAULT,
     execute: async (


### PR DESCRIPTION
### TL;DR
Added new admin command `/expirechallenges` to manually expire challenges

### What changed?
Added a new command that allows administrators to manually trigger the expiration of challenges through the `challengeManager`

### How to test?
1. Log in with an admin account
2. Type `/expirechallenges` in chat
3. Verify that active challenges are expired

### Why make this change?
Provides administrators with a tool to manually expire challenges when needed, rather than waiting for the automatic expiration system. This is useful for testing and managing challenge states in the game.