### PR TITLE
kill players too close to landing location of an airdrop

### DIFF
--- a/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
+++ b/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
@@ -523,6 +523,16 @@ export class WorldObjectManager {
             effectTime: 60
           }
         );
+
+        if (
+          isPosInRadius(
+            3,
+            c.character.state.position,
+            server._airdrop.destinationPos
+          )
+        ) {
+          server.killCharacter(c, { damage: 99999, entity: "aidrop" });
+        }
       }
     }
     server._lootbags[characterId] = lootbag;


### PR DESCRIPTION
### TL;DR

Added character kill when standing under an airdrop landing position.

### What changed?

Added logic to kill characters that are standing directly under an airdrop's landing position. When a character is within a 3-meter radius of the airdrop's destination position, they will be killed with 99999 damage from an entity labeled "aidrop".

### How to test?

1. Spawn an airdrop in the game
2. Position a character directly under the airdrop's landing position (within 3 meters)
3. Verify that the character is killed when the airdrop lands

### Why make this change?

This change adds realism to the game by ensuring players can't safely stand under falling airdrops. It creates a risk/reward scenario where players must be careful when attempting to claim airdrops, adding an additional tactical element to gameplay.