### PR TITLE
some fixes for display challenge infos

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -269,13 +269,16 @@ export class ChallengeManager {
     if (cInfos) {
       const challengeData = await this.getCurrentChallengeData(client);
       message = `Challenge "${cInfos.name}": ${cInfos.description}`;
-      if (cInfos.neededPoints > 1) {
+      if (
+        cInfos.neededPoints > 1 &&
+        cInfos.neededPoints !== challengeData?.points
+      ) {
         message += `\n Progression: ${challengeData?.points}/${cInfos.neededPoints}`;
-      } else {
+      } else if (cInfos.neededPoints === challengeData?.points) {
         message += ` Accomplished!`;
       }
     } else {
-      message = `No more challenges for today. (${this.challengesPerDay / this.challengesPerDay})`;
+      message = `No more challenges for today. (${this.challengesPerDay})`;
     }
     this.server.sendAlert(client, message);
   }


### PR DESCRIPTION
### TL;DR

Fixed challenge progress display in the challenge manager.

### What changed?

- Fixed the challenge progress message to only show progression when the challenge is not yet completed
- Added a condition to display "Accomplished!" only when the player has exactly the needed points
- Fixed the "No more challenges" message to correctly display the total challenges per day

### How to test?

1. Log into the game and trigger a challenge
2. Verify that:
   - In-progress challenges show "Progression: X/Y"
   - Completed challenges show "Accomplished!"
   - When all daily challenges are done, the correct number of challenges per day is displayed

### Why make this change?

The challenge progress display had logic issues that caused incorrect messages to be shown to players. This change ensures players receive accurate information about their challenge progress and completion status.