### PR TITLE
Set godmode when modifying run speed to bugatti

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/internalcommands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/internalcommands.ts
@@ -138,6 +138,13 @@ export const internalCommands: Array<InternalCommand> = [
       client: Client,
       packetData: CommandRunSpeed
     ) => {
+      if (
+        packetData.runSpeed &&
+        packetData.runSpeed > 10 &&
+        !client.character.isGodMode()
+      ) {
+        server.setGodMode(client, true);
+      }
       server.sendData<CommandRunSpeed>(client, "Command.RunSpeed", {
         runSpeed: packetData.runSpeed
       });


### PR DESCRIPTION
### TL;DR
Added automatic god mode activation when players attempt to set high run speeds

### What changed?
Added a safety check that automatically enables god mode for players who set their run speed above 10 without already having god mode enabled

### How to test?
1. Join the game as a regular player
2. Attempt to set run speed above 10
3. Verify god mode is automatically enabled
4. Verify run speed changes are applied

### Why make this change?
High movement speeds without god mode can cause death.