### PR TITLE
update devdeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/js-yaml": "4.0.9",
-        "@types/node": "25.0.6",
+        "@types/node": "25.2.0",
         "@types/ws": "8.18.1",
         "debug": "4.4.3",
         "h1emu-core": "1.3.2",
@@ -29,11 +29,11 @@
       },
       "devDependencies": {
         "cross-env": "^10.1.0",
-        "globals": "^17.0.0",
-        "oxlint": "^1.38.0",
-        "prettier": "^3.7.4",
+        "globals": "^17.3.0",
+        "oxlint": "^1.43.0",
+        "prettier": "^3.8.1",
         "tsx": "^4.21.0",
-        "typedoc": "^0.28.15"
+        "typedoc": "^0.28.16"
       },
       "engines": {
         "node": ">=0.24.0 <26"
@@ -512,9 +512,9 @@
       }
     },
     "node_modules/@oxlint/darwin-arm64": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.38.0.tgz",
-      "integrity": "sha512-9rN3047QTyA4i73FKikDUBdczRcLtOsIwZ5TsEx5Q7jr5nBjolhYQOFQf9QdhBLdInxw1iX4+lgdMCf1g74zjg==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-arm64/-/darwin-arm64-1.43.0.tgz",
+      "integrity": "sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw==",
       "cpu": [
         "arm64"
       ],
@@ -526,9 +526,9 @@
       ]
     },
     "node_modules/@oxlint/darwin-x64": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.38.0.tgz",
-      "integrity": "sha512-Y1UHW4KOlg5NvyrSn/bVBQP8/LRuid7Pnu+BWGbAVVsFcK0b565YgMSO3Eu9nU3w8ke91dr7NFpUmS+bVkdkbw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/darwin-x64/-/darwin-x64-1.43.0.tgz",
+      "integrity": "sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A==",
       "cpu": [
         "x64"
       ],
@@ -540,9 +540,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-gnu": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.38.0.tgz",
-      "integrity": "sha512-ZiVxPZizlXSnAMdkEFWX/mAj7U3bNiku8p6I9UgLrXzgGSSAhFobx8CaFGwVoKyWOd+gQgZ/ogCrunvx2k0CFg==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.43.0.tgz",
+      "integrity": "sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g==",
       "cpu": [
         "arm64"
       ],
@@ -554,9 +554,9 @@
       ]
     },
     "node_modules/@oxlint/linux-arm64-musl": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.38.0.tgz",
-      "integrity": "sha512-ELtlCIGZ72A65ATZZHFxHMFrkRtY+DYDCKiNKg6v7u5PdeOFey+OlqRXgXtXlxWjCL+g7nivwI2FPVsWqf05Qw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.43.0.tgz",
+      "integrity": "sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw==",
       "cpu": [
         "arm64"
       ],
@@ -568,9 +568,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-gnu": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.38.0.tgz",
-      "integrity": "sha512-E1OcDh30qyng1m0EIlsOuapYkqk5QB6o6IMBjvDKqIoo6IrjlVAasoJfS/CmSH998gXRL3BcAJa6Qg9IxPFZnQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.43.0.tgz",
+      "integrity": "sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g==",
       "cpu": [
         "x64"
       ],
@@ -582,9 +582,9 @@
       ]
     },
     "node_modules/@oxlint/linux-x64-musl": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.38.0.tgz",
-      "integrity": "sha512-4AfpbM/4sQnr6S1dMijEPfsq4stQbN5vJ2jsahSy/QTcvIVbFkgY+RIhrA5UWlC6eb0rD5CdaPQoKGMJGeXpYw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/linux-x64-musl/-/linux-x64-musl-1.43.0.tgz",
+      "integrity": "sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg==",
       "cpu": [
         "x64"
       ],
@@ -596,9 +596,9 @@
       ]
     },
     "node_modules/@oxlint/win32-arm64": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.38.0.tgz",
-      "integrity": "sha512-OvUVYdI68OwXh3d1RjH9N/okCxb6PrOGtEtzXyqGA7Gk+IxyZcX0/QCTBwV8FNbSSzDePSSEHOKpoIB+VXdtvg==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-arm64/-/win32-arm64-1.43.0.tgz",
+      "integrity": "sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA==",
       "cpu": [
         "arm64"
       ],
@@ -610,9 +610,9 @@
       ]
     },
     "node_modules/@oxlint/win32-x64": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.38.0.tgz",
