### PR TITLE
update hashes

### DIFF
--- a/data/2016/dataSources/AllowedFileHashes.json
+++ b/data/2016/dataSources/AllowedFileHashes.json
@@ -1025,11 +1025,15 @@
   },
   {
     "file_name": "Assets_256.pack",
-    "crc32_hash": "707a42b9",
-    "old_crc32_hash": "34babd51"
+    "crc32_hash": "6588efce",
+    "old_crc32_hash": "707a42b9"
   },
   {
     "file_name": "Assets_257.pack",
     "crc32_hash": "bc999532"
+  },
+  {
+    "file_name": "Assets_258.pack",
+    "crc32_hash": "5b6b2a7f"
   }
 ]


### PR DESCRIPTION
### TL;DR

Updated file hash entries for game assets

### What changed?

- Updated the `crc32_hash` for `Assets_256.pack` from `707a42b9` to `6588efce`
- Updated the `old_crc32_hash` for `Assets_256.pack` from `34babd51` to `707a42b9`
- Added a new entry for `Assets_258.pack` with `crc32_hash` value of `5b6b2a7f`

### How to test?

1. Verify that the game loads correctly with the updated asset hashes
2. Confirm that `Assets_258.pack` is properly recognized by the system
3. Check that no hash verification errors occur during runtime

### Why make this change?

These hash updates are necessary to support the latest asset versions. The previous hash values are now outdated, and the new `Assets_258.pack` file needs to be recognized by the system to ensure proper game functionality.