### PR TITLE
updt deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/js-yaml": "4.0.9",
-        "@types/node": "22.15.17",
+        "@types/node": "24.0.7",
         "@types/ws": "8.18.1",
-        "debug": "4.4.0",
+        "debug": "4.4.1",
         "h1emu-ai": "^0.1.0",
         "h1emu-core": "1.3.2",
         "h1z1-dataschema": "1.9.2",
         "js-yaml": "4.1.0",
-        "mongodb": "6.16.0",
-        "recast-navigation": "0.34.0",
+        "mongodb": "6.17.0",
+        "recast-navigation": "0.39.0",
         "threads": "1.7.0",
         "typescript": "5.8.3",
         "ws": "8.18.2"
@@ -30,14 +30,14 @@
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
-        "globals": "^16.1.0",
-        "oxlint": "^0.16.11",
-        "prettier": "^3.5.3",
-        "tsx": "^4.19.4",
-        "typedoc": "^0.28.4"
+        "globals": "^16.2.0",
+        "oxlint": "^1.3.0",
+        "prettier": "^3.6.2",
+        "tsx": "^4.20.3",
+        "typedoc": "^0.28.6"
       },
       "engines": {
-        "node": ">=0.22.0 <24"
+        "node": ">=0.22.0 <25"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-0.16.11.tgz",
-      "integrity": "sha512-zjDMBVWbP/0KhzcAdlOkZaYJtoMnJEZDc2BAXqfrXQvr1JFor7vTxZUFvWKF0B1XbSNGpJPvFWmho02bjPiR3g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-TcCaETXYfiEfS+u/gZNND4WwEEtnJJjqg8BIC56WiCQDduYTvmmbQ0vxtqdNXlFzlvmRpZCSs7qaqXNy8/8FLA==",
       "cpu": [
         "arm64"
       ],
@@ -503,9 +503,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-0.16.11.tgz",
-      "integrity": "sha512-KS9Y0rs0vwvJLc9AmxI73rUWuIdJLlyAshPuSycQN+i2p8uW8r/ZBAPBB/vFyKdPaSs8j8ymPXmfN4D1yFXG9Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-REgq9s1ZWuh++Vi+mUPNddLTp/D+iu+T8nLd3QM1dzQoBD/SZ7wRX3Mdv8QGT/m8dknmDBQuKAP6T47ox9HRSA==",
       "cpu": [
         "x64"
       ],
@@ -517,9 +517,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-0.16.11.tgz",
-      "integrity": "sha512-wULkYyufJz91NAjLtZyb3ycEw9w7sg0iFoGG9rHABqRtRHkFieaFT8BjjJTvUwRf2ZolQk+YZL4edE88h85QFQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-QAS8AWKDcDeUe8mJaw/pF2D9+js8FbFTo75AiekZKNm9V6QAAiCkyvesmILD8RrStw9aV2D/apOD71vsfcDoGA==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +531,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-0.16.11.tgz",
-      "integrity": "sha512-c7Evd7fCpocr2LFzHcl9eQF0BxXZauTraIiCxpKK7ddIuCnpbuPllkMpAUE9vob20mqnGy5WLHZby9v7vqSr+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-rAbz0KFkk5GPdERoFO4ZUZmVkECnHXjRG0O2MeT5zY7ddlyZUjEk1cWjw+HCtWVdKkqhZJeNFMuEiRLkpzBIIw==",
       "cpu": [
         "arm64"
       ],
@@ -545,9 +545,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-0.16.11.tgz",
-      "integrity": "sha512-LbjKo4seS7m6rOzw/r9H3VLvnjhuo/fFuRJ8OG6pYCbkZNtChdhk88DFN8Qr0n8Qe9PFwweIvQxXBZK7IEUu6A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-6uLO1WsJwCtVNGHtjXwg2TRvxQYttYJKMjSdv6RUXGWY1AI+/+yHzvu+phU/F40uNC7CFhFnqWDuPaSZ49hdAQ==",
       "cpu": [
         "x64"
       ],
@@ -559,9 +559,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-0.16.11.tgz",
-      "integrity": "sha512-kKuIf5hD12rtmJFSe/EGv8jXi0QWwCMDpcL2F0cRVvq6RSAxwSBF/RTEq40PJBBGAf6KJeqgV9j4glxhFn5f7w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-+vrmJUHgtJmgIo+L9eTP04NI/OQNCOZtQo6I49qGWc9cpr+0MnIh9KMcyAOxmzVTF5g+CF1I/1bUz4pk4I3LDw==",
       "cpu": [
         "x64"
       ],
@@ -573,9 +573,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-0.16.11.tgz",
-      "integrity": "sha512-lx9x2EEbyHW5t2aooWtXI2AWd3WzDs+4T/p3RBp/HPp9ziwL2hEdzmjMC3DgdnbmwUmUGvfquSElF6ZGC9L5pA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.3.0.tgz",
+      "integrity": "sha512-k+ETUVl+O3b8Rcd2PP5V3LqQ2QoN/TOX2f19XXHZEynbVLY3twLYPb3hLdXqoo7CKRq3RJdTfn1upHH48/qrZQ==",
       "cpu": [
         "arm64"
       ],
@@ -587,9 +587,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-0.16.11.tgz",
-      "integrity": "sha512-k/ZfoIR5V6bPoemFvMb9EJu3YkSoF2AAKhC7AfKM4tg9UfJ1Wj/9J/edTv1aRQCRTzPiWoS+W5v1SPogVE80Qg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.3.0.tgz",
+      "integrity": "sha512-nWSgK0fT02TQ/BiAUCd13BaobtHySkCDcQaL+NOmhgeb0tNWjtYiktuluahaIqFcYJPWczVlbs8DU/Eqo8vsug==",
       "cpu": [
         "x64"
       ],
@@ -601,42 +601,28 @@
       ]
     },
     "node_modules/@recast-navigation/core": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@recast-navigation/core/-/core-0.34.0.tgz",
