### PR TITLE
Reworked getDeathItems logic

### DIFF
--- a/src/servers/ZoneServer2016/data/deathitemdamageconfig.ts
+++ b/src/servers/ZoneServer2016/data/deathitemdamageconfig.ts
@@ -1,0 +1,62 @@
+// ======================================================================
+//
+//   GNU GENERAL PUBLIC LICENSE
+//   Version 3, 29 June 2007
+//   copyright (C) 2020 - 2021 Quentin Gruber
+//   copyright (C) 2021 - 2025 H1emu community
+//
+//   https://github.com/QuentinGruber/h1z1-server
+//   https://www.npmjs.com/package/h1z1-server
+//
+//   Based on https://github.com/psemu/soe-network
+// ======================================================================
+
+import { ItemClasses, Items } from "../models/enums";
+import { ZoneServer2016 } from "../zoneserver";
+
+interface DeathItemDetails {
+  damage: number;
+  lootItems?: { itemId: Items; count: number }[];
+}
+
+export class DeathItemDamageConfig {
+  static readonly ITEM_CLASS_CONFIG: { [key: number]: DeathItemDetails } = {
+    [ItemClasses.WEAPONS_BOW]: { damage: 350 },
+    [ItemClasses.WEAPONS_CROSSBOW]: { damage: 350 },
+    [ItemClasses.WEAPONS_GENERIC]: { damage: 350 },
+    [ItemClasses.WEAPONS_LONG]: { damage: 350 },
+    [ItemClasses.WEAPONS_MELEES]: { damage: 350 },
+    [ItemClasses.WEAPONS_MELEES0]: { damage: 350 },
+    [ItemClasses.WEAPONS_PISTOL]: { damage: 350 },
+    [ItemClasses.BACKPACKS]: {
+      damage: 500,
+      lootItems: [{ itemId: Items.CLOTH, count: 2 }]
+    },
+    [ItemClasses.FOOTWEAR]: {
+      damage: 800,
+      lootItems: [{ itemId: Items.CLOTH, count: 2 }]
+    }
+  };
+
+  static readonly ITEM_ID_CONFIG: { [key: number]: DeathItemDetails } = {
+    [Items.BACKPACK_FRAMED]: {
+      damage: 400,
+      lootItems: [
+        { itemId: Items.CLOTH, count: 2 },
+        { itemId: Items.BROKEN_METAL_ITEM, count: 1 }
+      ]
+    }
+  };
+
+  static getConfig(
+    server: ZoneServer2016,
+    itemId: Items
+  ): DeathItemDetails | undefined {
+    const itemDefinition = server.getItemDefinition(itemId);
+    const itemClass = itemDefinition?.ITEM_CLASS as ItemClasses | undefined;
+    return (
+      this.ITEM_ID_CONFIG[itemId] ??
+      (itemClass ? this.ITEM_CLASS_CONFIG[itemClass] : undefined)
+    );
+  }
+}

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -49,10 +49,7 @@ import {
   ModelIds,
   ItemTypes,
   ItemClasses,
-  ResourceIndicators,
-  Backpack1000,
-  MilitaryTan,
-  FramedBackpack
+  ResourceIndicators
 } from "./models/enums";
 import { WeatherManager } from "./managers/weathermanager";
 

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6214,36 +6214,6 @@ export class ZoneServer2016 extends EventEmitter {
   }
 
   /**
-   * Checks if an item with the specified itemDefinitionId is a MilitaryTan backpack.
-   *
-   * @param {number} itemDefinitionId - The itemDefinitionId to check.
-   * @returns {boolean} True if the item is a MilitaryTan bag, false otherwise.
-   */
-  isMilitaryTan(itemDefinitionId: number): boolean {
-    return Object.values(MilitaryTan).includes(itemDefinitionId);
-  }
-
-  /**
-   * Checks if an item with the specified itemDefinitionId is a Framed bag.
-   *
-   * @param {number} itemDefinitionId - The itemDefinitionId to check.
-   * @returns {boolean} True if the item is a MilitaryTan bag, false otherwise.
-   */
-  isFramedBp(itemDefinitionId: number): boolean {
-    return Object.values(FramedBackpack).includes(itemDefinitionId);
-  }
-
-  /**
-   * Checks if an item with the specified itemDefinitionId is a Small backpack (1000 bulk).
-   *
-   * @param {number} itemDefinitionId - The itemDefinitionId to check.
-   * @returns {boolean} True if the item is a MilitaryTan bag, false otherwise.
-   */
-  isBackpack(itemDefinitionId: number): boolean {
-    return Object.values(Backpack1000).includes(itemDefinitionId);
-  }
-
-  /**
    * Checks if an item with the specified itemDefinitionId is a convey.
    *
    * @param {number} itemDefinitionId - The itemDefinitionId to check.


### PR DESCRIPTION
Introduced PlayerDeathItemConfig to enable configuration of item IDs and item classes for applying damage to items when a player dies. If an item's durability drops to 0, the configured lootItems are added to the lootbag. Also resolved an issue that prevented items without durability from being included in the lootbag.