### PR TITLE
implement new challenges

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -565,6 +565,11 @@ export class Character2016 extends BaseFullCharacter {
         client.character._resources[ResourceIds.STAMINA] -= 14;
         break;
       case energy <= 3501 && energy > 2601:
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.TIRED_BUDDY,
+          1
+        );
         desiredEnergyIndicator = ResourceIndicators.TIRED;
         break;
       case energy > 3501:
@@ -769,6 +774,13 @@ export class Character2016 extends BaseFullCharacter {
       ResourceTypes.VIRUS,
       virus
     );
+    if (stamina <= 2) {
+      server.challengeManager.registerChallengeProgression(
+        client,
+        ChallengeType.CARDIO_ISSUES,
+        1
+      );
+    }
     this.updateResource(
       server,
       client,

--- a/src/servers/ZoneServer2016/entities/lootableprop.ts
+++ b/src/servers/ZoneServer2016/entities/lootableprop.ts
@@ -18,6 +18,7 @@ import { StringIds, Items, ModelIds } from "../models/enums";
 import { DamageInfo } from "types/zoneserver";
 import { randomIntFromInterval } from "../../../utils/utils";
 import { AddSimpleNpc } from "types/zone2016packets";
+import { ChallengeType } from "../managers/challengemanager";
 
 function getContainerAndTime(entity: LootableProp) {
   switch (entity.actorModelId) {
@@ -361,6 +362,11 @@ export class LootableProp extends BaseLootableEntity {
             client.character.lootItem(
               server,
               server.generateItem(Items.METAL_SCRAP)
+            );
+            server.challengeManager.registerChallengeProgression(
+              client,
+              ChallengeType.RECYCLING,
+              1
             );
             server.lootCrateWithChance(client, 2);
           }

--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -180,7 +180,7 @@ export class Npc extends BaseFullCharacter {
       if (client) {
         server.challengeManager.registerChallengeProgression(
           client,
-          ChallengeType.ZOMBIE,
+          ChallengeType.BRAIN_DEAD,
           1
         );
         if (!server._soloMode) {

--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -17,11 +17,22 @@ import { ZoneServer2016 } from "../zoneserver";
 import { Collection } from "mongodb";
 
 export enum ChallengeType {
-  NONE = 0,
-  WOOD = 1,
-  ZOMBIE = 2,
-  PLAYERS = 3,
-  BLACKBERRIES = 4
+  NONE,
+  TREE_HATER,
+  NO_WASTE,
+  DAWN_ITS_TASTY,
+  CARDIO_ISSUES,
+  BRAIN_DEAD,
+  RECYCLING,
+  MY_HOME,
+  TIRED_BUDDY,
+  LIGHTER,
+  MY_LAND,
+  PV_PD_SURVIVAL,
+  GLOBAL_DISARMAMENT,
+  ROCKY,
+  ROCKSTAR,
+  IED
 }
 export enum ChallengeStatus {
   CURRENT = 1,
@@ -55,41 +66,130 @@ export class ChallengeManager {
   challenges: ChallengeInfo[];
   challengesCollection!: Collection<ChallengeData>;
   // TODO: add to config
-  challengesPerDay: number = 3;
+  challengesPerDay: number = 6;
   // managed by config
   enabled: boolean = true;
   constructor(public server: ZoneServer2016) {
     this.challenges = [
       {
-        type: ChallengeType.WOOD,
+        type: ChallengeType.TREE_HATER,
         difficulty: ChallengeDifficulty.EASY,
-        name: "wood",
-        description: "Cut 2 trees",
-        neededPoints: 2,
-        pvpOnly: false
-      },
-      {
-        type: ChallengeType.ZOMBIE,
-        difficulty: ChallengeDifficulty.MEDIUM,
-        name: "zombie",
-        description: "Kill 10 zombies",
+        name: "Tree hater",
+        description: "Cut 10 trees",
         neededPoints: 10,
         pvpOnly: false
       },
+      {
+        type: ChallengeType.NO_WASTE,
+        difficulty: ChallengeDifficulty.EASY,
+        name: "No waste",
+        description: "Repair a gun",
+        neededPoints: 1,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.DAWN_ITS_TASTY,
+        difficulty: ChallengeDifficulty.EASY,
+        name: "Dawn it's tasty",
+        description: "Harvest 40 blackberries",
+        neededPoints: 40,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.CARDIO_ISSUES,
+        difficulty: ChallengeDifficulty.EASY,
+        name: "Cardio deficiency detected",
+        description: "Run out of stamina",
+        neededPoints: 1,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.BRAIN_DEAD,
+        difficulty: ChallengeDifficulty.MEDIUM,
+        name: "They're brain-dead anyway",
+        description: "Kill 50 zombies",
+        neededPoints: 50,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.RECYCLING,
+        difficulty: ChallengeDifficulty.MEDIUM,
+        name: "RECYCLING",
+        description: "Get 40 scraps from vehicles",
+        neededPoints: 40,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.MY_HOME,
+        difficulty: ChallengeDifficulty.MEDIUM,
+        name: "This is my home",
+        description: "Craft a shack",
+        neededPoints: 1,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.TIRED_BUDDY,
+        difficulty: ChallengeDifficulty.MEDIUM,
+        name: "Tired buddy",
+        description: "Survive until being tired",
+        neededPoints: 1,
+        pvpOnly: false
+      },
+      // Too easy to abuse rn
       // {
-      //   type: ChallengeType.PLAYERS,
-      //   difficulty: ChallengeDifficulty.EASY,
-      //   name: "players",
-      //   description: "Kill 2 players",
-      //   neededPoints: 2,
-      //   pvpOnly:true
+      //   type: ChallengeType.LIGHTER,
+      //   difficulty: ChallengeDifficulty.MEDIUM,
+      //   name: "You light up my life",
+      //   description: "Find 10 lighters",
+      //   neededPoints: 10,
+      //   pvpOnly: false
       // },
       {
-        type: ChallengeType.BLACKBERRIES,
+        type: ChallengeType.MY_LAND,
+        difficulty: ChallengeDifficulty.MEDIUM,
+        name: "My land!",
+        description: "Craft a deck foundation",
+        neededPoints: 1,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.PV_PD_SURVIVAL,
         difficulty: ChallengeDifficulty.HARD,
-        name: "blackberries",
-        description: "Harvest 3 blackberries",
-        neededPoints: 3,
+        name: "Proving a point",
+        description: "Survive 30 minutes in pv pd",
+        neededPoints: 30,
+        pvpOnly: true
+      },
+      {
+        type: ChallengeType.GLOBAL_DISARMAMENT,
+        difficulty: ChallengeDifficulty.HARD,
+        name: "GLOBAL DISARMAMENT",
+        description: "Fire 60 bullets of any gun",
+        neededPoints: 60,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.ROCKY,
+        difficulty: ChallengeDifficulty.HARD,
+        name: "Rocky",
+        description: "Kill 2 players with your fists",
+        neededPoints: 2,
+        pvpOnly: true
+      },
+      {
+        type: ChallengeType.ROCKSTAR,
+        difficulty: ChallengeDifficulty.HARD,
+        name: "Rockstar!!!",
+        description: "Kill someone with a guitar",
+        neededPoints: 1,
+        pvpOnly: true
+      },
+      {
+        type: ChallengeType.IED,
+        difficulty: ChallengeDifficulty.HARD,
+        name: "Let's blow this joint",
+        description: "Craft 15 IEDS",
+        neededPoints: 15,
         pvpOnly: false
       }
     ];

--- a/src/servers/ZoneServer2016/managers/craftmanager.ts
+++ b/src/servers/ZoneServer2016/managers/craftmanager.ts
@@ -19,6 +19,7 @@ import { Recipe } from "types/zoneserver";
 import { Character2016 } from "../entities/character";
 import { BaseItem } from "../classes/baseItem";
 import { BaseLootableEntity } from "../entities/baselootableentity";
+import { ChallengeType } from "./challengemanager";
 const debug = require("debug")("ZoneServer");
 
 interface CraftComponentDSEntry {
@@ -515,6 +516,27 @@ export class CraftManager {
       recipe.leftOverItems.forEach((id: number) => {
         client.character.lootItem(server, server.generateItem(id, 1));
       });
+    }
+    if (recipeId === Items.IED) {
+      server.challengeManager.registerChallengeProgression(
+        client,
+        ChallengeType.IED,
+        1
+      );
+    }
+    if (recipeId === Items.FOUNDATION) {
+      server.challengeManager.registerChallengeProgression(
+        client,
+        ChallengeType.MY_LAND,
+        1
+      );
+    }
+    if (recipeId === Items.SHACK) {
+      server.challengeManager.registerChallengeProgression(
+        client,
+        ChallengeType.MY_HOME,
+        1
+      );
     }
     return true;
     //#endregion

--- a/src/servers/ZoneServer2016/managers/speedtreemanager.ts
+++ b/src/servers/ZoneServer2016/managers/speedtreemanager.ts
@@ -91,7 +91,7 @@ export class SpeedTreeManager {
         }
         server.challengeManager.registerChallengeProgression(
           client,
-          ChallengeType.BLACKBERRIES,
+          ChallengeType.DAWN_ITS_TASTY,
           1
         );
         destroy = true;
@@ -154,7 +154,7 @@ export class SpeedTreeManager {
         if (this._speedTreesCounter[objectId].hitPoints-- == 0) {
           server.challengeManager.registerChallengeProgression(
             client,
-            ChallengeType.WOOD,
+            ChallengeType.TREE_HATER,
             1
           );
           destroy = true;


### PR DESCRIPTION
### TL;DR

Added new challenge types and progression tracking for various player activities.

### What changed?

- Expanded the `ChallengeType` enum with 16 new challenge types (up from 5)
- Increased daily challenges from 3 to 6
- Added challenge progression tracking for:
  - Being tired (energy level tracking)
  - Running out of stamina
  - Recycling vehicles for scrap
  - Killing zombies (renamed from ZOMBIE to BRAIN_DEAD)
  - Crafting IEDs, foundations, and shacks
  - Killing players with fists or guitar
  - Firing bullets
  - Surviving in PV PD area
  - Repairing guns

### How to test?

1. Perform various activities to trigger challenge progression:
   - Run until stamina is depleted
   - Stay alive until energy drops to "tired" level
   - Recycle vehicles for scrap
   - Kill zombies
   - Craft IEDs, foundations, and shacks
   - Kill players with fists or guitar
   - Fire bullets
   - Stay in PV PD area
   - Repair guns
2. Verify challenge progression is tracked correctly
3. Check that daily challenges now show 6 challenges instead of 3

### Why make this change?

This change adds more variety and depth to the challenge system, giving players more goals to work toward and activities to complete. The expanded challenge types cover a wider range of gameplay activities, encouraging players to engage with different aspects of the game.