### PR TITLE
do not display progression if neededPoints = 1

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -269,7 +269,12 @@ export class ChallengeManager {
     let message: string;
     if (cInfos) {
       const challengeData = await this.getCurrentChallengeData(client);
-      message = `Challenge "${cInfos.name}": ${cInfos.description} \n Progression: ${challengeData?.points}/${cInfos.neededPoints}`;
+      message = `Challenge "${cInfos.name}": ${cInfos.description}`;
+      if (cInfos.neededPoints > 1) {
+        message += `\n Progression: ${challengeData?.points}/${cInfos.neededPoints}`;
+      } else {
+        message += ` Accomplished!`;
+      }
     } else {
       message = `No more challenges for today. (${this.challengesPerDay / this.challengesPerDay})`;
     }


### PR DESCRIPTION
### TL;DR

Only show challenge progression when needed points is greater than 1.

### What changed?

Modified the challenge message in `challengemanager.ts` to conditionally display the progression information. Now, the progression line (`Progression: X/Y`) will only be shown when the challenge requires more than one point to complete.

### How to test?

1. Trigger a challenge that requires only 1 point to complete
2. Verify that the progression line is not displayed in the challenge message
3. Trigger a challenge that requires multiple points to complete
4. Verify that the progression line is displayed correctly

### Why make this change?

For challenges that only require a single point to complete, showing the progression as "0/1" or "1/1" is redundant and doesn't provide meaningful information to the user. This change improves the user experience by only showing progression information when it's actually useful.