### PR TITLE
Display random airdrop cell name

### DIFF
--- a/src/servers/ZoneServer2016/managers/randomeventsmanager.ts
+++ b/src/servers/ZoneServer2016/managers/randomeventsmanager.ts
@@ -13,6 +13,7 @@
 
 import { randomInt } from "node:crypto";
 import { ZoneServer2016 } from "../zoneserver";
+import { getCellName } from "../../../utils/utils";
 
 export class RandomEventsManager {
   interval?: NodeJS.Timeout;
@@ -30,12 +31,13 @@ export class RandomEventsManager {
   }
 
   spawnRandomAirdrop() {
-    const spg = this.server._spawnGrid[randomInt(100)];
+    const cellIndex = randomInt(100);
+    const spg = this.server._spawnGrid[cellIndex];
     const rnd_index = randomInt(spg.spawnPoints.length);
     const pos = spg.spawnPoints[rnd_index];
     this.server.spawnAirdrop(pos, false);
-    // TODO: add the cell
-    this.server.sendAlertToAll("Random airdrop");
+    const cellName = getCellName(cellIndex, 10);
+    this.server.sendAlertToAll(`Random airdrop on ${cellName}`);
     if (!this.server._soloMode) {
       this.server._db.collection("random_aidrops_logs").insertOne({
         position: pos,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1619,3 +1619,13 @@ export function isLootNerfedLoc(position: Float32Array): number {
 export function chance(chanceNum: number): boolean {
   return Math.random() * 1000 < chanceNum;
 }
+
+export function getCellName(index: number, numCols: number): string {
+  const columnIndex = index % numCols; // Get column index (0-9)
+  const rowIndex = Math.floor(index / numCols); // Get row index (0-9)
+
+  const columnLetter = String.fromCharCode(65 + columnIndex); // Convert to A-J
+  const rowNumber = rowIndex + 1; // Convert to 1-10
+
+  return columnLetter + rowNumber; // Example: "A1", "B3", "J10"
+}


### PR DESCRIPTION
### TL;DR

Added cell location information to random airdrop alerts.

### What changed?

- Created a new utility function `getCellName()` that converts a grid index to a human-readable coordinate (like "A1", "B3", "J10")
- Modified the random airdrop alert message to include the cell location where the airdrop is spawning
- Preserved the cell index in a variable to use for both spawning the airdrop and generating the cell name

### How to test?

1. Trigger a random airdrop event in the game
2. Verify that the alert message now includes the cell location (e.g., "Random airdrop on B3")
3. Confirm that the airdrop appears in the correct location on the map

### Why make this change?

This change improves the player experience by providing more specific information about where random airdrops are spawning. Instead of a generic "Random airdrop" message, players now receive the grid coordinate, making it easier to locate and compete for these resources.