### PR TITLE
add ranchito challenge

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -32,7 +32,8 @@ export enum ChallengeType {
   GLOBAL_DISARMAMENT,
   ROCKY,
   ROCKSTAR,
-  IED
+  IED,
+  RANCHITO
 }
 export enum ChallengeStatus {
   CURRENT = 1,
@@ -99,6 +100,14 @@ export class ChallengeManager {
         difficulty: ChallengeDifficulty.EASY,
         name: "Cardio deficiency detected",
         description: "Run out of stamina",
+        neededPoints: 1,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.RANCHITO,
+        difficulty: ChallengeDifficulty.EASY,
+        name: "Wait... Why am i here again?",
+        description: "Visit Ranchito",
         neededPoints: 1,
         pvpOnly: false
       },

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -4215,6 +4215,13 @@ export class ZoneServer2016 extends EventEmitter {
             id: point.POIid
           });
           client.currentPOI = point.stringId;
+          if (point.POIid === 13) {
+            this.challengeManager.registerChallengeProgression(
+              client,
+              ChallengeType.RANCHITO,
+              1
+            );
+          }
         }
       }
     });


### PR DESCRIPTION
### TL;DR

Added a new "Ranchito" challenge that triggers when players visit the Ranchito POI.

### What changed?

- Added a new `RANCHITO` challenge type to the `ChallengeType` enum
- Created a new easy difficulty challenge called "Wait... Why am i here again?" that requires visiting Ranchito
- Added logic in the zone server to register challenge progression when a player visits the Ranchito POI (POIid 13)

### How to test?

1. Enter the game and visit the Ranchito location
2. Verify that the challenge "Wait... Why am i here again?" is triggered and completed
3. Check that the challenge appears correctly in the challenge UI

### Why make this change?

This adds more variety to the challenge system by rewarding players for exploring different locations in the game world. The Ranchito POI now has an associated challenge, encouraging players to visit this area.