### PR TITLE
add a db log when a login fail

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -994,9 +994,15 @@ export class ZoneServer2016 extends EventEmitter {
     try {
       await this.sendInitData(client);
     } catch (error) {
-      debug(error);
       console.log(error);
       this.sendData<LoginFailed>(client, "LoginFailed", {});
+      if (!this._soloMode) {
+        await this._db.collection(DB_COLLECTIONS.LOGIN_ERRORS).insertOne({
+          error,
+          guid: client.loginSessionId,
+          characterId: client.character.characterId
+        });
+      }
     }
   }
 

--- a/src/utils/enums.ts
+++ b/src/utils/enums.ts
@@ -69,7 +69,8 @@ export enum DB_COLLECTIONS {
   GROUPS = "groups",
   VPN_WHITELIST = "vpn-whitelist",
   CHALLENGES = "challenges",
-  AUTHKEYS = "verified-authkeys"
+  AUTHKEYS = "verified-authkeys",
+  LOGIN_ERRORS = "login-errors"
 }
 
 export enum KILL_TYPE {


### PR DESCRIPTION
### TL;DR

Added login error logging to database for failed client initializations.

### What changed?

- Added error logging to the database when client initialization fails in the ZoneServer2016
- Created a new database collection `LOGIN_ERRORS` to store these errors
- Each error log includes the error details, client's login session ID, and character ID
- Error logging is skipped when the server is in solo mode

### How to test?

1. Trigger a client initialization failure (e.g., by providing invalid data)
2. Verify that the error is logged to the `login-errors` collection in the database
3. Confirm the logged error contains the expected fields: error, guid, and characterId
4. Test in solo mode to ensure errors are not logged to the database

### Why make this change?

This change improves debugging capabilities by persisting login errors to the database, making it easier to track and analyze client initialization failures. This will help identify patterns in login failures and provide better diagnostics for troubleshooting user login issues.