### PR TITLE
fix having the same challenge twice in a row

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -333,14 +333,12 @@ export class ChallengeManager {
   }
 
   async affectChallenge(client: ZoneClient2016) {
-    const today = new Date();
-    const timeZoneOffset = today.getTimezoneOffset() * 60000; // Convert minutes to milliseconds
     const now = Date.now();
 
-    const startOfDay = new Date(now - timeZoneOffset);
+    const startOfDay = new Date(now);
     startOfDay.setHours(0, 0, 0, 0);
 
-    const endOfDay = new Date(now - timeZoneOffset);
+    const endOfDay = new Date(now);
     endOfDay.setHours(23, 59, 59, 999);
 
     const challengesToday = await this.challengesCollection
@@ -371,8 +369,8 @@ export class ChallengeManager {
     }
     const challengesAvailable = this.challenges.filter((v) => {
       return (
-        ((!challengesTypesDoneToday.includes(v.type) && !v.pvpOnly) ||
-          !this.server.isPvE) &&
+        !challengesTypesDoneToday.includes(v.type) &&
+        (!v.pvpOnly || !this.server.isPvE) &&
         v.difficulty === nextDifficultyChallenge
       );
     });


### PR DESCRIPTION
### TL;DR

Fixed challenge filtering logic and simplified date handling in the challenge manager.

### What changed?

- Removed timezone offset calculations when determining the start and end of day for challenges
- Fixed the logic for filtering available challenges:
  - Corrected the parentheses in the boolean expression to properly handle PvP-only challenges
  - Changed from `((!challengesTypesDoneToday.includes(v.type) && !v.pvpOnly) || !this.server.isPvE)` to `!challengesTypesDoneToday.includes(v.type) && (!v.pvpOnly || !this.server.isPvE)`

### How to test?

1. Test challenge availability on both PvE and PvP servers
2. Verify that PvP-only challenges are correctly filtered out on PvE servers
3. Confirm that challenges are properly reset at the start of a new day regardless of timezone

### Why make this change?

The previous implementation had two issues:
1. The timezone offset calculation was unnecessary and potentially causing date-related bugs
2. The boolean logic for filtering available challenges was incorrect, which could lead to PvP-only challenges being incorrectly offered on PvE servers or challenges of completed types being offered again on the same day