### PR TITLE
adjust random airdrops types

### DIFF
--- a/src/servers/ZoneServer2016/managers/randomeventsmanager.ts
+++ b/src/servers/ZoneServer2016/managers/randomeventsmanager.ts
@@ -15,6 +15,11 @@ import { randomInt } from "node:crypto";
 import { ZoneServer2016 } from "../zoneserver";
 import { getCellName } from "../../../utils/utils";
 
+interface WeightedItem {
+  value: string;
+  weight: number;
+}
+
 export class RandomEventsManager {
   interval?: NodeJS.Timeout;
   // managed by config
@@ -30,12 +35,34 @@ export class RandomEventsManager {
     clearInterval(this.interval);
   }
 
+  weightedRandom(items: WeightedItem[]) {
+    let random =
+      Math.random() * items.reduce((sum: number, item) => sum + item.weight, 0);
+
+    return (
+      items.find((item) => (random -= item.weight) < 0) as unknown as {
+        value: string;
+        weight: number;
+      }
+    ).value;
+  }
+
   spawnRandomAirdrop() {
     const cellIndex = randomInt(100);
     const spg = this.server._spawnGrid[cellIndex];
     const rnd_index = randomInt(spg.spawnPoints.length);
     const pos = spg.spawnPoints[rnd_index];
-    this.server.spawnAirdrop(pos, "");
+    const airdropTypes: WeightedItem[] = [
+      { value: "Farmer", weight: 15 },
+      { value: "Demolitioner", weight: 5 },
+      { value: "Medic", weight: 25 },
+      { value: "Builder", weight: 25 },
+      { value: "Fighter", weight: 10 },
+      { value: "Supplier", weight: 20 }
+    ];
+    const airdropType = this.weightedRandom(airdropTypes);
+    console.log(airdropType);
+    this.server.spawnAirdrop(pos, airdropType);
     const cellName = getCellName(cellIndex, 10);
     this.server.sendAlertToAll(`Random airdrop on ${cellName}`);
     if (!this.server._soloMode) {


### PR DESCRIPTION
### TL;DR

Added weighted random airdrop types to the random events system.

### What changed?

- Added a `WeightedItem` interface to define items with weight values
- Implemented a `weightedRandom` method to select items based on their weights
- Modified the `spawnRandomAirdrop` function to use different airdrop types with varying probabilities:
  - Medic and Builder (25% each)
  - Supplier (20%)
  - Farmer (15%)
  - Fighter (10%)
  - Demolitioner (5%)

### How to test?

1. Trigger random airdrops in the game
2. Verify that different airdrop types appear with roughly the expected frequencies
3. Check the console logs to confirm the selected airdrop type is displayed
4. Verify that the airdrop contents match the specified type

### Why make this change?

This change adds variety to the random airdrop system by introducing different types of airdrops with varying probabilities. This creates a more dynamic gameplay experience where players can receive different types of supplies based on the weighted random selection, rather than having all airdrops be the same.