### PR TITLE
change craft challenges statement to a switch

### DIFF
--- a/src/servers/ZoneServer2016/managers/craftmanager.ts
+++ b/src/servers/ZoneServer2016/managers/craftmanager.ts
@@ -517,27 +517,32 @@ export class CraftManager {
         client.character.lootItem(server, server.generateItem(id, 1));
       });
     }
-    if (recipeId === Items.IED) {
-      server.challengeManager.registerChallengeProgression(
-        client,
-        ChallengeType.IED,
-        1
-      );
+    switch (recipeId) {
+      case Items.IED:
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.IED,
+          1
+        );
+        break;
+
+      case Items.FOUNDATION:
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.MY_LAND,
+          1
+        );
+        break;
+
+      case Items.SHACK:
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.MY_HOME,
+          1
+        );
+        break;
     }
-    if (recipeId === Items.FOUNDATION) {
-      server.challengeManager.registerChallengeProgression(
-        client,
-        ChallengeType.MY_LAND,
-        1
-      );
-    }
-    if (recipeId === Items.SHACK) {
-      server.challengeManager.registerChallengeProgression(
-        client,
-        ChallengeType.MY_HOME,
-        1
-      );
-    }
+
     return true;
     //#endregion
   }


### PR DESCRIPTION
### TL;DR

Refactored challenge progression logic in the craft manager to use a switch statement.

### What changed?

Replaced multiple if statements with a single switch statement in the `CraftManager` class. This change improves the readability of the code that registers challenge progression when crafting specific items (IED, FOUNDATION, and SHACK).

### How to test?

1. Craft an IED, Foundation, and Shack in the game
2. Verify that challenge progression is correctly registered for each item:
   - IED should progress the IED challenge
   - Foundation should progress the MY_LAND challenge
   - Shack should progress the MY_HOME challenge

### Why make this change?

The switch statement provides a cleaner and more maintainable approach for handling multiple conditional checks against the same variable. This improves code readability and makes it easier to add new challenge progression conditions in the future.