### PR TITLE
add challenge difficulty

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -28,8 +28,14 @@ export enum ChallengeStatus {
   DONE = 2,
   TIMED_OUT = 3
 }
+export enum ChallengeDifficulty {
+  EASY = 1,
+  MEDIUM = 2,
+  HARD = 3
+}
 export interface ChallengeInfo {
   type: ChallengeType;
+  difficulty: ChallengeDifficulty;
   name: string;
   description: string;
   neededPoints: number;
@@ -54,6 +60,7 @@ export class ChallengeManager {
     this.challenges = [
       {
         type: ChallengeType.WOOD,
+        difficulty: ChallengeDifficulty.EASY,
         name: "wood",
         description: "Cut 2 trees",
         neededPoints: 2,
@@ -61,6 +68,7 @@ export class ChallengeManager {
       },
       {
         type: ChallengeType.ZOMBIE,
+        difficulty: ChallengeDifficulty.EASY,
         name: "zombie",
         description: "Kill 10 zombies",
         neededPoints: 10,
@@ -68,6 +76,7 @@ export class ChallengeManager {
       },
       // {
       //   type: ChallengeType.PLAYERS,
+      //   difficulty: ChallengeDifficulty.EASY,
       //   name: "players",
       //   description: "Kill 2 players",
       //   neededPoints: 2,
@@ -75,6 +84,7 @@ export class ChallengeManager {
       // },
       {
         type: ChallengeType.BLACKBERRIES,
+        difficulty: ChallengeDifficulty.EASY,
         name: "blackberries",
         description: "Harvest 3 blackberries",
         neededPoints: 3,


### PR DESCRIPTION
### TL;DR

Added difficulty level to challenges in the challenge manager.

### What changed?

- Created a new `ChallengeDifficulty` enum with three levels: EASY, MEDIUM, and HARD
- Added a `difficulty` property to the `ChallengeInfo` interface
- Set all existing challenges to `ChallengeDifficulty.EASY`

### How to test?

1. Run the server and verify that challenges work as expected
2. Check that the difficulty property is properly assigned to each challenge
3. Verify that the challenge system continues to function with this new property

### Why make this change?

This change lays the groundwork for implementing difficulty-based challenge selection and rewards. By categorizing challenges by difficulty, we can create a more engaging progression system for players and potentially adjust rewards based on the challenge difficulty level.