### PR TITLE
allow /emote

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -396,11 +396,6 @@ export const commands: Array<Command> = [
     name: "emote",
     permissionLevel: PermissionLevels.DEFAULT,
     execute: (server: ZoneServer2016, client: Client, args: Array<string>) => {
-      server.sendChatText(
-        client,
-        "[ERROR] This emote has been disabled due to abuse."
-      );
-      return;
       const animationId = Number(args[0]);
       if (!animationId || animationId > MAX_UINT32) {
         server.sendChatText(client, "Usage /emote <id>");
@@ -408,15 +403,15 @@ export const commands: Array<Command> = [
       }
 
       // may need to disable more
-      switch (animationId) {
-        case 35:
-        case 97:
-          server.sendChatText(
-            client,
-            "[ERROR] This emote has been disabled due to abuse."
-          );
-          return;
-      }
+      // switch (animationId) {
+      //   case 35:
+      //   case 97:
+      //     server.sendChatText(
+      //       client,
+      //       "[ERROR] This emote has been disabled due to abuse."
+      //     );
+      //     return;
+      // }
 
       server.sendDataToAllWithSpawnedEntity(
         server._characters,


### PR DESCRIPTION
### TL;DR

Re-enabled the `/emote` command that was previously disabled.

### What changed?

- Removed the code block that was preventing all emotes from being used
- Commented out the switch statement that was specifically blocking emote IDs 35 and 97
- The command now allows players to use all emotes without restrictions

### How to test?

1. Log into the game
2. Use the `/emote` command with different animation IDs
3. Verify that previously disabled emotes (including IDs 35 and 97) now work properly

### Why make this change?

The emote command was previously disabled due to potential abuse. This change restores functionality to allow players to express themselves through emotes, improving the social experience in the game.