### PR TITLE
Backpack Durabillity loss

### DIFF
--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -770,6 +770,52 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
     }
     // --- End durability loss ---
 
+    // --- Durability loss for MilitaryTan bag on death ---
+    const bag = this._loadout[LoadoutSlots.BACK];
+    if (bag && server.isMilitaryTan(bag.itemDefinitionId)) {
+      bag.currentDurability = (bag.currentDurability || 0) - 334; /// 6 Lifes/Tan
+      if (bag.currentDurability <= 0) {
+        server.removeInventoryItem(this, bag);
+        this.lootContainerItem(server, server.generateItem(Items.CLOTH, 4));
+        this.lootContainerItem(server, server.generateItem(Items.TWINE, 1));
+        this.lootContainerItem(server, server.generateItem(Items.METAL_BRACKET, 1));
+      }
+    }
+    // --- End durability loss for MilitaryTan ---
+
+    // --- Durability loss for Small Backpack on death ---
+    const smallBackpack = this._loadout[LoadoutSlots.BACK];
+    if (
+    smallBackpack &&
+     server.isBackpack &&
+     server.isBackpack(smallBackpack.itemDefinitionId)
+) {
+  smallBackpack.currentDurability = (smallBackpack.currentDurability || 0) - 500; // 4 lifes/small backpack
+  if (smallBackpack.currentDurability <= 0) {
+    server.removeInventoryItem(this, smallBackpack);
+    this.lootContainerItem(server, server.generateItem(Items.CLOTH, 4));
+  }
+}
+    // --- End durability loss for Small Backpack ---
+
+    // --- Durability loss for Framed Backpack on death ---
+   const framedBackpack = this._loadout[LoadoutSlots.BACK];
+  if (
+  framedBackpack &&
+  server.isFramedBp &&
+  server.isFramedBp(framedBackpack.itemDefinitionId)
+) {
+  framedBackpack.currentDurability = (framedBackpack.currentDurability || 0) - 400; // 5 lifes/framed backpack
+  if (framedBackpack.currentDurability <= 0) {
+    server.removeInventoryItem(this, framedBackpack);
+    this.lootContainerItem(server, server.generateItem(Items.CLOTH, 2));
+    this.lootContainerItem(server, server.generateItem(Items.BACKPACK_FRAME, 1));
+  }
+}
+// --- End durability loss for Framed Backpack ---
+
+
+
     const items: { [itemGuid: string]: BaseItem } = {};
     Object.values(this._loadout).forEach((itemData) => {
       if (

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6162,6 +6162,47 @@ export class ZoneServer2016 extends EventEmitter {
     return itemDef?.ITEM_CLASS == 25000 && itemDef?.IS_ARMOR == 1;
   }
 
+/**
+ * Checks if an item with the specified itemDefinitionId is a MilitaryTan backpack.
+ *
+ * @param {number} itemDefinitionId - The itemDefinitionId to check.
+ * @returns {boolean} True if the item is a MilitaryTan bag, false otherwise.
+ */
+isMilitaryTan(itemDefinitionId: number): boolean {
+  const militaryTanBag = [
+    Items.BACKPACK_MILITARY_TAN,
+    2118,2119,2120,2121,2122,2123,2124,2393,2777,2778,3046,3169,5022,5033,3042,3043,3044,3045,3046,3047,3169,3403,3583,4008,4009,4010,4011,5012,
+  ];
+  return militaryTanBag.includes(itemDefinitionId);
+}
+
+/**
+ * Checks if an item with the specified itemDefinitionId is a Framed bag.
+ *
+ * @param {number} itemDefinitionId - The itemDefinitionId to check.
+ * @returns {boolean} True if the item is a MilitaryTan bag, false otherwise.
+ */
+isFramedBp(itemDefinitionId: number): boolean {
+  const BACKPACK_FRAMED = [
+    Items.BACKPACK_FRAMED,
+    1995,2073,2111,
+  ];
+  return BACKPACK_FRAMED.includes(itemDefinitionId);
+}
+
+/**
+ * Checks if an item with the specified itemDefinitionId is a Small backpack (1000 bulk).
+ *
+ * @param {number} itemDefinitionId - The itemDefinitionId to check.
+ * @returns {boolean} True if the item is a MilitaryTan bag, false otherwise.
+ */
+isBackpack(itemDefinitionId: number): boolean {
+  const Small_Backpack = [
+    2051,2072,2112,2113,2114,2115,2116,2117,2038,3643,3644,3742,3798
+  ];
+  return Small_Backpack.includes(itemDefinitionId);
+}
+
   /**
    * Checks if an item with the specified itemDefinitionId is a convey.
    *


### PR DESCRIPTION
Backpack Durabillity loss when dying + added rewards for them when brakeing

Military Tan - 6 Lifes (Reward: 4 Cloth,1 Twine, 1 Metal Bracket

Framed backpack - 5 lifes (Reward 2Cloth,1 Backpack frame)

Small backpack - 4 lifes (Reward 4 cloth)