### PR TITLE
Round up minutes survived to the nearest minute

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2517,8 +2517,7 @@ export class ZoneServer2016 extends EventEmitter {
       {
         recipesDiscovered: client.character.metrics.recipesDiscovered,
         zombiesKilled: client.character.metrics.zombiesKilled,
-        minutesSurvived:
-          (Date.now() - client.character.metrics.startedSurvivingTP) / 60000,
+        minutesSurvived: Math.ceil((Date.now() - client.character.metrics.startedSurvivingTP) / 60000),
         wildlifeKilled: client.character.metrics.wildlifeKilled,
         vehiclesDestroyed: client.character.metrics.vehiclesDestroyed,
         playersKilled: client.character.metrics.playersKilled,

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -2517,7 +2517,9 @@ export class ZoneServer2016 extends EventEmitter {
       {
         recipesDiscovered: client.character.metrics.recipesDiscovered,
         zombiesKilled: client.character.metrics.zombiesKilled,
-        minutesSurvived: Math.ceil((Date.now() - client.character.metrics.startedSurvivingTP) / 60000),
+        minutesSurvived: Math.ceil(
+          (Date.now() - client.character.metrics.startedSurvivingTP) / 60000
+        ),
         wildlifeKilled: client.character.metrics.wildlifeKilled,
         vehiclesDestroyed: client.character.metrics.vehiclesDestroyed,
         playersKilled: client.character.metrics.playersKilled,


### PR DESCRIPTION
this fix an console error


```
ClientUpdate.DeathMetrics : RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received -333.8397166666667
ClientUpdate.DeathMetrics : {"recipesDiscovered":0,"zombiesKilled":0,"minutesSurvived":-333.8397166666667,"wildlifeKilled":0,"vehiclesDestroyed":0,"playersKilled":2,"lastDamageAmount":1000,"killedByHeadshot":false}

```