### PR TITLE
reusePort on udp server

### DIFF
--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -56,15 +56,18 @@ export class SOEServer extends EventEmitter {
     this._serverAddressV6 = process.env.SERVER_BIND_ADDRESS_V6 || "::";
     this._cryptoKey = cryptoKey;
     this._maxMultiBufferSize = this._udpLength - 4 - this._crcLength;
+    const isWindows = process.platform === "win32";
     this._connection = dgram.createSocket({
       type: "udp4",
       reuseAddr: true,
+      reusePort: !isWindows,
       recvBufferSize: oneMb * 2,
       sendBufferSize: oneMb
     });
     this._connectionv6 = dgram.createSocket({
       type: "udp6",
       reuseAddr: true,
+      reusePort: !isWindows,
       recvBufferSize: oneMb * 2,
       sendBufferSize: oneMb
     });


### PR DESCRIPTION
### TL;DR

Enable port reuse for UDP sockets in the SOEServer.

### What changed?

Added the `reusePort: true` option to both UDP4 and UDP6 socket configurations in the SOEServer class. This allows multiple processes to bind to the same port.

### How to test?

1. Run multiple instances of the server on the same port
2. Verify that both instances can receive and send packets without socket binding errors
3. Test with both IPv4 and IPv6 connections to ensure both socket types work correctly

### Why make this change?

Enabling the `reusePort` option allows multiple processes to bind to the same port, which improves load balancing and failover capabilities. This is particularly useful in clustered environments where multiple server instances need to handle incoming connections on the same port.