### PR TITLE
explosive kills not display properly on killfeed

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2749,7 +2749,14 @@ export class ZoneServer2016 extends EventEmitter {
 
   sendKillFeed(client: Client, damageInfo: DamageInfo) {
     if (client.character.characterId === damageInfo.entity) return;
-    const killerClient = this.getClientByCharId(damageInfo.entity);
+    const killerEntity = this.getEntity(damageInfo.entity);
+    let killerClient;
+
+    if (killerEntity instanceof ProjectileEntity) {
+      killerClient = this.getClientByCharId(killerEntity.managerCharacterId);
+    } else {
+      killerClient = this.getClientByCharId(damageInfo.entity);
+    }
     let isInGodMode = false;
     if (killerClient) {
       isInGodMode = killerClient.character.isGodMode();
@@ -2760,7 +2767,7 @@ export class ZoneServer2016 extends EventEmitter {
       "Character.KilledBy",
 
       {
-        killer: damageInfo.entity,
+        killer: killerClient?.character.characterId,
         killed: client.character.characterId,
         isCheater: isInGodMode
       }
@@ -3184,6 +3191,7 @@ export class ZoneServer2016 extends EventEmitter {
       this._destroyables[entityKey] ||
       this._temporaryObjects[entityKey] ||
       this._traps[entityKey] ||
+      this._throwableProjectiles[entityKey] ||
       undefined
     );
   }


### PR DESCRIPTION
### TL;DR

Fixed kill feed attribution for projectile kills.

### What changed?

- Modified the `sendKillFeed` method to properly handle projectile kills by checking if the killing entity is a `ProjectileEntity`
- When a projectile kills a player, the kill is now attributed to the character who threw/fired the projectile instead of the projectile itself
- Added `_throwableProjectiles` to the entity lookup in the `getEntity` method to ensure projectiles can be properly identified

### How to test?

1. Join a game with at least two players
2. Use a projectile weapon (grenade, rocket launcher, etc.) to kill another player
3. Verify that the kill feed correctly shows your character as the killer, not the projectile

### Why make this change?

Previously, when a player was killed by a projectile, the kill feed would incorrectly attribute the kill to the projectile entity rather than the player who threw/fired it. This change ensures proper kill attribution in the kill feed, improving the player experience and game statistics tracking.