### PR TITLE
explosive kills add to stats player/zombie/playermetrics

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1299,6 +1299,16 @@ export class Character2016 extends BaseFullCharacter {
         sourceEntity.characterId != client.character.characterId
       ) {
         sourceEntity.metrics.playersKilled++;
+      } else if (sourceEntity instanceof ProjectileEntity) {
+        const sourceCharacter = server.getEntity(
+          sourceEntity.managerCharacterId
+        );
+        if (
+          sourceCharacter instanceof Character2016 &&
+          sourceCharacter.characterId != client.character.characterId
+        ) {
+          sourceCharacter.metrics.playersKilled++;
+        }
       }
     }
     server.updateResource(

--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -36,6 +36,7 @@ import { CommandInteractionString } from "types/zone2016packets";
 import { EntityType } from "h1emu-ai";
 import { BaseEntity } from "./baseentity";
 import { ChallengeType } from "../managers/challengemanager";
+import { ProjectileEntity } from "./projectileentity";
 
 export class Npc extends BaseFullCharacter {
   health: number;
@@ -170,8 +171,16 @@ export class Npc extends BaseFullCharacter {
   }
 
   async damage(server: ZoneServer2016, damageInfo: DamageInfo) {
-    const client = server.getClientByCharId(damageInfo.entity),
-      oldHealth = this.health;
+    let client = server.getClientByCharId(damageInfo.entity);
+    if (!client) {
+      const sourceEntity = server.getEntity(damageInfo.entity);
+      if (sourceEntity instanceof ProjectileEntity) {
+        client = server.getClientByCharId(sourceEntity.managerCharacterId);
+      } else {
+        return;
+      }
+    }
+    const oldHealth = this.health;
 
     if ((this.health -= damageInfo.damage) <= 0 && this.isAlive) {
       this.deathTime = Date.now();

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2513,7 +2513,16 @@ export class ZoneServer2016 extends EventEmitter {
 
   logPlayerDeath(client: Client, damageInfo: DamageInfo) {
     debug(client.character.name + " has died");
-    const sourceClient = this.getClientByCharId(damageInfo.entity);
+    let sourceClient = this.getClientByCharId(damageInfo.entity);
+    if (!sourceClient) {
+      const sourceEntity = this.getEntity(damageInfo.entity);
+      if (sourceEntity instanceof ProjectileEntity) {
+        sourceClient = this.getClientByCharId(sourceEntity.managerCharacterId);
+      } else {
+        return;
+      }
+    }
+
     if (!sourceClient) return;
 
     if (


### PR DESCRIPTION
### TL;DR

Fixed projectile kill attribution for player and NPC damage tracking.

### What changed?

- Added logic to properly attribute kills when a projectile is the source of damage
- Updated the character damage system to track kills from projectiles by finding the character who fired them
- Modified NPC damage handling to identify the client responsible when damaged by projectiles
- Enhanced player death logging to trace projectile damage back to the player who fired it

### How to test?

1. Launch a game session with at least two players
2. Have one player kill another using projectile weapons (bow, thrown weapons, etc.)
3. Verify that the kill is properly attributed to the player who fired the projectile
4. Check that player metrics correctly increment the "playersKilled" counter
5. Test the same with NPCs to ensure projectile damage is properly attributed

### Why make this change?

Previously, kills made with projectiles weren't being properly attributed to the player who fired them, resulting in inaccurate kill statistics and potentially affecting gameplay mechanics that rely on kill tracking. This change ensures that projectile kills are correctly attributed to the player who fired the projectile rather than to the projectile entity itself.