### PR TITLE
QOL: Slight nerf to burning tick on Blaze

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1707,7 +1707,7 @@ export class Character2016 extends BaseFullCharacter {
         server.applyCharacterEffect(
           this,
           Effects.PFX_Fire_Person_loop,
-          500,
+          400,
           10000
         );
         break;


### PR DESCRIPTION
In the current state if you get headshot by a blaze you are dead, you are not able to premed or outheal it


Now you end up on 16 health with posability of a bleeding effect