### PR TITLE
fix: tired buddy challenge

### DIFF
--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -554,10 +554,20 @@ export class Character2016 extends BaseFullCharacter {
     ];
     switch (true) {
       case energy <= 801:
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.TIRED_BUDDY,
+          1
+        );
         desiredEnergyIndicator = ResourceIndicators.EXHAUSTED;
         client.character._resources[ResourceIds.STAMINA] -= 20;
         break;
       case energy <= 2601 && energy > 801:
+        server.challengeManager.registerChallengeProgression(
+          client,
+          ChallengeType.TIRED_BUDDY,
+          1
+        );
         desiredEnergyIndicator = ResourceIndicators.VERY_TIRED;
         client.character._resources[ResourceIds.STAMINA] -= 14;
         break;


### PR DESCRIPTION
### TL;DR

Added challenge progression tracking for the "Tired Buddy" challenge when a character's energy is low.

### What changed?

Added calls to `server.challengeManager.registerChallengeProgression()` in two energy level conditions:
- When energy is ≤ 801 (Exhausted state)
- When energy is between 801 and 2601 (Very Tired state)

Both conditions now increment the TIRED_BUDDY challenge counter by 1 when triggered.

### How to test?

1. Log in with a character
2. Deplete the character's energy below 2601
3. Verify that the "Tired Buddy" challenge progression increases
4. Test both energy thresholds (≤801 and 801-2601) to ensure both trigger the challenge progression

### Why make this change?

This change enables players to progress in the "Tired Buddy" challenge when their character becomes tired or exhausted, providing appropriate challenge tracking for low-energy gameplay situations.