### PR TITLE
Allow to dynamically choose which type is the airdrop

### DIFF
--- a/src/servers/ZoneServer2016/managers/randomeventsmanager.ts
+++ b/src/servers/ZoneServer2016/managers/randomeventsmanager.ts
@@ -35,7 +35,7 @@ export class RandomEventsManager {
     const spg = this.server._spawnGrid[cellIndex];
     const rnd_index = randomInt(spg.spawnPoints.length);
     const pos = spg.spawnPoints[rnd_index];
-    this.server.spawnAirdrop(pos, false);
+    this.server.spawnAirdrop(pos, "");
     const cellName = getCellName(cellIndex, 10);
     this.server.sendAlertToAll(`Random airdrop on ${cellName}`);
     if (!this.server._soloMode) {

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -1327,7 +1327,7 @@ export class ZonePacketHandlers {
         server.worldObjectManager.createAirdropContainer(
           server,
           server._airdrop.destinationPos,
-          server._airdrop.hospitalCrate ? "Hospital" : ""
+          server._airdrop.forcedAirdropType
         );
         for (const client of Object.values(server._clients)) {
           server.airdropManager(client, false);

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -364,7 +364,7 @@ export class ZoneServer2016 extends EventEmitter {
     destinationPos: Float32Array;
     cargoSpawned: boolean;
     containerSpawned: boolean;
-    hospitalCrate: boolean;
+    forcedAirdropType?: string;
     manager?: Client;
   };
 
@@ -7097,14 +7097,14 @@ export class ZoneServer2016 extends EventEmitter {
     this.sendAlert(client, "Your delivery is on the way!");
     this.spawnAirdrop(
       client.character.state.position,
-      item.hasAirdropClearance
+      item.hasAirdropClearance ? "Hospital" : ""
     );
     if (item.hasAirdropClearance) {
       item.hasAirdropClearance = false;
     }
   }
 
-  spawnAirdrop(position: Float32Array, hasAirdropClearance: boolean) {
+  spawnAirdrop(position: Float32Array, forcedAirdropType: string) {
     const pos = new Float32Array([position[0], 400, position[2], 1]);
     const angle = getAngle(position, new Float32Array([0, 0, 0, 0]));
     const distance =
@@ -7149,7 +7149,7 @@ export class ZoneServer2016 extends EventEmitter {
       destinationPos: position,
       cargoSpawned: false,
       containerSpawned: false,
-      hospitalCrate: hasAirdropClearance
+      forcedAirdropType: forcedAirdropType
     };
     let choosenClient: Client | undefined;
     let currentDistance = 999999;


### PR DESCRIPTION
### TL;DR

Refactored airdrop type handling to support more than just hospital crates.

### What changed?

- Changed the `hospitalCrate` boolean property in the airdrop object to a more flexible `forcedAirdropType` string property
- Updated the `spawnAirdrop` method to accept a string parameter instead of a boolean
- Modified the random events manager to pass an empty string instead of `false`
- Updated the call in the airdrop item handler to pass "Hospital" when the player has airdrop clearance
- Adjusted the world object creation to use the new `forcedAirdropType` property

### How to test?

1. Test random airdrops to ensure they spawn with default loot (empty string type)
2. Test hospital airdrops by using an airdrop item with clearance
3. Verify that both types of airdrops spawn correctly and contain the appropriate loot

### Why make this change?

This change improves the airdrop system by making it more extensible. Instead of being limited to just hospital vs. non-hospital crates, the system can now support multiple airdrop types through a string identifier. This provides a foundation for adding more specialized airdrop types in the future without requiring further code restructuring.