### PR TITLE
updt_deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/js-yaml": "4.0.9",
-        "@types/node": "^25.0.3",
+        "@types/node": "25.0.6",
         "@types/ws": "8.18.1",
         "debug": "4.4.3",
         "h1emu-core": "1.3.2",
@@ -21,7 +21,7 @@
         "recast-navigation": "0.43.0",
         "threads": "1.7.0",
         "typescript": "5.9.3",
-        "ws": "8.18.3"
+        "ws": "8.19.0"
       },
       "bin": {
         "h1z1-server-demo": "scripts/h1z1-server-demo.js",
@@ -29,8 +29,8 @@
       },
       "devDependencies": {
         "cross-env": "^10.1.0",
-        "globals": "^16.5.0",
-        "oxlint": "^1.36.0",
+        "globals": "^17.0.0",
+        "oxlint": "^1.38.0",
         "prettier": "^3.7.4",
         "tsx": "^4.21.0",
         "typedoc": "^0.28.15"
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.36.0.tgz",
-      "integrity": "sha512-MJkj82GH+nhvWKJhSIM6KlZ8tyGKdogSQXtNdpIyP02r/tTayFJQaAEWayG2Jhsn93kske+nimg5MYFhwO/rlg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.38.0.tgz",
+      "integrity": "sha512-9rN3047QTyA4i73FKikDUBdczRcLtOsIwZ5TsEx5Q7jr5nBjolhYQOFQf9QdhBLdInxw1iX4+lgdMCf1g74zjg==",
       "cpu": [
         "arm64"
       ],
@@ -526,9 +526,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.36.0.tgz",
-      "integrity": "sha512-VvEhfkqj/99dCTqOcfkyFXOSbx4lIy5u2m2GHbK4WCMDySokOcMTNRHGw8fH/WgQ5cDrDMSTYIGQTmnBGi9tiQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.38.0.tgz",
+      "integrity": "sha512-Y1UHW4KOlg5NvyrSn/bVBQP8/LRuid7Pnu+BWGbAVVsFcK0b565YgMSO3Eu9nU3w8ke91dr7NFpUmS+bVkdkbw==",
       "cpu": [
         "x64"
       ],
@@ -540,9 +540,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.36.0.tgz",
-      "integrity": "sha512-EMx92X5q+hHc3olTuj/kgkx9+yP0p/AVs4yvHbUfzZhBekXNpUWxWvg4hIKmQWn+Ee2j4o80/0ACGO0hDYJ9mg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.38.0.tgz",
+      "integrity": "sha512-ZiVxPZizlXSnAMdkEFWX/mAj7U3bNiku8p6I9UgLrXzgGSSAhFobx8CaFGwVoKyWOd+gQgZ/ogCrunvx2k0CFg==",
       "cpu": [
         "arm64"
       ],
@@ -554,9 +554,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.36.0.tgz",
-      "integrity": "sha512-7YCxtrPIctVYLqWrWkk8pahdCxch6PtsaucfMLC7TOlDt4nODhnQd4yzEscKqJ8Gjrw1bF4g+Ngob1gB+Qr9Fw==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.38.0.tgz",
+      "integrity": "sha512-ELtlCIGZ72A65ATZZHFxHMFrkRtY+DYDCKiNKg6v7u5PdeOFey+OlqRXgXtXlxWjCL+g7nivwI2FPVsWqf05Qw==",
       "cpu": [
         "arm64"
       ],
@@ -568,9 +568,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.36.0.tgz",
-      "integrity": "sha512-lnaJVlx5r3NWmoOMesfQXJSf78jHTn8Z+sdAf795Kgteo72+qGC1Uax2SToCJVN2J8PNG3oRV5bLriiCNR2i6Q==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.38.0.tgz",
+      "integrity": "sha512-E1OcDh30qyng1m0EIlsOuapYkqk5QB6o6IMBjvDKqIoo6IrjlVAasoJfS/CmSH998gXRL3BcAJa6Qg9IxPFZnQ==",
       "cpu": [
         "x64"
       ],
@@ -582,9 +582,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.36.0.tgz",
-      "integrity": "sha512-AhuEU2Qdl66lSfTGu/Htirq8r/8q2YnZoG3yEXLMQWnPMn7efy8spD/N1NA7kH0Hll+cdfwgQkQqC2G4MS2lPQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.38.0.tgz",
+      "integrity": "sha512-4AfpbM/4sQnr6S1dMijEPfsq4stQbN5vJ2jsahSy/QTcvIVbFkgY+RIhrA5UWlC6eb0rD5CdaPQoKGMJGeXpYw==",
       "cpu": [
         "x64"
       ],
@@ -596,9 +596,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.36.0.tgz",
-      "integrity": "sha512-GlWCBjUJY2QgvBFuNRkiRJu7K/djLmM0UQKfZV8IN+UXbP/JbjZHWKRdd4LXlQmzoz7M5Hd6p+ElCej8/90FCg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.38.0.tgz",
+      "integrity": "sha512-OvUVYdI68OwXh3d1RjH9N/okCxb6PrOGtEtzXyqGA7Gk+IxyZcX0/QCTBwV8FNbSSzDePSSEHOKpoIB+VXdtvg==",
       "cpu": [
         "arm64"
       ],
@@ -610,9 +610,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.36.0.tgz",
-      "integrity": "sha512-J+Vc00Utcf8p77lZPruQgb0QnQXuKnFogN88kCnOqs2a83I+vTBB8ILr0+L9sTwVRvIDMSC0pLdeQH4svWGFZg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.38.0.tgz",
+      "integrity": "sha512-7IuZMYiZiOcgg5zHvpJY6jRlEwh8EB/uq7GsoQJO9hANq96TIjyntGByhIjFSsL4asyZmhTEki+MO/u5Fb/WQA==",
       "cpu": [
         "x64"
       ],
@@ -713,9 +713,9 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
     },
     "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
