### PR TITLE
Adjust wornOffDurability logic for weapons

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5940,8 +5940,14 @@ export class ZoneServer2016 extends EventEmitter {
       case WeaponDefinitionIds.WEAPON_WRENCH:
         durability = 2000;
         break;
-      case WeaponDefinitionIds.WEAPON_HAMMER:
       case WeaponDefinitionIds.WEAPON_CROWBAR:
+      case WeaponDefinitionIds.WEAPON_HAMMER:
+        if (!forceMaxDurability) {
+          do {
+            wornOffDurability = Math.floor(Math.random() * durability);
+          } while (wornOffDurability < 500);
+          break;
+        }
       case WeaponDefinitionIds.WEAPON_308:
       case WeaponDefinitionIds.WEAPON_SHOTGUN:
       case WeaponDefinitionIds.WEAPON_AK47:
@@ -5953,7 +5959,7 @@ export class ZoneServer2016 extends EventEmitter {
         if (!forceMaxDurability) {
           do {
             wornOffDurability = Math.floor(Math.random() * durability);
-          } while (durability < 250);
+          } while (wornOffDurability < 350);
           break;
         }
     }
@@ -7939,7 +7945,7 @@ export class ZoneServer2016 extends EventEmitter {
       itemDefinition.ID,
       overrideProjectileId
         ? packet.packet.sessionProjectileCount +
-          parseInt(client.character.characterId.slice(-5), 16)
+            parseInt(client.character.characterId.slice(-5), 16)
         : packet.packet.projectileUniqueId,
       client.character.characterId
     );


### PR DESCRIPTION
Refactored durability calculation for WEAPON_HAMMER and WEAPON_CROWBAR to ensure wornOffDurability is at least 500 when not forcing max durability. Also corrected wornOffDurability threshold for other weapons from 250 to 350.