### PR TITLE
limit the size of sessionIdString loginserver

### DIFF
--- a/src/servers/LoginServer/loginserver.ts
+++ b/src/servers/LoginServer/loginserver.ts
@@ -497,6 +497,9 @@ export class LoginServer extends EventEmitter {
     // In case of shitty json formatting
     sessionIdString = sessionIdString.replaceAll("\\", "");
     try {
+      if (sessionIdString.length > 100) {
+        throw new Error("sessionIdString too long");
+      }
       const sessionIdObject = JSON.parse(sessionIdString);
       authKey = sessionIdObject.sessionId;
       gameVersion = sessionIdObject.gameVersion;


### PR DESCRIPTION
### TL;DR

Added validation to prevent excessively long session ID strings in the login server.

### What changed?

Added a length check for `sessionIdString` in the LoginServer class that throws an error if the string exceeds 100 characters. This validation occurs before attempting to parse the JSON.

### How to test?

1. Try to authenticate with a normal session ID string (should work as before)
2. Try to authenticate with a session ID string longer than 100 characters (should receive an error)

### Why make this change?

This change prevents potential security issues or performance problems that could arise from processing extremely long session ID strings. It adds a safeguard against malformed or malicious inputs that could potentially be used in attacks like JSON injection or denial of service.