### PR TITLE
hide workbenchs that are in a secured shelter

### DIFF
--- a/src/servers/ZoneServer2016/entities/baseentity.ts
+++ b/src/servers/ZoneServer2016/entities/baseentity.ts
@@ -87,6 +87,9 @@ export abstract class BaseEntity {
   /** The physical material the entity is made of - See enums.ts/MaterialTypes for more information */
   materialType: number;
 
+  /** The guid of the secured shelter the entity is inside */
+  isHidden: string = "";
+
   h1emu_ai_id?: bigint;
 
   server: ZoneServer2016;

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -129,9 +129,6 @@ export class Character2016 extends BaseFullCharacter {
   isRunning = false;
   isSitting = false;
 
-  /** The guid of the secured shelter the player is inside */
-  isHidden: string = "";
-
   /** Used for resources */
   isBleeding = false;
   isBandaged = false;

--- a/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
+++ b/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
@@ -63,9 +63,6 @@ export class LootableConstructionEntity extends BaseLootableEntity {
   /** Determines if the LootableConstructionEntity is a SmeltingEntity or CollectingEntity */
   subEntity?: SmeltingEntity | CollectingEntity;
 
-  /** The guid of the secured shelter the LootableConstructionEntity is inside */
-  isHidden: string = "";
-
   /** Used by DecayManager, determines if the entity will be damaged the next decay tick */
   isDecayProtected: boolean = false;
   isProp: boolean = false;

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -1955,7 +1955,7 @@ export class ConstructionManager {
     for (const f in construction.freeplaceEntities) {
       const freePlacedEntity = construction.freeplaceEntities[f];
       if (construction.isInside(freePlacedEntity.state.position)) {
-        if (freePlacedEntity instanceof LootableConstructionEntity) {
+        if (freePlacedEntity instanceof BaseEntity) {
           if (allowed) {
             this.constructionHideEntities(
               server,
@@ -2046,7 +2046,7 @@ export class ConstructionManager {
     server: ZoneServer2016,
     client: Client,
     constructionGuid: string,
-    freePlacedEntity: LootableConstructionEntity,
+    freePlacedEntity: BaseEntity,
     state: boolean
   ) {
     if (state) {

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -4146,6 +4146,8 @@ export class ZoneServer2016 extends EventEmitter {
         }
 
         if (object instanceof ConstructionChildEntity) {
+          if (this.constructionManager.shouldHideEntity(this, client, object))
+            continue;
           this.constructionManager.spawnSimpleConstruction(
             this,
             client,


### PR DESCRIPTION
### TL;DR

Moved `isHidden` property from specific entity classes to the `BaseEntity` class to enable hiding any entity type inside secured shelters.

### What changed?

- Moved the `isHidden` property from `Character2016` and `LootableConstructionEntity` classes to the `BaseEntity` class
- Updated the `constructionHideEntities` method in `ConstructionManager` to accept any `BaseEntity` instead of just `LootableConstructionEntity`
- Modified the entity visibility check in `zoneserver.ts` to hide construction child entities when appropriate

### How to test?

1. Place various entity types inside a secured shelter
2. Lock the shelter and verify that all entities inside are properly hidden from players outside
3. Unlock the shelter and confirm that entities become visible again
4. Test with different entity types to ensure the hiding mechanism works universally

### Why make this change?

This change improves the secured shelter system by allowing any entity type to be hidden when inside a locked shelter, not just characters and lootable construction entities. This creates a more consistent and secure experience for players using shelters to protect their items and constructions.