### PR TITLE
fix braindead challenge

### DIFF
--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -178,11 +178,13 @@ export class Npc extends BaseFullCharacter {
       this.flags.knockedOut = 1;
       server.worldObjectManager.createLootbag(server, this);
       if (client) {
-        server.challengeManager.registerChallengeProgression(
-          client,
-          ChallengeType.BRAIN_DEAD,
-          1
-        );
+        if (this.npcId === NpcIds.ZOMBIE) {
+          server.challengeManager.registerChallengeProgression(
+            client,
+            ChallengeType.BRAIN_DEAD,
+            1
+          );
+        }
         if (!server._soloMode) {
           logClientActionToMongo(
             server._db.collection(DB_COLLECTIONS.KILLS),


### PR DESCRIPTION
### TL;DR

Added a check to only register "Brain Dead" challenge progression when killing zombies.

### What changed?

Modified the NPC death handling logic to only register progress for the "Brain Dead" challenge when the killed NPC is specifically a zombie (NpcId.ZOMBIE). Previously, this challenge was being incremented for killing any NPC.

### How to test?

1. Kill a zombie NPC and verify that the "Brain Dead" challenge counter increases
2. Kill any other type of NPC and verify that the "Brain Dead" challenge counter does not increase

### Why make this change?

The "Brain Dead" challenge is specifically designed to track zombie kills, but the previous implementation was incorrectly counting all NPC kills toward this challenge. This change ensures the challenge works as intended by only tracking zombie kills.