### PR TITLE
get offline group members

### DIFF
--- a/src/servers/ZoneServer2016/managers/groupmanager.ts
+++ b/src/servers/ZoneServer2016/managers/groupmanager.ts
@@ -40,7 +40,6 @@ export class GroupManager {
       let client = server.getClientByCharId(member);
       if (!client) {
         client = await server.getOfflineClientByCharId(member);
-        console.log(client);
       }
       const character = client?.character;
 

--- a/src/servers/ZoneServer2016/managers/groupmanager.ts
+++ b/src/servers/ZoneServer2016/managers/groupmanager.ts
@@ -33,6 +33,38 @@ export class GroupManager {
     server.sendChatText(client, `[GroupError] ${error}`);
   }
 
+  async getGroupMembers(group: Group, server: ZoneServer2016) {
+    const members = [];
+
+    for (const [index, member] of Object.values(group.members).entries()) {
+      let client = server.getClientByCharId(member);
+      if (!client) {
+        client = await server.getOfflineClientByCharId(member);
+        console.log(client);
+      }
+      const character = client?.character;
+
+      if (!client || !character) continue;
+
+      members.push({
+        characterId: member,
+        inviteData: {
+          characterId: member,
+          identity: {
+            characterFirstName: character?.name,
+            unknownQword1: member
+          }
+        },
+        unknownByte1: character.isAlive ? 0 : -1,
+        position: character?.state.position,
+        rotation: character?.state.rotation,
+        memberId: index,
+        unknownQword2: member
+      });
+    }
+    return members;
+  }
+
   async syncGroup(
     server: ZoneServer2016,
     groupId: number,
@@ -46,36 +78,14 @@ export class GroupManager {
     if (!lastSyncTime || lastSyncTime + 5000 <= now || forceSync) {
       this.groupSync[groupId] = now;
 
+      const members = await this.getGroupMembers(group, server);
       const sendData = {
         unknownDword1: group.groupId,
         unknownData1: {
           groupId: group.groupId,
           characterId: group.leader
         },
-        members: Object.values(group.members)
-          .map((member, index) => {
-            const client = server.getClientByCharId(member);
-            const character = client?.character;
-
-            if (!client || !character) return null;
-
-            return {
-              characterId: member,
-              inviteData: {
-                characterId: member,
-                identity: {
-                  characterFirstName: character?.name,
-                  unknownQword1: member
-                }
-              },
-              unknownByte1: character.isAlive ? 0 : -1,
-              position: character?.state.position,
-              rotation: character?.state.rotation,
-              memberId: index,
-              unknownQword2: member
-            };
-          })
-          .filter((m) => m !== null)
+        members
       };
 
       this.sendDataToGroup<GroupUnknown12>(
@@ -370,6 +380,7 @@ export class GroupManager {
 
     const leaderClient = server.getClientByCharId(group.leader);
     if (!leaderClient) return;
+    const members = await this.getGroupMembers(group, server);
     this.sendDataToGroup(server, group.groupId, "Group.Unknown12", {
       unknownDword1: group.groupId,
       unknownData1: {
@@ -377,30 +388,7 @@ export class GroupManager {
         characterId: leaderClient.character.characterId
       },
       unknownString1: leaderClient.character.name,
-      members: Object.values(group.members)
-        .map((member, index) => {
-          const client = server.getClientByCharId(member);
-          const character = client?.character;
-
-          if (!client || !character) return null;
-
-          return {
-            characterId: member,
-            inviteData: {
-              characterId: member,
-              identity: {
-                characterFirstName: character?.name,
-                unknownQword1: member
-              }
-            },
-            unknownByte1: character.isAlive ? 0 : -1,
-            position: character?.state.position,
-            rotation: character?.state.rotation,
-            memberId: index,
-            unknownQword2: member
-          };
-        })
-        .filter((m) => m !== null)
+      members
     });
   }
 


### PR DESCRIPTION
### TL;DR
Extracted group member data collection into a dedicated method and added support for offline client data retrieval.

### What changed?
- Created new `getGroupMembers` method to centralize group member data collection logic
- Updated `syncGroup` and other methods to use the new `getGroupMembers` function
- Changed from `getClientByCharId` to `getOfflineClientByCharId` to handle offline members
- Added proper handling of character alive status in member data

### How to test?
1. Create a group with multiple players
2. Have some players go offline
3. Verify group information updates correctly for both online and offline members
4. Check that member status (alive/dead) is displayed correctly
5. Confirm group synchronization still functions as expected

### Why make this change?
The previous implementation duplicated member data collection logic and couldn't handle offline players. This refactor improves code maintainability and adds support for tracking offline group members, providing a more complete group management system.