### PR TITLE
fix dupe challenges rewards

### DIFF
--- a/src/servers/ZoneServer2016/managers/challengemanager.ts
+++ b/src/servers/ZoneServer2016/managers/challengemanager.ts
@@ -336,6 +336,10 @@ export class ChallengeManager {
   }
 
   async finishChallenge(client: ZoneClient2016) {
+    if (client.character.currentChallenge === ChallengeType.NONE) {
+      return;
+    }
+    client.character.currentChallenge = ChallengeType.NONE;
     const query = {
       status: ChallengeStatus.CURRENT,
       serverId: this.server._worldId,


### PR DESCRIPTION
### TL;DR

Fixed a bug in the challenge system where the character's current challenge state wasn't being reset properly.

### What changed?

Added a check in the `finishChallenge` method to prevent processing if the character doesn't have an active challenge. Also added code to reset the character's `currentChallenge` property to `NONE` when a challenge is finished.

### How to test?

1. Start a challenge in-game
2. Complete the challenge
3. Verify that the character's challenge state is properly reset to NONE
4. Try to finish a challenge when no challenge is active and confirm no errors occur

### Why make this change?

This fixes a potential issue where the character's challenge state could remain in an inconsistent state after completing a challenge. The added check also prevents unnecessary processing when there's no active challenge to finish.