-      "integrity": "sha512-aJRDmwCSgBgGnnL4pWi2ya/U0NwDJWJrPQnX0a5WG3fVRnL+fkgUfVCVaNAqb0ouLFQVSARqV0QalYtv2kyClw==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@recast-navigation/core/-/core-0.39.0.tgz",
+      "integrity": "sha512-l48GHrimIUR+9ugAsjIecdUh5ohHULrFYUn5EqClafV5HJB/cPFBbN4n9HV2jDamCjGRGEhtSpId7NpkhoF0qQ==",
       "license": "MIT",
       "dependencies": {
-        "@recast-navigation/wasm": "0.34.0"
+        "@recast-navigation/wasm": "0.39.0"
       }
     },
     "node_modules/@recast-navigation/generators": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@recast-navigation/generators/-/generators-0.34.0.tgz",
-      "integrity": "sha512-DSXZEIw5mlTjHXOKKymo3UMgoEtHz4DgAircw0dF0m0b8RRoA7KnIZ/OXBtT2JwuJqllclCiD9iI6gRmHHjgew==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@recast-navigation/generators/-/generators-0.39.0.tgz",
+      "integrity": "sha512-ymiacmEWK4SGY/FUlr6/n9/FgvA9NikPR57JyCGbteScEG10UYByrPGXJQU/UXuzUhUbmtKlPJAk2KP+MLgxJA==",
       "license": "MIT",
       "dependencies": {
-        "@recast-navigation/core": "0.34.0",
-        "@recast-navigation/wasm": "0.34.0"
-      }
-    },
-    "node_modules/@recast-navigation/three": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@recast-navigation/three/-/three-0.34.0.tgz",
-      "integrity": "sha512-JQRiMSUk2Ex9gsOVBfPz49nlaTzlv2HU7QQm1N3/YpPkN/t8SRzj4bDDozhL5rCqtWnbgFZtmM2rLr/c3E3AKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@recast-navigation/core": "0.34.0",
-        "@recast-navigation/generators": "0.34.0"
-      },
-      "peerDependencies": {
-        "@types/three": "0.x.x",
-        "three": "0.x.x"
+        "@recast-navigation/core": "0.39.0",
+        "@recast-navigation/wasm": "0.39.0"
       }
     },
     "node_modules/@recast-navigation/wasm": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@recast-navigation/wasm/-/wasm-0.34.0.tgz",