+      "version": "25.0.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
+      "integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
+      "integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1157,13 +1157,12 @@
       "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "node_modules/oxlint": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.36.0.tgz",
-      "integrity": "sha512-IicUdXfXgI8OKrDPnoSjvBfeEF8PkKtm+CoLlg4LYe4ypc8U+T4r7730XYshdBGZdelg+JRw8GtCb2w/KaaZvw==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.38.0.tgz",
+      "integrity": "sha512-XT7tBinQS+hVLxtfJOnokJ9qVBiQvZqng40tDgR6qEJMRMnpVq/JwYfbYyGntSq8MO+Y+N9M1NG4bAMFUtCJiw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "oxc_language_server": "bin/oxc_language_server",
         "oxlint": "bin/oxlint"
       },
       "engines": {
@@ -1173,14 +1172,14 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.36.0",
-        "@oxlint/darwin-x64": "1.36.0",
-        "@oxlint/linux-arm64-gnu": "1.36.0",
-        "@oxlint/linux-arm64-musl": "1.36.0",
-        "@oxlint/linux-x64-gnu": "1.36.0",
-        "@oxlint/linux-x64-musl": "1.36.0",
-        "@oxlint/win32-arm64": "1.36.0",
-        "@oxlint/win32-x64": "1.36.0"
+        "@oxlint/darwin-arm64": "1.38.0",
+        "@oxlint/darwin-x64": "1.38.0",
+        "@oxlint/linux-arm64-gnu": "1.38.0",
+        "@oxlint/linux-arm64-musl": "1.38.0",
+        "@oxlint/linux-x64-gnu": "1.38.0",
+        "@oxlint/linux-x64-musl": "1.38.0",
+        "@oxlint/win32-arm64": "1.38.0",
+        "@oxlint/win32-x64": "1.38.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=0.10.0"
@@ -1435,9 +1434,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@types/js-yaml": "4.0.9",
-    "@types/node": "^25.0.3",
+    "@types/node": "25.0.6",
     "@types/ws": "8.18.1",
     "debug": "4.4.3",
     "h1emu-core": "1.3.2",
@@ -24,15 +24,15 @@
     "recast-navigation": "0.43.0",
     "threads": "1.7.0",
     "typescript": "5.9.3",
-    "ws": "8.18.3"
+    "ws": "8.19.0"
   },
   "directories": {
     "src": "./src"
   },
   "devDependencies": {
     "cross-env": "^10.1.0",
-    "globals": "^16.5.0",
-    "oxlint": "^1.36.0",
+    "globals": "^17.0.0",
+    "oxlint": "^1.38.0",
     "prettier": "^3.7.4",
     "tsx": "^4.21.0",
     "typedoc": "^0.28.15"


### PR DESCRIPTION
### TL;DR

Updated dependencies to their latest versions to ensure compatibility and security.

### What changed?

- Pinned `@types/node` to version 25.0.6 (from ^25.0.3)
- Updated `ws` from 8.18.3 to 8.19.0
- Updated dev dependencies:
  - `globals` from ^16.5.0 to ^17.0.0
  - `oxlint` from ^1.36.0 to ^1.38.0

### How to test?

1. Run `npm install` to update the dependencies
2. Verify that the application builds and runs correctly
3. Test the WebSocket functionality to ensure the updated `ws` package works as expected
4. Run linting with the updated `oxlint` to confirm it functions properly

### Why make this change?

Keeping dependencies up-to-date is important for:
- Security patches and vulnerability fixes
- Bug fixes and performance improvements
- Ensuring compatibility with the latest Node.js versions
- Taking advantage of new features in the updated packages