### PR TITLE
allow some default items to be in lootbag

### DIFF
--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -63,6 +63,24 @@ function getGender(actorModelId: number): number {
   }
 }
 
+const invalidItemForLootbag: Items[] = [
+  Items.WEAPON_FISTS,
+  Items.WEAPON_FLASHLIGHT,
+  Items.MAP,
+  Items.COMPASS_IMPROVISED,
+  Items.BOOTS_GRAY_BLUE
+];
+
+function isValidForLootbag(itemDefinitionId: number): boolean {
+  for (let index = 0; index < invalidItemForLootbag.length; index++) {
+    const invalidId = invalidItemForLootbag[index];
+    if (invalidId === itemDefinitionId) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export abstract class BaseFullCharacter extends BaseLightweightCharacter {
   /** Callback for OnFullCharacterDataRequest */
   onReadyCallback?: (clientTriggered: ZoneClient2016) => void;
@@ -819,7 +837,7 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
     Object.values(this._loadout).forEach((itemData) => {
       if (
         itemData.itemGuid != "0x0" &&
-        !this.isDefaultItem(itemData.itemDefinitionId) &&
+        isValidForLootbag(itemData.itemDefinitionId) &&
         !server.isAdminItem(itemData.itemDefinitionId)
       ) {
         const item = new BaseItem(
@@ -840,7 +858,7 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
     Object.values(this._containers).forEach((container: LoadoutContainer) => {
       Object.values(container.items).forEach((item) => {
         if (
-          !this.isDefaultItem(item.itemDefinitionId) &&
+          isValidForLootbag(item.itemDefinitionId) &&
           !server.isAdminItem(item.itemDefinitionId)
         ) {
           let stacked = false;


### PR DESCRIPTION
### TL;DR

Improved loot bag generation by using a whitelist approach for valid items.

### What changed?

- Created a new array `invalidItemForLootbag` that explicitly lists items that should not be included in loot bags
- Added a new function `isValidForLootbag()` to check if an item should be included in a loot bag
- Replaced calls to `isDefaultItem()` with the new `isValidForLootbag()` function when determining what items to include in loot bags

### How to test?

1. Kill a character that has items in their inventory
2. Verify that a loot bag is created
3. Check that the loot bag does not contain any of the invalid items (fists, flashlight, map, improvised compass, gray/blue boots)
4. Verify that all other valid items are properly included in the loot bag

### Why make this change?

This change provides a more explicit and maintainable approach to determining which items should be included in loot bags. By using a specific list of invalid items rather than a generic "default item" check, we can more precisely control what items players can loot, improving gameplay balance and reducing potential exploits.