### PR TITLE
Exchange hotfix

### DIFF
--- a/data/2016/dataSources/AccountCrates.json
+++ b/data/2016/dataSources/AccountCrates.json
@@ -2779,130 +2779,35 @@
     "name": "Skirmish Bag: Small Firearms",
     "itemDefinitionId": 3274,
     "rewards": [
-      {
-        "name": "Blue and Black Hoodie",
-        "itemDefinitionId": 2368,
-        "rewardChance": 20
-      },
-      {
-        "name": "Scorpion Hoodie",
-        "itemDefinitionId": 2885,
-        "rewardChance": 20
-      },
-      {
-        "name": "Stormcloud Leggings",
-        "itemDefinitionId": 3238,
-        "rewardChance": 20
-      },
-      {
-        "name": "Teal Scale Leggings",
-        "itemDefinitionId": 3215,
-        "rewardChance": 20
-      }
+
     ]
   },
   {
     "name": "Skirmish Bag: Shotties & Snipers",
     "itemDefinitionId": 3365,
     "rewards": [
-      {
-        "name": "Green Starred Armor",
-        "itemDefinitionId": 3271,
-        "rewardChance": 20
-      },
-      {
-        "name": "Pink Anarchy Armor",
-        "itemDefinitionId": 3270,
-        "rewardChance": 20
-      },
-      {
-        "name": "Plaid Jacket",
-        "itemDefinitionId": 2945,
-        "rewardChance": 20
-      },
-      {
-        "name": "Forest Camo Jacket",
-        "itemDefinitionId": 2947,
-        "rewardChance": 20
-      }
+
     ]
   },
   {
     "name": "Skirmish Bag: Ironman",
     "itemDefinitionId": 3447,
     "rewards": [
-      {
-        "name": "Blue Survivor Backpack",
-        "itemDefinitionId": 3048,
-        "rewardChance": 20
-      },
-      {
-        "name": "Orange Survivor Backpack",
-        "itemDefinitionId": 3050,
-        "rewardChance": 20
-      },
-      {
-        "name": "Chaos Face Bandana",
-        "itemDefinitionId": 2932,
-        "rewardChance": 20
-      },
-      {
-        "name": "Yellow Plaid Face Bandana",
-        "itemDefinitionId": 2935,
-        "rewardChance": 20
-      }
+
     ]
   },
   {
     "name": "Skirmish Bag: Reanimated",
     "itemDefinitionId": 3523,
     "rewards": [
-      {
-        "name": "Starry-Eyed Goggles",
-        "itemDefinitionId": 2959,
-        "rewardChance": 20
-      },
-      {
-        "name": "Beige Suit Jacket",
-        "itemDefinitionId": 2842,
-        "rewardChance": 20
-      },
-      {
-        "name": "Emote: Formal Bow",
-        "itemDefinitionId": 3291,
-        "rewardChance": 20
-      },
-      {
-        "name": "Emote: Tea Time",
-        "itemDefinitionId": 3342,
-        "rewardChance": 20
-      }
+
     ]
   },
   {
     "name": "Skirmish Bag: Shotguns & Snipers 2",
     "itemDefinitionId": 3633,
     "rewards": [
-      {
-        "name": "Beige Slacks",
-        "itemDefinitionId": 2844,
-        "rewardChance": 20
-      },
-      {
-        "name": "Camo Goggles",
-        "itemDefinitionId": 2956,
-        "rewardChance": 20
-      },
-      {
-        "name": "Rasta Face Bandana",
-        "itemDefinitionId": 2934,
-        "rewardChance": 20
-      },
-      {
-        "name": "Emote: World's Smallest Violin",
-        "itemDefinitionId": 3348,
-        "rewardChance": 20
-      }
+
     ]
   },
   {


### PR DESCRIPTION
- Removed skins out of unused Bags since they do collide with skins from new crates which could result in nothing in reward.

- Added "Blue Camo Cants" as exchangeable.

Asset sent in discord, required for the blue camo pants to work correctly.

Serveritem def are the changes from my old push aswell as the new changes i made. 

Did not manage to update my serverfolder b4 making the PR. 