### PR TITLE
remake the aimanager in ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/node": "24.0.7",
         "@types/ws": "8.18.1",
         "debug": "4.4.1",
-        "h1emu-ai": "^0.1.0",
         "h1emu-core": "1.3.2",
         "h1z1-dataschema": "1.9.2",
         "js-yaml": "4.1.0",
@@ -920,11 +919,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/h1emu-ai": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/h1emu-ai/-/h1emu-ai-0.1.0.tgz",
-      "integrity": "sha512-dq2yvHEwUqbMNbYAwRV7M6GP86jvpvZhIemrSca5LbeRoIqaxKNXzsbdEuOYKF7gxLCcXSglgHG3TRgHHc2rbQ=="
     },
     "node_modules/h1emu-core": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@types/node": "24.0.7",
     "@types/ws": "8.18.1",
     "debug": "4.4.1",
-    "h1emu-ai": "^0.1.0",
     "h1emu-core": "1.3.2",
     "h1z1-dataschema": "1.9.2",
     "js-yaml": "4.1.0",

--- a/src/servers/ZoneServer2016/entities/baseentity.ts
+++ b/src/servers/ZoneServer2016/entities/baseentity.ts
@@ -89,9 +89,6 @@ export abstract class BaseEntity {
 
   /** The guid of the secured shelter the entity is inside */
   isHidden: string = "";
-
-  h1emu_ai_id?: bigint;
-
   server: ZoneServer2016;
   constructor(
     characterId: string,

--- a/src/servers/ZoneServer2016/entities/explosiveentity.ts
+++ b/src/servers/ZoneServer2016/entities/explosiveentity.ts
@@ -24,7 +24,6 @@ import { ZoneClient2016 } from "../classes/zoneclient";
 import { CharacterPlayWorldCompositeEffect } from "types/zone2016packets";
 import { scheduler } from "node:timers/promises";
 import { BaseEntity } from "./baseentity";
-import { TRAPS_DESPAWN_TIME } from "../../../utils/constants";
 
 export class ExplosiveEntity extends BaseLightweightCharacter {
   /** Id of the item - See ServerItemDefinitions.json for more information */
@@ -129,12 +128,7 @@ export class ExplosiveEntity extends BaseLightweightCharacter {
   async arm(server: ZoneServer2016) {
     // Wait 10 seconds before activating the trap
     await scheduler.wait(10_000);
-    this.h1emu_ai_id = server.aiManager.add_trap(
-      this,
-      0.6,
-      90n,
-      TRAPS_DESPAWN_TIME
-    );
+    server.aiManager.addEntity(this);
   }
 
   /** Called when the explosive gets hit by a projectile (bullet, arrow, etc.) */

--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -33,7 +33,6 @@ import {
   StringIds
 } from "../models/enums";
 import { CommandInteractionString } from "types/zone2016packets";
-import { EntityType } from "h1emu-ai";
 import { BaseEntity } from "./baseentity";
 import { ChallengeType } from "../managers/challengemanager";
 import { ProjectileEntity } from "./projectileentity";
@@ -75,7 +74,6 @@ export class Npc extends BaseFullCharacter {
     return this.deathTime == 0;
   }
   server: ZoneServer2016;
-  entityType: EntityType;
   npcMeleeDamage: number;
   isSelected: boolean = false;
   constructor(
@@ -94,41 +92,34 @@ export class Npc extends BaseFullCharacter {
     this.initNpcData();
     this.server = server;
     switch (actorModelId) {
-      // TODO: use enums
       case ModelIds.ZOMBIE_FEMALE_WALKER:
       case ModelIds.ZOMBIE_MALE_WALKER:
-        this.entityType = EntityType.Zombie;
         this.materialType = MaterialTypes.ZOMBIE;
         this.npcMeleeDamage = 2000;
         break;
       case ModelIds.ZOMBIE_SCREAMER:
-        this.entityType = EntityType.Screamer;
         this.materialType = MaterialTypes.ZOMBIE;
         this.npcMeleeDamage = 3000;
         break;
       case ModelIds.DEER:
       case ModelIds.DEER_BUCK:
-        this.entityType = EntityType.Deer;
         this.materialType = MaterialTypes.FLESH;
         this.npcMeleeDamage = 0;
         break;
       case ModelIds.WOLF:
-        this.entityType = EntityType.Wolf;
         this.materialType = MaterialTypes.FLESH;
         this.npcMeleeDamage = 2000;
         break;
       case ModelIds.BEAR:
-        this.entityType = EntityType.Bear;
         this.materialType = MaterialTypes.FLESH;
         this.npcMeleeDamage = 4000;
         break;
       default:
-        this.entityType = EntityType.Deer;
         this.materialType = MaterialTypes.FLESH;
         this.npcMeleeDamage = 0;
         break;
     }
-    this.h1emu_ai_id = server.aiManager.add_entity(this, this.entityType);
+    server.aiManager.addEntity(this);
   }
 
   playAnimation(animationName: string) {

--- a/src/servers/ZoneServer2016/handlers/commands/dev.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/dev.ts
@@ -491,16 +491,6 @@ const dev: any = {
   acc: function (server: ZoneServer2016, client: Client, args: Array<string>) {
     server.sendData<ItemsAddAccountItem>(client, "Items.AddAccountItem", {});
   },
-  ai_load: function (
-    server: ZoneServer2016,
-    client: Client,
-    args: Array<string>
-  ) {
-    server.sendChatText(
-      client,
-      server.aiManager.get_stats().entities.toString()
-    );
-  },
   ui: function (server: ZoneServer2016, client: Client, args: Array<string>) {
     server.sendData(client, "Effect.AddUiIndicator", {
       characterId: client.character.characterId,
@@ -530,6 +520,9 @@ const dev: any = {
       unknownData2: {}
     });
   },
+  ai: function (server: ZoneServer2016, client: Client, args: Array<string>) {
+    server.sendChatText(client, server.aiManager.getEntitiesStats());
+  },
   zombie: async function (
     server: ZoneServer2016,
     client: Client,
@@ -548,7 +541,7 @@ const dev: any = {
     );
 
     server._npcs[characterId] = zombie;
-    server.aiManager.add_entity(zombie, zombie.entityType);
+    // server.aiManager.add_entity(zombie, zombie.entityType);
     const a = server.navManager.createAgent(zombie.state.position);
     zombie.navAgent = a;
 

--- a/src/servers/ZoneServer2016/managers/aimanager.ts
+++ b/src/servers/ZoneServer2016/managers/aimanager.ts
@@ -1,0 +1,106 @@
+// ======================================================================
+//
+//   GNU GENERAL PUBLIC LICENSE
+//   Version 3, 29 June 2007
+//   copyright (C) 2020 - 2021 Quentin Gruber
+//   copyright (C) 2021 - 2025 H1emu community
+//
+//   https://github.com/QuentinGruber/h1z1-server
+//   https://www.npmjs.com/package/h1z1-server
+//
+//   Based on https://github.com/psemu/soe-network
+// ======================================================================
+
+import { isPosInRadiusWithY } from "../../../utils/utils";
+import { Character2016 } from "../entities/character";
+import { ExplosiveEntity } from "../entities/explosiveentity";
+import { TrapEntity } from "../entities/trapentity";
+import { ZoneServer2016 } from "../zoneserver";
+
+export class AiManager {
+  trapEntities: Set<TrapEntity> = new Set();
+  playerEntities: Set<Character2016> = new Set();
+  explosiveEntities: Set<ExplosiveEntity> = new Set();
+  constructor(public server: ZoneServer2016) {}
+  addEntity(entity: unknown) {
+    switch (true) {
+      case entity instanceof TrapEntity: {
+        this.trapEntities.add(entity);
+        break;
+      }
+      case entity instanceof Character2016: {
+        this.playerEntities.add(entity);
+        break;
+      }
+      case entity instanceof ExplosiveEntity: {
+        this.explosiveEntities.add(entity);
+        break;
+      }
+    }
+  }
+  removeEntity(entity: unknown) {
+    switch (true) {
+      case entity instanceof TrapEntity: {
+        this.trapEntities.delete(entity);
+        break;
+      }
+      case entity instanceof Character2016: {
+        this.playerEntities.delete(entity);
+        break;
+      }
+      case entity instanceof ExplosiveEntity: {
+        this.explosiveEntities.delete(entity);
+        break;
+      }
+    }
+  }
+  getEntitiesTotalNumber(): number {
+    return (
+      this.trapEntities.size +
+      this.playerEntities.size +
+      this.explosiveEntities.size
+    );
+  }
+  getEntitiesStats(): string {
+    return `Players: ${this.playerEntities.size}\nTraps: ${this.trapEntities.size}\nExplosive: ${this.explosiveEntities.size}`;
+  }
+
+  private checkTraps(now: number) {
+    this.playerEntities.forEach((player) => {
+      this.trapEntities.forEach((trap) => {
+        if (trap.lastTrigger + trap.cooldown > now) {
+          return;
+        }
+        const inRadius = isPosInRadiusWithY(
+          trap.triggerRadiusX,
+          player.state.position,
+          trap.state.position,
+          trap.triggerRadiusY
+        );
+        if (player.isAlive && inRadius) {
+          trap.detonate(player.characterId);
+        }
+      });
+    });
+  }
+  private checkExplosive() {
+    this.playerEntities.forEach((player) => {
+      this.explosiveEntities.forEach((explosive) => {
+        const inRadius = isPosInRadiusWithY(
+          0.6,
+          player.state.position,
+          explosive.state.position,
+          0.5
+        );
+        if (player.isAlive && inRadius) {
+          explosive.detonate(player.characterId);
+        }
+      });
+    });
+  }
+  run() {
+    const now = Date.now();
+    this.checkTraps(now);
+    this.checkExplosive();
+  }
+}

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -64,7 +64,6 @@ import {
   ConstructionUnknown,
   PlayerUpdatePosition
 } from "types/zone2016packets";
-import { MAX_UINT32, TRAPS_DESPAWN_TIME } from "../../../utils/constants";
 
 export class ConstructionManager {
   overridePlacementItems: Array<number> = [
@@ -1489,7 +1488,7 @@ export class ConstructionManager {
         worldOwned,
         owner
       );
-    npc.arm(worldOwned ? BigInt(MAX_UINT32) : TRAPS_DESPAWN_TIME);
+    npc.arm();
     //temporarily disabled
     server._traps[characterId] = npc;
     server.spawnSimpleNpcForAllInRange(npc);

--- a/src/servers/ZoneServer2016/managers/worlddatamanager.ts
+++ b/src/servers/ZoneServer2016/managers/worlddatamanager.ts
@@ -57,7 +57,7 @@ import { ConstructionDoor } from "../entities/constructiondoor";
 import { PlantingDiameter } from "../entities/plantingdiameter";
 import { Plant } from "../entities/plant";
 import { DB_COLLECTIONS } from "../../../utils/enums";
-import { DB_NAME, TRAPS_DESPAWN_TIME } from "../../../utils/constants";
+import { DB_NAME } from "../../../utils/constants";
 import { Character2016 } from "../entities/character";
 import { Items, VehicleIds } from "../models/enums";
 import { Vehicle2016 } from "../entities/vehicle";
@@ -1410,7 +1410,7 @@ export class WorldDataManager {
         );
         trap.health = entityData.health;
         server._traps[trap.characterId] = trap;
-        trap.arm(TRAPS_DESPAWN_TIME);
+        trap.arm();
     }
   }
 

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -157,7 +157,6 @@ import { Lootbag } from "./entities/lootbag";
 import { ReceivedPacket } from "types/shared";
 import { LoadoutItem } from "./classes/loadoutItem";
 import { BaseItem } from "./classes/baseItem";
-import { EntityType } from "h1emu-ai";
 
 function getStanceFlags(num: number): StanceFlags {
   function getBit(bin: string, bit: number) {
@@ -392,10 +391,7 @@ export class ZonePacketHandlers {
       if (client.firstCharacterReleased) {
         server.challengeManager.loadChallenges(client);
         client.firstCharacterReleased = false;
-        client.character.h1emu_ai_id = server.aiManager.add_entity(
-          client.character,
-          EntityType.Player
-        );
+        server.aiManager.addEntity(client.character);
         if (
           server.voiceChatManager.useVoiceChatV2 &&
           server.voiceChatManager.joinVoiceChatOnConnect
@@ -1614,9 +1610,6 @@ export class ZonePacketHandlers {
 
       // Update character position
       client.character.state.position = position;
-      if (client.character.h1emu_ai_id) {
-        server.aiManager.update_pos(client.character.h1emu_ai_id, position);
-      }
 
       // Stop HUD timer if position is out of radius
       if (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,4 +23,3 @@ export const OBSERVER_GUID = "0xFAFAFAFAFAFAFAFA";
 export const LOADOUT_CONTAINER_GUID = "0xffffffffffffffff";
 export const EXTERNAL_CONTAINER_GUID = "0x0000000000000001";
 export const LOADOUT_CONTAINER_ID = 101;
-export const TRAPS_DESPAWN_TIME = 3600_000n;


### PR DESCRIPTION
### TL;DR

Replaced the external `h1emu-ai` package with a custom internal AI manager implementation.

### What changed?

- Removed the `h1emu-ai` dependency from package.json and package-lock.json
- Created a new internal `AiManager` class in `src/servers/ZoneServer2016/managers/aimanager.ts`
- Refactored entity classes to use the new AI manager:
  - Removed `h1emu_ai_id` property from `BaseEntity`
  - Updated `Npc`, `TrapEntity`, and `ExplosiveEntity` classes to work with the new system
  - Simplified trap triggering logic with direct radius checks
- Updated command handlers and zone server code to use the new AI manager

### How to test?

1. Run the server and verify that NPCs, traps, and explosives function correctly
2. Test trap triggering by placing traps and walking into their radius
3. Use the `/ai` command to check entity statistics
4. Verify that performance monitoring for AI processing still works

### Why make this change?

This change internalizes the AI management system, removing the external dependency on `h1emu-ai`. The new implementation provides better control over entity tracking and interaction detection, with a simpler architecture that directly checks entity positions rather than relying on external ID tracking. This should improve maintainability and potentially performance by reducing the overhead of cross-package communication.