-      "integrity": "sha512-O14c01YYV/zp4nDQ6L71W3ljfasH8L5xgxpSdqSEs3XkhKyePZz5bng9K7DALHSOZVVXnqdWYazRT1GQ1fQrfw==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@recast-navigation/wasm/-/wasm-0.39.0.tgz",
+      "integrity": "sha512-1P/8pqXtwJSVseLBtO0AOdqQe1XnhPFTVvG9FMORFVFunYqkKXxULgni8x3fsutkQisyY+X7YQoIMLvZR4lKFA==",
       "license": "MIT"
     },
     "node_modules/@shikijs/engine-oniguruma": {
@@ -688,13 +674,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tweenjs/tween.js": {
-      "version": "23.1.3",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
-      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -711,34 +690,12 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
     },
     "node_modules/@types/node": {
-      "version": "22.15.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
-      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "version": "24.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
+      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/stats.js": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
-      "integrity": "sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/three": {
-      "version": "0.168.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.168.0.tgz",
-      "integrity": "sha512-qAGLGzbaYgkkonOBfwOr+TZpOskPfFjrDAj801WQSVkUz0/D9zwir4vhruJ/CC/GteywzR9pqeVVfs5th/2oKw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@tweenjs/tween.js": "~23.1.3",
-        "@types/stats.js": "*",
-        "@types/webxr": "*",
-        "@webgpu/types": "*",
-        "fflate": "~0.8.2",
-        "meshoptimizer": "~0.18.1"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/unist": {
@@ -752,13 +709,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
-    },
-    "node_modules/@types/webxr": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.20.tgz",
-      "integrity": "sha512-JGpU6qiIJQKUuVSKx1GtQnHJGxRjtfGIhzO2ilq43VZZS//f1h1Sgexbdk+Lq+7569a6EYhOWrUpIruR/1Enmg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/whatwg-url": {
       "version": "11.0.3",
@@ -776,13 +726,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@webgpu/types": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.45.tgz",
-      "integrity": "sha512-0TBBF/mhakJoK0qUWCZugBnh23x+VwmYA5RLmtNQwvZt1pQ4P2fzIvQUiSe6jxzkBi4GF8R4BejJjro0ZSoSXQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -807,9 +750,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
-      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
@@ -858,9 +801,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -937,13 +880,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -973,9 +909,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
-      "integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
+      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1139,13 +1075,6 @@
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "license": "MIT"
     },
-    "node_modules/meshoptimizer": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
-      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -1163,13 +1092,13 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
-      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
+      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
+        "bson": "^6.10.4",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -1229,9 +1158,9 @@
       "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "node_modules/oxlint": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-0.16.11.tgz",
-      "integrity": "sha512-JjeOwCeDfA9Y5vLswScJZlMyWBXEVz0LKKksgfkO3cgRV/XXvVzLzBEZ0h5bBiCBK1eS+jCFWh0bycECQkoWUQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.3.0.tgz",
+      "integrity": "sha512-PzAOmPxnXYpVF1q6h9pkOPH6uJ/44XrtFWJ8JcEMpoEq9HISNelD3lXhACtOAW8CArjLy/qSlu2KkyPxnXgctA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1245,14 +1174,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "0.16.11",
-        "@oxlint/darwin-x64": "0.16.11",
-        "@oxlint/linux-arm64-gnu": "0.16.11",
-        "@oxlint/linux-arm64-musl": "0.16.11",
-        "@oxlint/linux-x64-gnu": "0.16.11",
-        "@oxlint/linux-x64-musl": "0.16.11",
-        "@oxlint/win32-arm64": "0.16.11",
-        "@oxlint/win32-x64": "0.16.11"
+        "@oxlint/darwin-arm64": "1.3.0",
+        "@oxlint/darwin-x64": "1.3.0",
+        "@oxlint/linux-arm64-gnu": "1.3.0",
+        "@oxlint/linux-arm64-musl": "1.3.0",
+        "@oxlint/linux-x64-gnu": "1.3.0",
+        "@oxlint/linux-x64-musl": "1.3.0",
+        "@oxlint/win32-arm64": "1.3.0",
+        "@oxlint/win32-x64": "1.3.0"
       }
     },
     "node_modules/path-key": {
@@ -1266,9 +1195,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1300,14 +1229,13 @@
       }
     },
     "node_modules/recast-navigation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/recast-navigation/-/recast-navigation-0.34.0.tgz",
-      "integrity": "sha512-b0bBOk6SaT+PmtkPNV9UxMHwt81DzhdL1X5dwWv7KSt93xajCPsaWikVuiX7DlIGi7GZ0jXaTFR2G6y+xbR8TQ==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/recast-navigation/-/recast-navigation-0.39.0.tgz",
+      "integrity": "sha512-xh9gYN990nDGs8QXRPXt4gqDCSQhS954lSTukI1i//GHecWonKVBFNxt79mqC+v0Lz2RFz5gKqpQQPHLdFM/iQ==",
       "license": "MIT",
       "dependencies": {
-        "@recast-navigation/core": "0.34.0",
-        "@recast-navigation/generators": "0.34.0",
-        "@recast-navigation/three": "0.34.0"
+        "@recast-navigation/core": "0.39.0",
+        "@recast-navigation/generators": "0.39.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1404,13 +1332,6 @@
         "tiny-worker": ">= 2"
       }
     },
