### PR TITLE
update drop chances

### DIFF
--- a/src/servers/ZoneServer2016/managers/rewardmanager.ts
+++ b/src/servers/ZoneServer2016/managers/rewardmanager.ts
@@ -30,15 +30,15 @@ export class RewardManager {
     this.rewards = [
       {
         itemId: AccountItems.REWARD_CRATE_MARAUDER,
-        dropChances: 20
+        dropChances: 5
       },
       {
         itemId: AccountItems.REWARD_CRATE_SHOWDOWN,
-        dropChances: 20
+        dropChances: 5
       },
       {
         itemId: AccountItems.REWARD_CRATE_INVITATIONAL,
-        dropChances: 20
+        dropChances: 5
       },
       {
         itemId: AccountItems.REWARD_CRATE_INFERNAL,
@@ -50,7 +50,7 @@ export class RewardManager {
       },
       {
         itemId: AccountItems.REWARD_CRATE_PREDATOR,
-        dropChances: 20
+        dropChances: 10
       },
       {
         itemId: AccountItems.REWARD_CRATE_EZW,
@@ -90,15 +90,15 @@ export class RewardManager {
       },
       {
         itemId: AccountItems.REWARD_CRATE_SWIRL,
-        dropChances: 0
+        dropChances: 25
       },
       {
         itemId: AccountItems.REWARD_CRATE_BREAKOUT,
-        dropChances: 0
+        dropChances: 20
       },
       {
         itemId: AccountItems.REWARD_CRATE_VICTORY,
-        dropChances: 0
+        dropChances: 10
       },
       {
         itemId: AccountItems.REWARD_CRATE_H1EMUEX,


### PR DESCRIPTION
### TL;DR

Adjusted drop chances for various reward crates to improve balance and player experience.

### What changed?

- Reduced drop chances for MARAUDER, SHOWDOWN, and INVITATIONAL crates from 20 to 5
- Reduced PREDATOR crate drop chance from 20 to 10
- Increased drop chances for previously unavailable crates:
  - SWIRL crate from 0 to 25
  - BREAKOUT crate from 0 to 20
  - VICTORY crate from 0 to 10

### How to test?

1. Launch the game and play multiple matches
2. Observe the distribution of crate rewards received
3. Verify that SWIRL crates appear most frequently, followed by BREAKOUT, then VICTORY
4. Confirm that MARAUDER, SHOWDOWN, and INVITATIONAL crates appear less frequently than before

### Why make this change?

This rebalancing of crate drop chances introduces previously unavailable crates into the reward pool while reducing the frequency of older crates. This provides players with access to new cosmetic items and creates a more diverse and refreshed reward experience.