### PR TITLE
add swizzle challenge

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -33,7 +33,8 @@ export enum ChallengeType {
   ROCKY,
   ROCKSTAR,
   IED,
-  RANCHITO
+  RANCHITO,
+  SWIZZLE
 }
 export enum ChallengeStatus {
   CURRENT = 1,
@@ -157,6 +158,14 @@ export class ChallengeManager {
         difficulty: ChallengeDifficulty.MEDIUM,
         name: "My land!",
         description: "Craft a deck foundation",
+        neededPoints: 1,
+        pvpOnly: false
+      },
+      {
+        type: ChallengeType.SWIZZLE,
+        difficulty: ChallengeDifficulty.MEDIUM,
+        name: "Shady buisness",
+        description: "Consume some swizzle",
         neededPoints: 1,
         pvpOnly: false
       },

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -7389,6 +7389,11 @@ export class ZoneServer2016 extends EventEmitter {
   sniffPass(client: Client, character: BaseFullCharacter, item: BaseItem) {
     if (!this.removeInventoryItem(character, item)) return;
     if (item.itemDefinitionId === Items.SWIZZLE) {
+      this.challengeManager.registerChallengeProgression(
+        client,
+        ChallengeType.SWIZZLE,
+        1
+      );
       this.applyMovementModifier(client, MovementModifiers.SWIZZLE);
     } else {
       this.applyMovementModifier(client, MovementModifiers.ADRENALINE);


### PR DESCRIPTION
### TL;DR

Added a new "Swizzle" challenge that tracks when players consume swizzle.

### What changed?

- Added a new `SWIZZLE` challenge type to the `ChallengeType` enum
- Created a new medium difficulty challenge called "Shady buisness" that requires consuming swizzle
- Updated the `sniffPass` method to register progression for the swizzle challenge when a player consumes swizzle

### How to test?

1. Join a server and find swizzle
2. Consume the swizzle
3. Verify that the "Shady buisness" challenge progresses in your challenge list

### Why make this change?

This change adds gameplay depth by rewarding players for consuming swizzle, which previously only provided a movement modifier effect. This creates additional incentives for players to seek out and use this item.