### PR TITLE
add forcerandomairdrop admin command

### DIFF
--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -80,6 +80,21 @@ export const commands: Array<Command> = [
     }
   },
   {
+    name: "forcerandomairdrop",
+    permissionLevel: PermissionLevels.ADMIN,
+    execute: async (
+      server: ZoneServer2016,
+      client: Client,
+      args: Array<string>
+    ) => {
+      if (!server._airdrop) {
+        server.randomEventsManager.spawnRandomAirdrop();
+      } else {
+        server.sendAlert(client, "There is already an active airdrop");
+      }
+    }
+  },
+  {
     name: "expirechallenges",
     permissionLevel: PermissionLevels.ADMIN,
     execute: async (


### PR DESCRIPTION
### TL;DR

Added a new admin command to force spawn a random airdrop.

### What changed?

Added a new command called `forcerandomairdrop` to the commands array with admin permission level. This command allows administrators to manually trigger a random airdrop event in the game.

### How to test?

1. Log in with an admin account
2. Use the `/forcerandomairdrop` command in-game
3. Verify that a random airdrop spawns in the game world
4. Try using the command when an airdrop is already active to confirm the error message appears

### Why make this change?

This command provides administrators with the ability to manually trigger airdrops for testing purposes or to enhance gameplay during specific events without waiting for the random event system to naturally spawn one.