### PR TITLE
create a var for challenge per day

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -54,6 +54,8 @@ export interface ChallengeData {
 export class ChallengeManager {
   challenges: ChallengeInfo[];
   challengesCollection!: Collection<ChallengeData>;
+  // TODO: add to config
+  challengesPerDay: number = 3;
   // managed by config
   enabled: boolean = true;
   constructor(public server: ZoneServer2016) {
@@ -169,7 +171,7 @@ export class ChallengeManager {
       const challengeData = await this.getCurrentChallengeData(client);
       message = `Challenge "${cInfos.name}": ${cInfos.description} \n Progression: ${challengeData?.points}/${cInfos.neededPoints}`;
     } else {
-      message = "No more challenges for today.";
+      message = `No more challenges for today. (${this.challengesPerDay / this.challengesPerDay})`;
     }
     this.server.sendAlert(client, message);
   }
@@ -239,7 +241,7 @@ export class ChallengeManager {
         playerGuid: client.loginSessionId
       })
       .toArray();
-    if (challengesToday.length >= 3) {
+    if (challengesToday.length >= this.challengesPerDay) {
       client.character.currentChallenge = ChallengeType.NONE;
       this.displayChallengeInfos(client);
       return;


### PR DESCRIPTION
### TL;DR

Added a configurable limit for daily challenges and fixed the "no more challenges" message.

### What changed?

- Added a `challengesPerDay` property to the `ChallengeManager` class with a default value of 3
- Updated the challenge limit check to use this new property instead of the hardcoded value
- Fixed the "No more challenges for today" message to display the correct ratio of completed challenges

### How to test?

1. Complete challenges until you reach the daily limit
2. Verify that the "No more challenges for today" message displays correctly
3. Modify the `challengesPerDay` value and verify that the new limit is enforced

### Why make this change?

This change makes the daily challenge limit configurable rather than hardcoded, allowing for easier adjustment of game difficulty and progression. It also fixes a display issue in the "no more challenges" message that was showing incorrect information to players.