### PR TITLE
add challenge & randomevents config

### DIFF
--- a/data/2016/sampleData/defaultconfig.yaml
+++ b/data/2016/sampleData/defaultconfig.yaml
@@ -25,6 +25,12 @@ rcon:
 
 challenges:
   enabled: true
+  challengePerDay: 6
+
+# Random events
+
+randomevents:
+  enabled: true
 
 # VoiceChat
 

--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -65,9 +65,8 @@ export interface ChallengeData {
 export class ChallengeManager {
   challenges: ChallengeInfo[];
   challengesCollection!: Collection<ChallengeData>;
-  // TODO: add to config
-  challengesPerDay: number = 6;
   // managed by config
+  challengesPerDay: number = 3;
   enabled: boolean = true;
   constructor(public server: ZoneServer2016) {
     this.challenges = [

--- a/src/servers/ZoneServer2016/managers/configmanager.ts
+++ b/src/servers/ZoneServer2016/managers/configmanager.ts
@@ -90,7 +90,8 @@ export class ConfigManager {
       speedtree,
       construction,
       decay,
-      smelting
+      smelting,
+      randomevents
     } = this.defaultConfig;
     return {
       ...this.defaultConfig,
@@ -138,6 +139,10 @@ export class ConfigManager {
       smelting: {
         ...smelting,
         ...config.smelting
+      },
+      randomevents: {
+        ...randomevents,
+        ...config.randomevents
       }
     };
   }
@@ -184,8 +189,14 @@ export class ConfigManager {
     server.rconManager.password = password;
 
     //#region Challenges
-    const { enabled } = this.config.challenges;
-    server.challengeManager.enabled = enabled;
+    const { enabled: challengeEnabled, challengePerDay } =
+      this.config.challenges;
+    server.challengeManager.enabled = challengeEnabled;
+    server.challengeManager.challengesPerDay = challengePerDay;
+    //#endregion
+    //#region RandomEvents
+    const { enabled: randomEventsEnabled } = this.config.randomevents;
+    server.challengeManager.enabled = randomEventsEnabled;
     //#endregion
     //
     //#region voicechat

--- a/src/servers/ZoneServer2016/models/config.ts
+++ b/src/servers/ZoneServer2016/models/config.ts
@@ -139,6 +139,11 @@ interface VoiceChatConfig {
 
 interface ChallengeConfig {
   enabled: boolean;
+  challengePerDay: number;
+}
+
+interface RandomEventsConfig {
+  enabled: boolean;
 }
 
 export interface Config {
@@ -154,4 +159,5 @@ export interface Config {
   construction: ConstructionConfig;
   decay: DecayConfig;
   smelting: SmeltingConfig;
+  randomevents: RandomEventsConfig;
 }


### PR DESCRIPTION
### TL;DR

Added configuration options for daily challenges and random events.

### What changed?

- Added `challengePerDay` configuration option to the challenges section in the default config
- Added a new `randomevents` section with an `enabled` flag in the default config
- Updated the `ChallengeManager` to use the configurable `challengesPerDay` value instead of a hardcoded value
- Modified the `ConfigManager` to properly load and apply these new configuration options
- Added type definitions for the new configuration options

### How to test?

1. Modify the `challengePerDay` value in your server config and verify that the correct number of daily challenges are generated
2. Toggle the `randomevents.enabled` setting and verify that random events are enabled/disabled accordingly

### Why make this change?

This change provides server administrators with more flexibility to customize gameplay by:
- Controlling how many challenges are presented to players each day
- Enabling or disabling random events through configuration rather than code changes

These options allow for better server customization without requiring code modifications.