### PR TITLE
Add challenges to config file

### DIFF
--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -21,6 +21,11 @@ rcon:
   password: ""
   port: 0
 
+# Challenges
+
+challenges:
+  enabled: true
+
 # VoiceChat
 
 voicechat:

--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -48,6 +48,8 @@ export interface ChallengeData {
 export class ChallengeManager {
   challenges: ChallengeInfo[];
   challengesCollection!: Collection<ChallengeData>;
+  // managed by config
+  enabled: boolean = true;
   constructor(public server: ZoneServer2016) {
     this.challenges = [
       {
@@ -82,7 +84,10 @@ export class ChallengeManager {
   }
 
   init(collection: Collection<ChallengeData>) {
-    this.challengesCollection = collection;
+    if (this.enabled) {
+      this.challengesCollection = collection;
+      this.scheduleExpires();
+    }
   }
 
   getChallengeInfo(type: ChallengeType): ChallengeInfo | undefined {
@@ -90,7 +95,7 @@ export class ChallengeManager {
   }
 
   async loadChallenges(client: ZoneClient2016) {
-    if (this.server._soloMode) {
+    if (this.server._soloMode || !this.enabled) {
       return;
     }
     const currentChallenge = await this.getCurrentChallengeData(client);

--- a/src/servers/ZoneServer2016/managers/configmanager.ts
+++ b/src/servers/ZoneServer2016/managers/configmanager.ts
@@ -82,6 +82,7 @@ export class ConfigManager {
     const {
       server,
       rcon,
+      challenges: challenge,
       fairplay,
       voicechat,
       weather,
@@ -101,6 +102,10 @@ export class ConfigManager {
       rcon: {
         ...rcon,
         ...config.rcon
+      },
+      challenges: {
+        ...challenge,
+        ...config.challenges
       },
       voicechat: {
         ...voicechat,
@@ -178,7 +183,11 @@ export class ConfigManager {
     server.rconManager.wssPort = port;
     server.rconManager.password = password;
 
+    //#region Challenges
+    const { enabled } = this.config.challenges;
+    server.challengeManager.enabled = enabled;
     //#endregion
+    //
     //#region voicechat
     const { useVoiceChatV2, joinVoiceChatOnConnect, serverAccessToken } =
       this.config.voicechat;

--- a/src/servers/ZoneServer2016/models/config.ts
+++ b/src/servers/ZoneServer2016/models/config.ts
@@ -137,9 +137,14 @@ interface VoiceChatConfig {
   serverAccessToken: string;
 }
 
+interface ChallengeConfig {
+  enabled: boolean;
+}
+
 export interface Config {
   server: ServerConfig;
   rcon: RconConfig;
+  challenges: ChallengeConfig;
   voicechat: VoiceChatConfig;
   fairplay: FairplayConfig;
   weather: WeatherConfig;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -508,6 +508,7 @@ export class ZoneServer2016 extends EventEmitter {
     this.playTimeManager = new PlayTimeManager();
     this.aiManager = new AiManager();
     this.navManager = new NavManager();
+    this.challengeManager = new ChallengeManager(this);
     /* CONFIG MANAGER MUST BE INSTANTIATED LAST ! */
     this.configManager = new ConfigManager(this, process.env.CONFIG_PATH);
     this.enableWorldSaves =
@@ -534,7 +535,6 @@ export class ZoneServer2016 extends EventEmitter {
     }
 
     this.accountInventoriesManager = new AccountInventoryManager(this);
-    this.challengeManager = new ChallengeManager(this);
     this.on("login", async (client) => {
       if (!this._soloMode) {
         this.sendZonePopulationUpdate();


### PR DESCRIPTION
### TL;DR
Added configuration option to enable/disable challenges system-wide

### What changed?
- Added new `challenges` section to config.yaml with `enabled` flag
- Modified ChallengeManager to respect the enabled setting
- Initialized ChallengeManager earlier in the startup sequence
- Added challenge configuration interface and integration with ConfigManager

### How to test?
1. Set `challenges.enabled: false` in config.yaml
2. Launch server and verify no challenges are loaded or available
3. Set `challenges.enabled: true` in config.yaml
4. Restart server and verify challenges system works as expected

### Why make this change?
Provides server operators more control over game features by allowing them to disable the challenges system when not needed or desired for their specific server configuration.