### PR TITLE
update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/js-yaml": "4.0.9",
-        "@types/node": "22.13.13",
-        "@types/ws": "8.18.0",
+        "@types/node": "22.14.0",
+        "@types/ws": "8.18.1",
         "debug": "4.4.0",
         "h1emu-ai": "0.0.8",
         "h1emu-core": "1.3.2",
@@ -21,7 +21,7 @@
         "mongodb": "6.15.0",
         "recast-navigation": "0.34.0",
         "threads": "1.7.0",
-        "typescript": "5.8.2",
+        "typescript": "5.8.3",
         "ws": "8.18.1"
       },
       "bin": {
@@ -31,10 +31,10 @@
       "devDependencies": {
         "cross-env": "^7.0.3",
         "globals": "^16.0.0",
-        "oxlint": "^0.16.3",
+        "oxlint": "^0.16.5",
         "prettier": "^3.5.3",
         "tsx": "^4.19.3",
-        "typedoc": "^0.28.1"
+        "typedoc": "^0.28.2"
       },
       "engines": {
         "node": ">=0.22.0 <24"
@@ -466,13 +466,15 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.1.tgz",
-      "integrity": "sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.2.tgz",
+      "integrity": "sha512-vaZNGhGLKMY14HbF53xxHNgFO9Wz+t5lTlGNpl2N9xFiKQ0I5oIe0vKjU9dh7Nb3Dw6lZ7wqUE0ri+zcdpnK+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@shikijs/engine-oniguruma": "^3.2.1",
+        "@shikijs/langs": "^3.2.1",
+        "@shikijs/themes": "^3.2.1",
         "@shikijs/types": "^3.2.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
@@ -487,9 +489,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.16.3.tgz",
-      "integrity": "sha512-X0VSK4mjPWJTzNHTExFlN+MdEVbxhdl/fXSLDKPf8Sm46ebY7qat8Df06Z0fncZc1+aDAb32xDy0U3cnUA1vgg==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.16.5.tgz",
+      "integrity": "sha512-syGjqZ9ES2CZSxL2hJivZNhlaZG/H9EjW1kyup77cSzTqEoaf/wEgiqIEyb1nvkvA2/HexIOkgsL+MsQZ2b04Q==",
       "cpu": [
         "arm64"
       ],
@@ -501,9 +503,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.16.3.tgz",
-      "integrity": "sha512-/fTRMu2wjSbp9ai6jFlNSOME3Eoq9+7W9JpGyi7s3vht5PnqKVSCZVXaawEAlHgFIlcwi9MZHbRo6GDsqfZnuw==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.16.5.tgz",
+      "integrity": "sha512-JczXMFNRwcKYivi4OGaUKfOeugxMF5yMS4oELbSVeP2FQgEPoH/l1WErb+aYNSRuvr5QZiGZST0lGgWy/RPl7A==",
       "cpu": [
         "x64"
       ],
@@ -515,9 +517,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.16.3.tgz",
-      "integrity": "sha512-t1xtcbHoJGpE/0oRA8z2/szBB0gHGy0eua0ko57Lo1LscHiyvkmpqPJTiaR8+1b+EbGO8KKgLcKDoxqvmIqDbA==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.16.5.tgz",
+      "integrity": "sha512-II1U6+IZeNRZ+BIPlOQ30cwkzBusF9bx4icx8Pxq7jAbtGKNFMEej9+sp4oXv2b8LU5bWVTQEvH/vuIwusMtmw==",
       "cpu": [
         "arm64"
       ],
@@ -529,9 +531,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.16.3.tgz",
-      "integrity": "sha512-N0kCa9K9MssXO/Gk6tPHYQWUdWhEJPek4rsYRLXyoVKX0c36Ty66Ye74LiDtFkkB33S0P38hTAwYWF68nqCEmw==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.16.5.tgz",
+      "integrity": "sha512-2BVhlqspH6Mtqs2jONV6Eu/z+PaDxqPgcFxKV95RJVPHZv3+H6+rElwbCKx73b5IsHZa0SIj/nG1QKYb+GfKiw==",
       "cpu": [
         "arm64"
       ],
@@ -543,9 +545,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.16.3.tgz",
-      "integrity": "sha512-f/MzfVTTxdO2YqWLvv/yyDF4O82yBC9KsDgd01M3M2cqrBlczDZ8FZaVAMO9RzKGiPZi6nwxxK0VPaLzGEc3XQ==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.16.5.tgz",
+      "integrity": "sha512-4z8eAvwJq7EYM9jUSjw1eL/RsP6Z6mB9e1leKUBY0B1/nRxivDPMA3ryOdJ6ZKTIxWUkJhMshKDP9qa5V8KoEA==",
       "cpu": [
         "x64"
       ],
@@ -557,9 +559,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.16.3.tgz",
-      "integrity": "sha512-xdAtPsXkAe1XyXGTwmhDRy48j9EOUMiT7yL0OziHndU8U5/kfrEXgwLAw0tb8XEvfu5ZVn76EtTyQxpG0KkPpw==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.16.5.tgz",
+      "integrity": "sha512-dfswyGsukAJ291Z+Yu7HLZV3JT66B31sCOauPZUqI7MKKqZaYH/2gVKAp/kTq0h94ENIME6jkPLNwJkYmNpYnw==",
       "cpu": [
         "x64"
       ],
@@ -571,9 +573,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.16.3.tgz",
-      "integrity": "sha512-B54p7IrcACUEypQtKzMJ07xP+pFJbTwktB9TuANogMIMo33DsxoBvAYoGFOL/sFq1Dvg5jtCa6LX1dAzSPXwTA==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.16.5.tgz",
+      "integrity": "sha512-YTtBQObOays+OyT31du5WGNhl+I9yWyogTcn9RpKUapoA3XY9q3lS1DNuqTTEOC08+KDDygFGT7fIraMQjehVg==",
       "cpu": [
         "arm64"
       ],
@@ -585,9 +587,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.16.3.tgz",
-      "integrity": "sha512-ZpnyNyXAS5xsZggOD2V5tYYBALnW8p0w70UNXPWnXl3ScAb3QMW7IQRyOvKNPbXyW7XNYebWlgJkSCFij9gKvA==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.16.5.tgz",
+      "integrity": "sha512-cHJJRyVA2XlsGjIVKqw2DC5dkzWGOH6gxQwf6StTHn8F4i5P8gksV70VoNW5mwEXefF2USDX7H43YVIDG5E/Yw==",
       "cpu": [
         "x64"
       ],
@@ -648,6 +650,26 @@
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
+    "node_modules/@shikijs/langs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.1.tgz",
+      "integrity": "sha512-If0iDHYRSGbihiA8+7uRsgb1er1Yj11pwpX1c6HLYnizDsKAw5iaT3JXj5ZpaimXSWky/IhxTm7C6nkiYVym+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.1.tgz",
+      "integrity": "sha512-k5DKJUT8IldBvAm8WcrDT5+7GA7se6lLksR+2E3SvyqGTyFMzU2F9Gb7rmD+t+Pga1MKrYFxDIeyWjMZWM6uBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.2.1"
+      }
+    },
     "node_modules/@shikijs/types": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
