### PR TITLE
update oxlint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "cross-env": "^7.0.3",
         "globals": "^16.1.0",
-        "oxlint": "^0.16.10",
+        "oxlint": "^0.16.11",
         "prettier": "^3.5.3",
         "tsx": "^4.19.4",
         "typedoc": "^0.28.4"
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.16.10.tgz",
-      "integrity": "sha512-lNnkf7/auNXXD7gU3IbWMyuYiKj4Va+hhoe6+NwGfAjpKm5L4Uvc93o7tay163WVzQePVUOz/IwsJPLQs3hcjQ==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.16.11.tgz",
+      "integrity": "sha512-zjDMBVWbP/0KhzcAdlOkZaYJtoMnJEZDc2BAXqfrXQvr1JFor7vTxZUFvWKF0B1XbSNGpJPvFWmho02bjPiR3g==",
       "cpu": [
         "arm64"
       ],
@@ -503,9 +503,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.16.10.tgz",
-      "integrity": "sha512-axqbGX//v+AF/73OZUfUGG5pZidnZf9T+wc+1Jf19O0DViPpcmbVH7l0aLImFQuRn6Nl9LAbfBbKAgO1BS+OSg==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.16.11.tgz",
+      "integrity": "sha512-KS9Y0rs0vwvJLc9AmxI73rUWuIdJLlyAshPuSycQN+i2p8uW8r/ZBAPBB/vFyKdPaSs8j8ymPXmfN4D1yFXG9Q==",
       "cpu": [
         "x64"
       ],
@@ -517,9 +517,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.16.10.tgz",
-      "integrity": "sha512-CoFYLjmttdBRw6k3waRuSoW+36ojY8WspOkr5KzNM6GytrKKIRSLUNkaLLSSnXQK6MN13jemJa32U1DRn8/V1Q==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.16.11.tgz",
+      "integrity": "sha512-wULkYyufJz91NAjLtZyb3ycEw9w7sg0iFoGG9rHABqRtRHkFieaFT8BjjJTvUwRf2ZolQk+YZL4edE88h85QFQ==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +531,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.16.10.tgz",
-      "integrity": "sha512-jidO59qo6RZ1HRk7a27noIgUeJmzju13NcKm7+5zZObPPGuXXO1OT3ZYabyO4Zz3eU+wqMTgjM4yphbJerkxPQ==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.16.11.tgz",
+      "integrity": "sha512-c7Evd7fCpocr2LFzHcl9eQF0BxXZauTraIiCxpKK7ddIuCnpbuPllkMpAUE9vob20mqnGy5WLHZby9v7vqSr+Q==",
       "cpu": [
         "arm64"
       ],
@@ -545,9 +545,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.16.10.tgz",
-      "integrity": "sha512-RWbkaDIX4fD+OaE+XfNG8nOxh+qLA90KhuejlTFbAApn7lZtyhr/UTIPuJsjmzMUW145C0NJTugOB6Q6XtKGNA==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.16.11.tgz",
+      "integrity": "sha512-LbjKo4seS7m6rOzw/r9H3VLvnjhuo/fFuRJ8OG6pYCbkZNtChdhk88DFN8Qr0n8Qe9PFwweIvQxXBZK7IEUu6A==",
       "cpu": [
         "x64"
       ],
@@ -559,9 +559,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.16.10.tgz",
-      "integrity": "sha512-V7oXFLCowIEOnYBph4J2KSiHYtBIrx00xmwzKzSvwMzVOxDkw1LmPUYLCz/AEU6MctE6S2ZR947IXJY7ch4HeQ==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.16.11.tgz",
+      "integrity": "sha512-kKuIf5hD12rtmJFSe/EGv8jXi0QWwCMDpcL2F0cRVvq6RSAxwSBF/RTEq40PJBBGAf6KJeqgV9j4glxhFn5f7w==",
       "cpu": [
         "x64"
       ],
