### PR TITLE
trigger old landmines after a certain time

### DIFF
--- a/src/servers/ZoneServer2016/entities/explosiveentity.ts
+++ b/src/servers/ZoneServer2016/entities/explosiveentity.ts
@@ -42,6 +42,8 @@ export class ExplosiveEntity extends BaseLightweightCharacter {
   /** the characterId from who place this to keep track */
   ownerCharacterId: string;
 
+  creationTime: number = Date.now();
+
   isAwaitingExplosion: boolean = false;
 
   constructor(


### PR DESCRIPTION
### TL;DR

Added automatic detonation of explosives after 3 hours to prevent world clutter.

### What changed?

- Added a `creationTime` property to `ExplosiveEntity` to track when explosives are placed
- Created a new `triggerOldExplosives()` method in `AiManager` that checks for and detonates explosives older than 3 hours
- Added a scheduled execution of this method every 60 seconds
- Renamed `degradeTrapsTime` to `degradeTrapsCallTime` for clarity

### How to test?

1. Place explosives in the game world
2. Wait for 3 hours (or temporarily reduce the `ttlExplosives` constant for testing)
3. Verify that old explosives automatically detonate

### Why make this change?

Explosives that are placed but never detonated can accumulate in the game world, causing clutter and potentially impacting performance. This change ensures that all explosives will eventually be removed from the world, even if players forget about them.