@@ -689,12 +711,12 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
     },
     "node_modules/@types/node": {
-      "version": "22.13.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
-      "integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/stats.js": {
@@ -747,9 +769,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1178,9 +1200,9 @@
       "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "node_modules/oxlint": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.16.3.tgz",
-      "integrity": "sha512-CqHLqyVLL0UYLsJTLHuwzbM3/dCxA5v0ngSCTnVFYwQsj8qYr8p1KS0TbCX4Mv20vcOJifSoQdQhvNcWFSKMZw==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.16.5.tgz",
+      "integrity": "sha512-z5MX2v4KUqzZQTnRkHHBPE4qEo08f5mJ4dQxi+r5t3xpGspVH/pBzWQ0UUy2xO3JHO8H6wpoeoh8bGs6jEygvQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1194,14 +1216,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "0.16.3",
-        "@oxlint/darwin-x64": "0.16.3",
-        "@oxlint/linux-arm64-gnu": "0.16.3",
-        "@oxlint/linux-arm64-musl": "0.16.3",
-        "@oxlint/linux-x64-gnu": "0.16.3",
-        "@oxlint/linux-x64-musl": "0.16.3",
-        "@oxlint/win32-arm64": "0.16.3",
-        "@oxlint/win32-x64": "0.16.3"
+        "@oxlint/darwin-arm64": "0.16.5",
+        "@oxlint/darwin-x64": "0.16.5",
+        "@oxlint/linux-arm64-gnu": "0.16.5",
+        "@oxlint/linux-arm64-musl": "0.16.5",
+        "@oxlint/linux-x64-gnu": "0.16.5",
+        "@oxlint/linux-x64-musl": "0.16.5",
+        "@oxlint/win32-arm64": "0.16.5",
+        "@oxlint/win32-x64": "0.16.5"
       }
     },
     "node_modules/path-key": {
@@ -1401,17 +1423,17 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz",
-      "integrity": "sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.2.tgz",
+      "integrity": "sha512-9Giuv+eppFKnJ0oi+vxqLM817b/IrIsEMYgy3jj6zdvppAfDqV3d6DXL2vXUg2TnlL62V48th25Zf/tcQKAJdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.2.1",
+        "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "yaml": "^2.7.0 "
+        "yaml": "^2.7.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -1425,9 +1447,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1445,9 +1467,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {
@@ -1508,9 +1530,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@types/js-yaml": "4.0.9",
-    "@types/node": "22.13.13",
-    "@types/ws": "8.18.0",
+    "@types/node": "22.14.0",
+    "@types/ws": "8.18.1",
     "debug": "4.4.0",
     "h1emu-ai": "0.0.8",
     "h1emu-core": "1.3.2",
@@ -24,19 +24,19 @@
     "mongodb": "6.15.0",
     "recast-navigation": "0.34.0",
     "threads": "1.7.0",
-    "typescript": "5.8.2",
+    "typescript": "5.8.3",
     "ws": "8.18.1"
   },
   "directories": {
     "src": "./src"
   },
   "devDependencies": {
-    "oxlint": "^0.16.3",
     "cross-env": "^7.0.3",
     "globals": "^16.0.0",
+    "oxlint": "^0.16.5",
     "prettier": "^3.5.3",
     "tsx": "^4.19.3",
-    "typedoc": "^0.28.1"
+    "typedoc": "^0.28.2"
   },
   "scripts": {
     "gen-packets-types": "tsx ./scripts/genPacketsNames.ts",


### PR DESCRIPTION
### TL;DR

Updated development dependencies and TypeScript-related packages to their latest versions.

### What changed?

- Updated TypeScript from 5.8.2 to 5.8.3
- Updated type definitions:
  - @types/node from 22.13.13 to 22.14.0
  - @types/ws from 8.18.0 to 8.18.1
- Updated development dependencies:
  - oxlint from 0.16.3 to 0.16.5
  - typedoc from 0.28.1 to 0.28.2

### How to test?

1. Run `npm install` to update the dependencies
2. Verify the project builds correctly with `npm run build`
3. Run tests to ensure everything works with the updated packages
4. Check that documentation generation works with the updated typedoc

### Why make this change?

Keeping dependencies up-to-date ensures we have the latest bug fixes, security patches, and performance improvements. The TypeScript update may include compiler optimizations and bug fixes, while the updated type definitions provide better compatibility with the latest Node.js and WebSocket APIs.