-      "integrity": "sha512-7IuZMYiZiOcgg5zHvpJY6jRlEwh8EB/uq7GsoQJO9hANq96TIjyntGByhIjFSsL4asyZmhTEki+MO/u5Fb/WQA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/win32-x64/-/win32-x64-1.43.0.tgz",
+      "integrity": "sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==",
       "cpu": [
         "x64"
       ],
@@ -713,9 +713,9 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
     },
     "node_modules/@types/node": {
-      "version": "25.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.6.tgz",
-      "integrity": "sha512-NNu0sjyNxpoiW3YuVFfNz7mxSQ+S4X2G28uqg2s+CzoqoQjLPsWSbsFFyztIAqt2vb8kfEAsJNepMGPTxFDx3Q==",
+      "version": "25.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
+      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
-      "integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.3.0.tgz",
+      "integrity": "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1157,9 +1157,9 @@
       "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
     },
     "node_modules/oxlint": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.38.0.tgz",
-      "integrity": "sha512-XT7tBinQS+hVLxtfJOnokJ9qVBiQvZqng40tDgR6qEJMRMnpVq/JwYfbYyGntSq8MO+Y+N9M1NG4bAMFUtCJiw==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.43.0.tgz",
+      "integrity": "sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1172,17 +1172,17 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxlint/darwin-arm64": "1.38.0",
-        "@oxlint/darwin-x64": "1.38.0",
-        "@oxlint/linux-arm64-gnu": "1.38.0",
-        "@oxlint/linux-arm64-musl": "1.38.0",
-        "@oxlint/linux-x64-gnu": "1.38.0",
-        "@oxlint/linux-x64-musl": "1.38.0",
-        "@oxlint/win32-arm64": "1.38.0",
-        "@oxlint/win32-x64": "1.38.0"
+        "@oxlint/darwin-arm64": "1.43.0",
+        "@oxlint/darwin-x64": "1.43.0",
+        "@oxlint/linux-arm64-gnu": "1.43.0",
+        "@oxlint/linux-arm64-musl": "1.43.0",
+        "@oxlint/linux-x64-gnu": "1.43.0",
+        "@oxlint/linux-x64-musl": "1.43.0",
+        "@oxlint/win32-arm64": "1.43.0",
+        "@oxlint/win32-x64": "1.43.0"
       },
       "peerDependencies": {
-        "oxlint-tsgolint": ">=0.10.0"
+        "oxlint-tsgolint": ">=0.11.2"
       },
       "peerDependenciesMeta": {
         "oxlint-tsgolint": {
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1346,9 +1346,9 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.15",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.15.tgz",
-      "integrity": "sha512-mw2/2vTL7MlT+BVo43lOsufkkd2CJO4zeOSuWQQsiXoV2VuEn7f6IZp2jsUDPmBMABpgR0R5jlcJ2OGEFYmkyg==",
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.16.tgz",
+      "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@types/js-yaml": "4.0.9",
-    "@types/node": "25.0.6",
+    "@types/node": "25.2.0",
     "@types/ws": "8.18.1",
     "debug": "4.4.3",
     "h1emu-core": "1.3.2",
@@ -31,11 +31,11 @@
   },
   "devDependencies": {
     "cross-env": "^10.1.0",
-    "globals": "^17.0.0",
-    "oxlint": "^1.38.0",
-    "prettier": "^3.7.4",
+    "globals": "^17.3.0",
+    "oxlint": "^1.43.0",
+    "prettier": "^3.8.1",
     "tsx": "^4.21.0",
-    "typedoc": "^0.28.15"
+    "typedoc": "^0.28.16"
   },
   "scripts": {
     "gen-packets-types": "tsx ./scripts/genPacketsNames.ts",


### PR DESCRIPTION
### TL;DR

Updated development dependencies and Node.js type definitions to their latest versions.

### What changed?

- Updated `@types/node` from 25.0.6 to 25.2.0
- Updated development dependencies:
  - `globals` from 17.0.0 to 17.3.0
  - `oxlint` from 1.38.0 to 1.43.0
  - `prettier` from 3.7.4 to 3.8.1
  - `typedoc` from 0.28.15 to 0.28.16

### How to test?

1. Run `npm install` to update the dependencies
2. Verify that the project builds and runs correctly
3. Check that linting and formatting work as expected with the updated tools

### Why make this change?

Keeping dependencies up-to-date ensures we have the latest bug fixes, security patches, and features. This is particularly important for development tools like linters and formatters to maintain code quality standards.