### PR TITLE
block some emotes due to abuse

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -402,16 +402,32 @@ export const commands: Array<Command> = [
         return;
       }
 
-      // may need to disable more
-      // switch (animationId) {
-      //   case 35:
-      //   case 97:
-      //     server.sendChatText(
-      //       client,
-      //       "[ERROR] This emote has been disabled due to abuse."
-      //     );
-      //     return;
-      // }
+      if (!server.isPvE) {
+        switch (animationId) {
+          case 18:
+          case 21:
+          case 29:
+          case 30:
+          case 39:
+          case 88:
+          case 34:
+          case 35:
+          case 43:
+          case 46:
+          case 51:
+          case 58:
+          case 68:
+          case 95:
+          case 97:
+          case 101:
+          case 102:
+            server.sendChatText(
+              client,
+              "[ERROR] This emote has been disabled due to abuse."
+            );
+            return;
+        }
+      }
 
       server.sendDataToAllWithSpawnedEntity(
         server._characters,


### PR DESCRIPTION
### TL;DR

Disabled specific emotes on non-PvE servers to prevent abuse.

### What changed?

Uncommented and expanded the emote restriction code to block 17 specific animation IDs (18, 21, 29, 30, 39, 88, 34, 35, 43, 46, 51, 58, 68, 95, 97, 101, 102) from being used on PvP servers. These restrictions only apply when `server.isPvE` is false, allowing all emotes to remain available on PvE servers.

### How to test?

1. Join a PvP server and attempt to use any of the restricted emotes - you should receive an error message: "[ERROR] This emote has been disabled due to abuse."
2. Join a PvE server and verify that all emotes work without restriction.

### Why make this change?

Certain emotes were being exploited on PvP servers to gain unfair advantages or to grief other players. This change prevents abuse while maintaining the full emote experience on PvE servers where competitive advantages are less of a concern.