### PR TITLE
check for permissionLevel on getadmin

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1037,7 +1037,7 @@ export class ZoneServer2016 extends EventEmitter {
     return Boolean(
       await this._db
         ?.collection(DB_COLLECTIONS.ADMINS)
-        .findOne({ sessionId: loginSessionId })
+        .findOne({ sessionId: loginSessionId, permissionLevel: { $ne: 0 } })
     );
   }
 


### PR DESCRIPTION
### TL;DR

Updated admin authentication check to exclude users with permission level 0.

### What changed?

Modified the admin authentication query in `ZoneServer2016` to check that the user not only has a matching `sessionId` but also has a permission level that is not equal to 0.

### How to test?

1. Create a user with `permissionLevel: 0` and a valid `sessionId`
2. Attempt to perform admin actions with this user
3. Verify that the user is denied access despite having a valid `sessionId`
4. Test with users having permission levels > 0 to ensure they still have proper access

### Why make this change?

This change prevents users with permission level 0 from being authenticated as admins, even if they have a valid session ID. This adds an additional security layer to ensure only users with appropriate permission levels can perform admin actions.