### PR TITLE
change_pop_level_calculations

### DIFF
--- a/src/servers/LoginServer/loginserver.ts
+++ b/src/servers/LoginServer/loginserver.ts
@@ -83,6 +83,13 @@ export enum PopLevel {
   HIGH = 2,
   FULL = 3
 }
+export function getPopLevel(population: number): PopLevel {
+  if (population <= 20) return PopLevel.LOW;
+  else if (population >= 21 && population <= 50) return PopLevel.MEDIUM;
+  else if (population >= 51 && population <= 120) return PopLevel.HIGH;
+  else if (population >= 121) return PopLevel.FULL;
+  else return PopLevel.LOW;
+}
 
 interface QueuedClient {
   client: Client;
@@ -258,18 +265,18 @@ export class LoginServer extends EventEmitter {
                     console.error(`Game server ${serverId} not found`);
                     return;
                   }
-                  let populationLevel: PopLevel = PopLevel.LOW;
+                  let populationLevel: PopLevel = getPopLevel(population);
 
-                  if (population <= 50 && population >= 25) {
-                    populationLevel = PopLevel.MEDIUM;
-                  } else if (
-                    population < serverData.maxPopulationNumber &&
-                    population > 50
-                  ) {
-                    populationLevel = PopLevel.HIGH;
-                  } else if (population >= serverData.maxPopulationNumber) {
-                    populationLevel = PopLevel.FULL;
-                  }
+                  // if (population <= 50 && population >= 25) {
+                  //   populationLevel = PopLevel.MEDIUM;
+                  // } else if (
+                  //   population < serverData.maxPopulationNumber &&
+                  //   population > 50
+                  // ) {
+                  //   populationLevel = PopLevel.HIGH;
+                  // } else if (population >= serverData.maxPopulationNumber) {
+                  //   populationLevel = PopLevel.FULL;
+                  // }
 
                   this._db?.collection(DB_COLLECTIONS.SERVERS).findOneAndUpdate(
                     { serverId: serverId },


### PR DESCRIPTION
### TL;DR

Refactored server population level calculation into a utility function.

### What changed?

- Extracted population level calculation logic from `LoginServer` class into a new utility function `getPopLevel` in `utils.ts`
- Updated the population thresholds for different levels:
  - LOW: ≤ 20 players
  - MEDIUM: 21-50 players
  - HIGH: 51-120 players
  - FULL: ≥ 121 players
- Commented out the old inline calculation in `loginserver.ts`

### How to test?

1. Connect to different game servers with varying player populations
2. Verify that the population level indicators display correctly based on the new thresholds
3. Check that servers show the correct population status (LOW/MEDIUM/HIGH/FULL) in the server selection UI

### Why make this change?

This change improves code maintainability by centralizing the population level calculation logic in a single utility function. It also standardizes the population thresholds across the application, making it easier to adjust these values in the future if needed.