### PR TITLE
cooldown_on_force_exit

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -647,7 +647,16 @@ export class ZoneServer2016 extends EventEmitter {
     );
     this._gatewayServer.on("disconnect", (sessionId: number) => {
       // this happen when the connection is close without a regular logout
-      this.deleteClient(this._clients[sessionId]);
+      const client = this._clients[sessionId];
+      if (client) {
+        if (client.properlyLogout) {
+          this.deleteClient(client);
+        } else {
+          setTimeout(() => {
+            this.deleteClient(client);
+          }, 10_000);
+        }
+      }
     });
 
     this._gatewayServer.on(


### PR DESCRIPTION
### TL;DR

Added a delay when handling disconnects for clients that didn't properly logout.

### What changed?

Modified the disconnect event handler in the ZoneServer2016 class to check if a client has properly logged out before deleting it. If the client did not properly logout, the deletion is now delayed by 10 seconds using setTimeout.

### How to test?

1. Connect to the zone server
2. Force a disconnect without proper logout (e.g., close the client abruptly)
3. Verify that the client remains in the system for 10 seconds before being deleted
4. Test with a proper logout to confirm immediate deletion still works

### Why make this change?

This change helps handle unexpected disconnections more gracefully by giving the system time to potentially recover or complete any pending operations before removing the client. This can prevent data loss or inconsistent states that might occur when a client disconnects abruptly without going through the proper logout procedure.