### PR TITLE
change raw datareception from console.log to debug

### DIFF
--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -440,7 +440,7 @@ export class SOEServer extends EventEmitter {
           console.log("Raw data received from client", clientId, data);
           this.emit("appdata", client, data, true); // Unreliable + Unordered
         } else {
-          console.log(
+          debug(
             "Raw data received from client but raw data reception isn't enabled",
             clientId,
             data


### PR DESCRIPTION
### TL;DR

Changed console.log to debug for raw data reception message

### What changed?

Modified the logging in SOEServer when raw data is received from a client but raw data reception isn't enabled. Replaced `console.log` with `debug` to reduce console output in normal operation while still maintaining the ability to see these messages when debugging.

### How to test?

1. Run the server with debug mode disabled and verify that these messages no longer appear in the console
2. Enable debug mode and verify that these messages still appear when appropriate
3. Test by sending raw data to the server when raw data reception is disabled

### Why make this change?

This change reduces unnecessary console output during normal operation. The message about raw data reception being disabled is primarily useful for debugging purposes, not for regular operation logs, making the debug function more appropriate than console.log.