### PR TITLE
Convey durability loss on death

### DIFF
--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -764,7 +764,7 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
         server.isGator(footwear.itemDefinitionId)
       )
     ) {
-      footwear.currentDurability = (footwear.currentDurability || 0) - 200;
+      footwear.currentDurability = (footwear.currentDurability || 0) - 1080;
       if (footwear.currentDurability <= 0) {
 
     for (const a in server._clients) {

--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -754,6 +754,32 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
   }
 
   getDeathItems(server: ZoneServer2016) {
+    // --- Durability loss for footwear on death ---
+    const footwear = this._loadout[LoadoutSlots.FEET];
+    if (
+      footwear &&
+      (
+        server.isConvey(footwear.itemDefinitionId) ||
+        server.isZed(footwear.itemDefinitionId) ||
+        server.isGator(footwear.itemDefinitionId)
+      )
+    ) {
+      footwear.currentDurability = (footwear.currentDurability || 0) - 200;
+      if (footwear.currentDurability <= 0) {
+
+    for (const a in server._clients) {
+      const client = server._clients[a];
+
+server.removeInventoryItem(client.character, footwear);
+      client.character.lootContainerItem(
+      server,
+      server.generateItem(Items.CLOTH, 4)
+      );
+          }
+      }
+    }
+    // --- End durability loss ---
+
     const items: { [itemGuid: string]: BaseItem } = {};
     Object.values(this._loadout).forEach((itemData) => {
       if (

--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -758,24 +758,21 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
     const footwear = this._loadout[LoadoutSlots.FEET];
     if (
       footwear &&
-      (
-        server.isConvey(footwear.itemDefinitionId) ||
+      (server.isConvey(footwear.itemDefinitionId) ||
         server.isZed(footwear.itemDefinitionId) ||
-        server.isGator(footwear.itemDefinitionId)
-      )
+        server.isGator(footwear.itemDefinitionId))
     ) {
       footwear.currentDurability = (footwear.currentDurability || 0) - 1080;
       if (footwear.currentDurability <= 0) {
+        for (const a in server._clients) {
+          const client = server._clients[a];
 
-    for (const a in server._clients) {
-      const client = server._clients[a];
-
-server.removeInventoryItem(client.character, footwear);
-      client.character.lootContainerItem(
-      server,
-      server.generateItem(Items.CLOTH, 4)
-      );
-          }
+          server.removeInventoryItem(client.character, footwear);
+          client.character.lootContainerItem(
+            server,
+            server.generateItem(Items.CLOTH, 4)
+          );
+        }
       }
     }
     // --- End durability loss ---

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5919,7 +5919,7 @@ export class ZoneServer2016 extends EventEmitter {
       case this.isHelmet(itemDefinitionId):
         return 100;
       case this.isConvey(itemDefinitionId):
-        return 1000;
+        return 5400;
       case this.isWeapon(itemDefinitionId):
       default:
         return 2000;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -3214,6 +3214,23 @@ export class ZoneServer2016 extends EventEmitter {
     item.currentDurability -= damage;
     if (item.currentDurability <= 0) {
       this.removeInventoryItem(character, item);
+      
+      {
+
+  // Give broken metal if weapon breaks (except branch)
+  if (
+    this.isWeapon(item.itemDefinitionId) &&
+    item.itemDefinitionId != Items.WEAPON_BRANCH
+  ) {
+    character.lootContainerItem(
+      this,
+      this.generateItem(Items.BROKEN_METAL_ITEM)
+    );
+  }
+  return;
+}
+
+
       if (
         this.isWeapon(item.itemDefinitionId) &&
         item.itemDefinitionId != Items.WEAPON_BRANCH
@@ -3222,6 +3239,22 @@ export class ZoneServer2016 extends EventEmitter {
           this,
           this.generateItem(Items.BROKEN_METAL_ITEM)
         );
+                item.currentDurability -= damage;
+        if (item.currentDurability <= 0) {
+          this.removeInventoryItem(character, item);
+
+      
+          if (
+            this.isWeapon(item.itemDefinitionId) &&
+            item.itemDefinitionId != Items.WEAPON_BRANCH
+          ) {
+            character.lootContainerItem(
+              this,
+              this.generateItem(Items.BROKEN_METAL_ITEM)
+            );
+          }
+          return;
+        }
       }
       return;
     }
@@ -5886,7 +5919,7 @@ export class ZoneServer2016 extends EventEmitter {
       case this.isHelmet(itemDefinitionId):
         return 100;
       case this.isConvey(itemDefinitionId):
-        return 5400;
+        return 1000;
       case this.isWeapon(itemDefinitionId):
       default:
         return 2000;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -3214,23 +3214,6 @@ export class ZoneServer2016 extends EventEmitter {
     item.currentDurability -= damage;
     if (item.currentDurability <= 0) {
       this.removeInventoryItem(character, item);
-      
-      {
-
-  // Give broken metal if weapon breaks (except branch)
-  if (
-    this.isWeapon(item.itemDefinitionId) &&
-    item.itemDefinitionId != Items.WEAPON_BRANCH
-  ) {
-    character.lootContainerItem(
-      this,
-      this.generateItem(Items.BROKEN_METAL_ITEM)
-    );
-  }
-  return;
-}
-
-
       if (
         this.isWeapon(item.itemDefinitionId) &&
         item.itemDefinitionId != Items.WEAPON_BRANCH
@@ -3239,22 +3222,6 @@ export class ZoneServer2016 extends EventEmitter {
           this,
           this.generateItem(Items.BROKEN_METAL_ITEM)
         );
-                item.currentDurability -= damage;
-        if (item.currentDurability <= 0) {
-          this.removeInventoryItem(character, item);
-
-      
-          if (
-            this.isWeapon(item.itemDefinitionId) &&
-            item.itemDefinitionId != Items.WEAPON_BRANCH
-          ) {
-            character.lootContainerItem(
-              this,
-              this.generateItem(Items.BROKEN_METAL_ITEM)
-            );
-          }
-          return;
-        }
       }
       return;
     }


### PR DESCRIPTION
- Reduced overall item durability to 1000

- Boots, Convey, Gator, and Zed now lose 200 durability upon each death, Effectively grants 5 lives per Convey item