@@ -573,9 +573,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.16.10.tgz",
-      "integrity": "sha512-QrWe71tjRKSDLejklPoU7gySq16nrJMOrqcSaw+ERQtJpnJBruF0RWQEVFEev6TvzwRnxrdTqDucYcFmoFqGeg==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.16.11.tgz",
+      "integrity": "sha512-lx9x2EEbyHW5t2aooWtXI2AWd3WzDs+4T/p3RBp/HPp9ziwL2hEdzmjMC3DgdnbmwUmUGvfquSElF6ZGC9L5pA==",
       "cpu": [
         "arm64"
       ],
@@ -587,9 +587,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.16.10.tgz",
-      "integrity": "sha512-V5LHfgB5uiiKNpOFOAfygsL36pN6qSuQ0moiuEyZFfWL2Iyx5026ksefiD9nXcygQsLYU7f6xQbOINAY3uIvcw==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.16.11.tgz",
+      "integrity": "sha512-k/ZfoIR5V6bPoemFvMb9EJu3YkSoF2AAKhC7AfKM4tg9UfJ1Wj/9J/edTv1aRQCRTzPiWoS+W5v1SPogVE80Qg==",
       "cpu": [
         "x64"
       ],
@@ -1229,9 +1229,9 @@
       "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "node_modules/oxlint": {
-      "version": "0.16.10",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.16.10.tgz",
-      "integrity": "sha512-xSHmXzQ8cuoeUFoHsc0NIab81KsXNNUKJbK7ZaoCcSWcWSDc4oyc9giPnaVOnVCye5XR7FfX2x4OXqJ9nQdKHw==",
+      "version": "0.16.11",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.16.11.tgz",
+      "integrity": "sha512-JjeOwCeDfA9Y5vLswScJZlMyWBXEVz0LKKksgfkO3cgRV/XXvVzLzBEZ0h5bBiCBK1eS+jCFWh0bycECQkoWUQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1245,14 +1245,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "0.16.10",
-        "@oxlint/darwin-x64": "0.16.10",
-        "@oxlint/linux-arm64-gnu": "0.16.10",
-        "@oxlint/linux-arm64-musl": "0.16.10",
-        "@oxlint/linux-x64-gnu": "0.16.10",
-        "@oxlint/linux-x64-musl": "0.16.10",
-        "@oxlint/win32-arm64": "0.16.10",
-        "@oxlint/win32-x64": "0.16.10"
+        "@oxlint/darwin-arm64": "0.16.11",
+        "@oxlint/darwin-x64": "0.16.11",
+        "@oxlint/linux-arm64-gnu": "0.16.11",
+        "@oxlint/linux-arm64-musl": "0.16.11",
+        "@oxlint/linux-x64-gnu": "0.16.11",
+        "@oxlint/linux-x64-musl": "0.16.11",
+        "@oxlint/win32-arm64": "0.16.11",
+        "@oxlint/win32-x64": "0.16.11"
       }
     },
     "node_modules/path-key": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "globals": "^16.1.0",
-    "oxlint": "^0.16.10",
+    "oxlint": "^0.16.11",
     "prettier": "^3.5.3",
     "tsx": "^4.19.4",
     "typedoc": "^0.28.4"


### PR DESCRIPTION
### TL;DR

Upgraded oxlint from version 0.16.10 to 0.16.11.

### What changed?

This PR updates the oxlint dependency from version 0.16.10 to 0.16.11 in both package.json and package-lock.json files. All related oxlint platform-specific packages were also updated to the same version.

### How to test?

1. Run `npm install` to update dependencies
2. Run linting with `npx oxlint` to verify the new version works correctly
3. Ensure no regressions in linting functionality

### Why make this change?

Keeping dependencies up to date ensures we have the latest bug fixes and improvements. This minor version update of oxlint likely includes performance improvements and bug fixes that will enhance our linting process.