### PR TITLE
fix killedBy issue

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2764,18 +2764,18 @@ export class ZoneServer2016 extends EventEmitter {
     let isInGodMode = false;
     if (killerClient) {
       isInGodMode = killerClient.character.isGodMode();
-    }
-    this.sendDataToAllWithSpawnedEntity<CharacterKilledBy>(
-      this._characters,
-      client.character.characterId,
-      "Character.KilledBy",
+      this.sendDataToAllWithSpawnedEntity<CharacterKilledBy>(
+        this._characters,
+        client.character.characterId,
+        "Character.KilledBy",
 
-      {
-        killer: killerClient?.character.characterId,
-        killed: client.character.characterId,
-        isCheater: isInGodMode
-      }
-    );
+        {
+          killer: killerClient?.character.characterId,
+          killed: client.character.characterId,
+          isCheater: isInGodMode
+        }
+      );
+    }
   }
 
   applyCharacterEffect(


### PR DESCRIPTION
### TL;DR

Fixed a bug where death notifications were being sent even when there was no killer.

### What changed?

Moved the `sendDataToAllWithSpawnedEntity` call inside the `if (killerClient)` block to ensure that death notifications are only sent when there is a valid killer client.

### How to test?

1. Test character deaths with a valid killer and verify the death notification is sent
2. Test character deaths without a killer (e.g., environmental damage) and verify no death notification is sent

### Why make this change?

This change prevents unnecessary death notifications from being sent when a character dies without a killer. Previously, the code would attempt to send a notification even when `killerClient` was null, which could lead to unexpected behavior or errors.