### PR TITLE
updt deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/js-yaml": "4.0.9",
-        "@types/node": "24.0.8",
+        "@types/node": "^24.0.15",
         "@types/ws": "8.18.1",
         "debug": "4.4.1",
         "h1emu-core": "1.3.2",
@@ -29,8 +29,8 @@
       },
       "devDependencies": {
         "cross-env": "^7.0.3",
-        "globals": "^16.2.0",
-        "oxlint": "^1.4.0",
+        "globals": "^16.3.0",
+        "oxlint": "^1.7.0",
         "prettier": "^3.6.2",
         "tsx": "^4.20.3",
         "typedoc": "^0.28.7"
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
-      "integrity": "sha512-G3UsDnZpykvQ5GDzDCAhgBMwM6SzbQyH1If/oH5e/CutUC7sq/QTY8a2l1Hu7liK/euvKiZtM3C/cKdUKy1DNw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.7.0.tgz",
+      "integrity": "sha512-51vhCSQO4NSkedwEwOyqThiYqV0DAUkwNdqMQK0d29j5zmtNJJJRRBLeQuLGdstNmn3F7WMQ75Ci0/3Nq4ff8A==",
       "cpu": [
         "arm64"
       ],
@@ -502,9 +502,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.4.0.tgz",
-      "integrity": "sha512-4AgFOkf88iG/nH/bR0i6WV/SKap2ZvBwxvZ9TvrF4Cxag3bVBViy36DgoZXr7AloEybtXZ0IRdrQEJstHkwbtg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.7.0.tgz",
+      "integrity": "sha512-c0GN52yehYZ4TYuh4lBH9wYbBOI/RDOxZhJdBsttG0GwfvKYg/tiPNrNEsPzu0/rd1j6x3yT0zt6vezDMeC1sQ==",
       "cpu": [
         "x64"
       ],
@@ -516,9 +516,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.4.0.tgz",
-      "integrity": "sha512-9qZarfKyq6v56GhcN0IyejQsmv8GiSi+lJjjXQ/uaa50JrY4/2+i63uRJceUT7SBZbCj1PHvgZuqN+QXov6dWg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.7.0.tgz",
+      "integrity": "sha512-pam/lbzbzVMDzc3f1hoRPtnUMEIqkn0dynlB5nUll/MVBSIvIPLS9kJLrRA48lrlqbkS9LGiF37JvpwXA58A9A==",
       "cpu": [
         "arm64"
       ],
@@ -530,9 +530,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.4.0.tgz",
-      "integrity": "sha512-Nfbvqi+o5wU/ZPOYUpM+QMzT6Or8Mog89IUsKRJBBmIPUvcwQhyCKp8B4CZswNJyXisJ3gZ3kdCaaKgnsLln4Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.7.0.tgz",
+      "integrity": "sha512-LTyPy9FYS3SZ2XxJx+ITvlAq/ek5PtZK9Z2m3W72TA8hchGhJy5eQ+aotYjd/YVXOpGRpB12RdOpOTsZRu50bA==",
       "cpu": [
         "arm64"
       ],
@@ -544,9 +544,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.4.0.tgz",
-      "integrity": "sha512-z/71xdZpvudjZsaEDk+EJxEzDIcyCaKbvUtGjAfKv60jLuP83bDHD0VD8GI8FSPjhlLpDPmrbcXWbT690Q7NAA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.7.0.tgz",
+      "integrity": "sha512-YtZ4DiAgjaEiqUiwnvtJ/znZMAAVPKR7pnsi6lqbA3BfXJ/IwMaNpdoGlCGVdDGeN4BuGCwnFtBVqKVvVg3DDg==",
       "cpu": [
         "x64"
       ],
@@ -558,9 +558,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.4.0.tgz",
-      "integrity": "sha512-D6C165X6/hjZ1yi2mNttzeihjL3IoW0s612VNyfW6KrV/lesSaIFTXqII3ThOOQezGTDhpz4xudemcv0g7iFlg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.7.0.tgz",
+      "integrity": "sha512-5aIpemNUBvwMMk4MCx1V3M6R9eMB1/SS6/24Orax9FqaI1lDX08tySdv696sr4Lms9ocA+rotxIPW9NP9439vA==",
       "cpu": [
         "x64"
       ],
@@ -572,9 +572,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.4.0.tgz",
-      "integrity": "sha512-wFa7ywGt0jnuukynANm5k/D189YwrQKHIdNgBjBsTvvJZNxGzVy8Q5dwsG0qwWS6RkVh9CMUpOTccPsKBdGHkQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.7.0.tgz",
+      "integrity": "sha512-fpFpkHwbAu0NcR5bc1WapCPcM9qSYi5lCRVOp1WwDoFLKI2b9/UWB8OEg8UHWV5dnBu7HZAWH/SEslYGkZNsbQ==",
       "cpu": [
         "arm64"
       ],
@@ -586,9 +586,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.4.0.tgz",
-      "integrity": "sha512-B3ezHSEzQL6Enszl9i9wLwIhWt3lkJ5x2xmgvJ77RrzoaF46QciGvs4TeGU++kPRe5DKpRGlgsruig7GLNUaSg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.7.0.tgz",
+      "integrity": "sha512-0EPWBWOiD3wZHgeWDlTUaiFzhzIonXykxYUC+NRerPQFkO/G+bd9uLMJddHDKqfP/7g8s3E5V6KvBvvFpb7U6g==",
       "cpu": [
         "x64"
       ],
@@ -689,9 +689,9 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
     },
     "node_modules/@types/node": {
-      "version": "24.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
-      "integrity": "sha512-WytNrFSgWO/esSH9NbpWUfTMGQwCGIKfCmNlmFDNiI5gGhgMmEA+V1AEvKLeBNvvtBnailJtkrEa2OIISwrVAA==",
+      "version": "24.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
+      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
-      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
+      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1152,9 +1152,9 @@
       "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "node_modules/oxlint": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.4.0.tgz",
-      "integrity": "sha512-whu+lxSL9GCzO+b+X++tk81d5UoCeAq+plU5DWSoLqmwjCV0OyDkRlfGPDhbBHXm2z6GrepvF0d0Sb66z6SG4A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.7.0.tgz",
+      "integrity": "sha512-krJN1fIRhs3xK1FyVyPtYIV9tkT4WDoIwI7eiMEKBuCjxqjQt5ZemQm1htPvHqNDOaWFRFt4btcwFdU8bbwgvA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1168,14 +1168,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.4.0",
-        "@oxlint/darwin-x64": "1.4.0",
-        "@oxlint/linux-arm64-gnu": "1.4.0",
-        "@oxlint/linux-arm64-musl": "1.4.0",
-        "@oxlint/linux-x64-gnu": "1.4.0",
-        "@oxlint/linux-x64-musl": "1.4.0",
-        "@oxlint/win32-arm64": "1.4.0",
-        "@oxlint/win32-x64": "1.4.0"
+        "@oxlint/darwin-arm64": "1.7.0",
+        "@oxlint/darwin-x64": "1.7.0",
+        "@oxlint/linux-arm64-gnu": "1.7.0",
+        "@oxlint/linux-arm64-musl": "1.7.0",
+        "@oxlint/linux-x64-gnu": "1.7.0",
+        "@oxlint/linux-x64-musl": "1.7.0",
+        "@oxlint/win32-arm64": "1.7.0",
+        "@oxlint/win32-x64": "1.7.0"
       }
     },
     "node_modules/path-key": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@types/js-yaml": "4.0.9",
-    "@types/node": "24.0.8",
+    "@types/node": "^24.0.15",
     "@types/ws": "8.18.1",
     "debug": "4.4.1",
     "h1emu-core": "1.3.2",
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "globals": "^16.2.0",
-    "oxlint": "^1.4.0",
+    "globals": "^16.3.0",
+    "oxlint": "^1.7.0",
     "prettier": "^3.6.2",
     "tsx": "^4.20.3",
     "typedoc": "^0.28.7"


### PR DESCRIPTION
### TL;DR

Updated development dependencies and Node.js type definitions to their latest versions.

### What changed?

- Updated `@types/node` from `24.0.8` to `^24.0.15`
- Updated `globals` from `^16.2.0` to `^16.3.0`
- Updated `oxlint` from `^1.4.0` to `^1.7.0`

### How to test?

1. Run `npm install` to update the dependencies
2. Verify that the project builds and runs correctly
3. Run linting with `oxlint` to ensure it works with the new version

### Why make this change?

Keeping dependencies up-to-date ensures we have the latest bug fixes, security patches, and features. The updated Node.js type definitions provide better TypeScript support for newer Node.js APIs, while the newer version of oxlint may include improved linting rules and performance.