### PR TITLE
fix cringe typo

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -7559,7 +7559,7 @@ export class ZoneServer2016 extends EventEmitter {
             ]
           ) {
             setTimeout(() => {
-              this.sendChatText(client, "You will died of an heart attack.");
+              this.sendChatText(client, "You will die of an heart attack.");
             }, 2000);
             setTimeout(() => {
               this.killCharacter(client, {


### PR DESCRIPTION
### TL;DR
Fixed a grammatical error in the heart attack death message.

### What changed?
Changed the message "You will died of an heart attack" to "You will die of an heart attack"

### How to test?
1. Trigger the conditions that cause a heart attack death
2. Verify the message displays correctly with proper grammar

### Why make this change?
The original message contained incorrect grammar using "died" instead of "die" in future tense, making the message confusing to players.