### PR TITLE
remove game-logs

### DIFF
--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -158,8 +158,7 @@ import {
 import { Vehicle2016 } from "./entities/vehicle";
 import { Plant } from "./entities/plant";
 import { ConstructionChildEntity } from "./entities/constructionchildentity";
-import { Collection } from "mongodb";
-import { DB_COLLECTIONS, GAME_LOGS_TYPES } from "../../utils/enums";
+import { DB_COLLECTIONS } from "../../utils/enums";
 import { LootableConstructionEntity } from "./entities/lootableconstructionentity";
 import { Character2016 } from "./entities/character";
 import { Crate } from "./entities/crate";
@@ -1079,12 +1078,6 @@ export class ZonePacketHandlers {
       )
     ) {
       return;
-    }
-    if (isLootable) {
-      server.registerGameLog(GAME_LOGS_TYPES.ACCESS_LOOTABLE, client, {
-        lootableCharacterId: entity.characterId,
-        containers: entity._containers
-      });
     }
     client.character.lastInteractionRequestGuid = entity.characterId;
     entity.OnPlayerSelect(server, client, packet.data.isInstant);
@@ -2247,13 +2240,6 @@ export class ZonePacketHandlers {
       if (mountedContainer.items[item.itemGuid]) {
         container = mountedContainer;
       }
-    }
-
-    if (itemUseOption) {
-      server.registerGameLog(GAME_LOGS_TYPES.ITEM_USE, client, {
-        itemUseOption: ItemUseOptions[itemUseOption],
-        item: item
-      });
     }
 
     switch (itemUseOption) {
@@ -3539,10 +3525,6 @@ export class ZonePacketHandlers {
         });
 
         if (reward > 0 && itemSubData.unknownBoolean1 == 0) {
-          server.registerGameLog(GAME_LOGS_TYPES.OPEN_CRATE, client, {
-            crateItemDefinitionId: item.itemDefinitionId,
-            rewardItemDefinitionId: reward
-          });
           setTimeout(() => {
             if (rewardResult.isRare) {
               server.sendAlertToAll(

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -144,7 +144,6 @@ import { UseOptions } from "./data/useoptions";
 import {
   CONNECTION_REJECTION_FLAGS,
   DB_COLLECTIONS,
-  GAME_LOGS_TYPES,
   GAME_VERSIONS,
   KILL_TYPE,
   LOGIN_KICK_REASON
@@ -9416,30 +9415,6 @@ export class ZoneServer2016 extends EventEmitter {
       color: status == 0 ? 1 : 0,
       status: status
     });
-  }
-  async registerGameLog(
-    logType: GAME_LOGS_TYPES,
-    client: Client,
-    gameLog: object
-  ) {
-    if (this._soloMode) {
-      return;
-    }
-    try {
-      const gameLogDocument = {
-        serverId: this._worldId,
-        time: new Date(),
-        type: logType,
-        characterName: client.character.name,
-        loginSessionId: client.loginSessionId,
-        ...gameLog
-      };
-      await this._db
-        .collection(DB_COLLECTIONS.GAME_LOGS)
-        .insertOne(gameLogDocument);
-    } catch (e: any) {
-      console.error(e);
-    }
   }
 }
 

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -43,7 +43,6 @@ export enum CUSTOM_PROFILES_IDS {
 }
 
 export enum DB_COLLECTIONS {
-  GAME_LOGS = "game-logs",
   CONSTRUCTION_LOGS = "construction-logs",
   ADMINS = "admins",
   BANNED = "banned",
@@ -78,12 +77,6 @@ export enum KILL_TYPE {
   ZOMBIE = "zombie",
   WILDLIFE = "wildlife",
   VEHICLE = "vehicle"
-}
-
-export enum GAME_LOGS_TYPES {
-  OPEN_CRATE = "open_crate",
-  ITEM_USE = "item_use",
-  ACCESS_LOOTABLE = "access_lootable"
 }
 
 export enum LOGIN_KICK_REASON {


### PR DESCRIPTION
### TL;DR

Removed game logging functionality that was tracking player actions.

### What changed?

- Removed the `registerGameLog` method from `ZoneServer2016` class
- Removed all calls to this method throughout the codebase
- Removed the `GAME_LOGS_TYPES` enum from `enums.ts`
- Removed the `GAME_LOGS` entry from the `DB_COLLECTIONS` enum
- Removed unused import of `Collection` from MongoDB

### How to test?

1. Perform actions that previously triggered logs:
   - Open crates
   - Use items with different options
   - Access lootable entities
2. Verify that the server continues to function normally
3. Check that no new entries are being added to the game-logs collection in the database

### Why make this change?

This change removes potentially unnecessary tracking of player actions, which could improve performance and reduce database storage requirements. It also simplifies the codebase by removing functionality that may no longer be needed for game operation.