-    "node_modules/three": {
-      "version": "0.168.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
-      "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tiny-worker": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
@@ -1432,9 +1353,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.19.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
-      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1452,9 +1373,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.4.tgz",
-      "integrity": "sha512-xKvKpIywE1rnqqLgjkoq0F3wOqYaKO9nV6YkkSat6IxOWacUCc/7Es0hR3OPmkIqkPoEn7U3x+sYdG72rstZQA==",
+      "version": "0.28.6",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.6.tgz",
+      "integrity": "sha512-2VvfK6z3yupcu75qZB00LGICg4qa0lw4yPBrFcnZgqIMwpLjLWopTqNeJ4SSS/s92myvWBECY5zcOSMqpvW3CA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1496,9 +1417,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "GPL-3.0-only",
   "main": "h1z1-server.js",
   "engines": {
-    "node": ">=0.22.0 <24"
+    "node": ">=0.22.0 <25"
   },
   "bin": {
     "h1z1-server-demo": "scripts/h1z1-server-demo.js",
@@ -14,15 +14,15 @@
   },
   "dependencies": {
     "@types/js-yaml": "4.0.9",
-    "@types/node": "22.15.17",
+    "@types/node": "24.0.7",
     "@types/ws": "8.18.1",
-    "debug": "4.4.0",
+    "debug": "4.4.1",
     "h1emu-ai": "^0.1.0",
     "h1emu-core": "1.3.2",
     "h1z1-dataschema": "1.9.2",
     "js-yaml": "4.1.0",
-    "mongodb": "6.16.0",
-    "recast-navigation": "0.34.0",
+    "mongodb": "6.17.0",
+    "recast-navigation": "0.39.0",
     "threads": "1.7.0",
     "typescript": "5.8.3",
     "ws": "8.18.2"
@@ -32,11 +32,11 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "globals": "^16.1.0",
-    "oxlint": "^0.16.11",
-    "prettier": "^3.5.3",
-    "tsx": "^4.19.4",
-    "typedoc": "^0.28.4"
+    "globals": "^16.2.0",
+    "oxlint": "^1.3.0",
+    "prettier": "^3.6.2",
+    "tsx": "^4.20.3",
+    "typedoc": "^0.28.6"
   },
   "scripts": {
     "gen-packets-types": "tsx ./scripts/genPacketsNames.ts",

--- a/src/packets/ClientProtocol/ClientProtocol_860/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/shared.ts
@@ -381,7 +381,7 @@ export function packItemDefinitionData(obj: any) {
   }
   v.writeUInt8(flagValue, 0); // flags
   data = Buffer.concat([data, v]);
-  (v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["nameId"], 0);
+  ((v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["nameId"], 0));
   data = Buffer.concat([data, v]);
   v.writeUInt32LE(obj["descriptionId"], 0);
   data = Buffer.concat([data, v]);
@@ -406,20 +406,20 @@ export function packItemDefinitionData(obj: any) {
   v.writeUInt32LE(obj["slot"], 0);
   data = Buffer.concat([data, v]);
   if (obj["modelName"]) {
-    (v = Buffer.allocUnsafe(4 + obj["modelName"].length)),
-      v.writePrefixedStringLE(obj["modelName"], 0);
+    ((v = Buffer.allocUnsafe(4 + obj["modelName"].length)),
+      v.writePrefixedStringLE(obj["modelName"], 0));
   } else {
-    (v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0);
+    ((v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0));
   }
   data = Buffer.concat([data, v]);
   if (obj["textureAlias"]) {
-    (v = Buffer.allocUnsafe(4 + obj["textureAlias"].length)),
-      v.writePrefixedStringLE(obj["textureAlias"], 0);
+    ((v = Buffer.allocUnsafe(4 + obj["textureAlias"].length)),
+      v.writePrefixedStringLE(obj["textureAlias"], 0));
   } else {
-    (v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0);
+    ((v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0));
   }
   data = Buffer.concat([data, v]);
-  (v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["genderUsage"], 0);
+  ((v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["genderUsage"], 0));
   data = Buffer.concat([data, v]);
   v.writeUInt32LE(obj["itemType"], 0);
   data = Buffer.concat([data, v]);
@@ -448,13 +448,13 @@ export function packItemDefinitionData(obj: any) {
   v.writeUInt32LE(obj["unknownDword27"], 0);
   data = Buffer.concat([data, v]);
   if (obj["tintAlias"]) {
-    (v = Buffer.allocUnsafe(4 + obj["tintAlias"].length)),
-      v.writePrefixedStringLE(obj["tintAlias"], 0);
+    ((v = Buffer.allocUnsafe(4 + obj["tintAlias"].length)),
+      v.writePrefixedStringLE(obj["tintAlias"], 0));
   } else {
-    (v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0);
+    ((v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0));
   }
   data = Buffer.concat([data, v]);
-  (v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["unknownDword28"], 0);
+  ((v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["unknownDword28"], 0));
   data = Buffer.concat([data, v]);
   v.writeUInt32LE(obj["unknownDword29"], 0);
   data = Buffer.concat([data, v]);
@@ -475,20 +475,20 @@ export function packItemDefinitionData(obj: any) {
   v.writeUInt32LE(obj["unknownDword37"], 0);
   data = Buffer.concat([data, v]);
   if (obj["overlayTexture"]) {
-    (v = Buffer.allocUnsafe(4 + obj["overlayTexture"].length)),
-      v.writePrefixedStringLE(obj["overlayTexture"], 0);
+    ((v = Buffer.allocUnsafe(4 + obj["overlayTexture"].length)),
+      v.writePrefixedStringLE(obj["overlayTexture"], 0));
   } else {
-    (v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0);
+    ((v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0));
   }
   data = Buffer.concat([data, v]);
   if (obj["decalSlot"]) {
-    (v = Buffer.allocUnsafe(4 + obj["decalSlot"].length)),
-      v.writePrefixedStringLE(obj["decalSlot"], 0);
+    ((v = Buffer.allocUnsafe(4 + obj["decalSlot"].length)),
+      v.writePrefixedStringLE(obj["decalSlot"], 0));
   } else {
-    (v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0);
+    ((v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0));
   }
   data = Buffer.concat([data, v]);
-  (v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["unknownDword38"], 0);
+  ((v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["unknownDword38"], 0));
   data = Buffer.concat([data, v]);
   v.writeUInt32LE(obj["unknownDword39"], 0);
   data = Buffer.concat([data, v]);
@@ -497,13 +497,13 @@ export function packItemDefinitionData(obj: any) {
   v.writeUInt32LE(obj["unknownDword41"], 0);
   data = Buffer.concat([data, v]);
   if (obj["overrideAppearance"]) {
-    (v = Buffer.allocUnsafe(4 + obj["overrideAppearance"].length)),
-      v.writePrefixedStringLE(obj["overrideAppearance"], 0);
+    ((v = Buffer.allocUnsafe(4 + obj["overrideAppearance"].length)),
+      v.writePrefixedStringLE(obj["overrideAppearance"], 0));
   } else {
-    (v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0);
+    ((v = Buffer.allocUnsafe(4)), v.writePrefixedStringLE("", 0));
   }
   data = Buffer.concat([data, v]);
-  (v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["overrideCameraId"], 0);
+  ((v = Buffer.allocUnsafe(4)), v.writeUInt32LE(obj["overrideCameraId"], 0));
   data = Buffer.concat([data, v]);
   v.writeUInt32LE(obj["unknownDword43"], 0);
   data = Buffer.concat([data, v]);


### PR DESCRIPTION
### TL;DR

Updated dependencies to newer versions and expanded Node.js compatibility to include Node 25.

### What changed?

- Updated Node.js engine compatibility from `<24` to `<25`
- Updated core dependencies:
  - `@types/node` from 22.15.17 to 24.0.7
  - `debug` from 4.4.0 to 4.4.1
  - `mongodb` from 6.16.0 to 6.17.0
  - `recast-navigation` from 0.34.0 to 0.39.0
- Updated dev dependencies:
  - `globals` from 16.1.0 to 16.2.0
  - `oxlint` from 0.16.11 to 1.3.0
  - `prettier` from 3.5.3 to 3.6.2
  - `tsx` from 4.19.4 to 4.20.3
  - `typedoc` from 0.28.4 to 0.28.6

### How to test?

1. Run the application with Node.js 25 to verify compatibility
2. Test core functionality to ensure the updated dependencies don't introduce regressions
3. Run the development toolchain (linting, formatting, etc.) to verify the updated dev dependencies work correctly

### Why make this change?

This update ensures the project stays current with the latest dependency versions, which includes bug fixes, performance improvements, and security patches. The expanded Node.js compatibility allows developers to use the latest Node.js version (25) with the application.