### PR TITLE
See mound on fertilized tillers on hover + small fixes

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/replication.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/replication.ts
@@ -23,7 +23,15 @@ export function packComponentNameString(name: string) {
 }
 
 export function packClientNpcComponent(obj: any) {
-  const raw: Buffer = Buffer.alloc(78);
+  let raw: Buffer;
+  
+  if (obj["worldItem"]) {
+    raw = Buffer.alloc(78);
+    raw.writeUint8(1, raw.length - 1);
+  }
+  else {
+    raw = Buffer.alloc(16);
+  }
   if (obj["nameId"]) {
     raw.writeUInt32LE(obj["nameId"], 12);
   }
@@ -31,7 +39,6 @@ export function packClientNpcComponent(obj: any) {
   raw.writeUint8(122, 0);
   raw.writeUint8(2, 1);
 
-  raw.writeUint8(1, raw.length - 1);
   return raw;
 }
 

--- a/src/servers/ZoneServer2016/data/loadouts.ts
+++ b/src/servers/ZoneServer2016/data/loadouts.ts
@@ -153,6 +153,13 @@ export const characterBuildKitLoadout = [
   { item: Items.GROUND_TAMPER, count: 10 },
   { item: Items.WEAPON_HAMMER_DEMOLITION }
 ];
+export const characterFarmKitLoadout = [
+  { item: Items.GROUND_TAMPER, count: 10 },
+  { item: Items.GROUND_TILLER, count: 400 },
+  { item: Items.SEED_CORN, count: 400 },
+  { item: Items.SEED_WHEAT, count: 400 },
+  { item: Items.FERTILIZER, count: 400 },
+]
 
 export const characterTestKitLoadout = [
   { item: Items.FOUNDATION, count: 10 },

--- a/src/servers/ZoneServer2016/entities/plant.ts
+++ b/src/servers/ZoneServer2016/entities/plant.ts
@@ -32,6 +32,9 @@ export class Plant extends ItemObject {
 
   /** Next time (milliseconds) that the crop will enter the next state */
   nextStateTime: number;
+  
+  /** Next time (milliseconds) that a fertilizer mound can appear */
+  nextMoundTime: number = 0;
 
   /** Time (milliseconds) it takes for a crop to enter the next state - Default: 8hrs */
   readonly growTime = 28800000;
@@ -188,8 +191,9 @@ export class Plant extends ItemObject {
   }
 
   OnInteractionString(server: ZoneServer2016, client: ZoneClient2016): void {
-    if (this.isFertilized) {
+    if (this.isFertilized && new Date().getTime() > this.nextMoundTime) {
       const pos = this.state.position;
+      this.nextMoundTime = new Date().getTime() + 180000;
       server.sendData<CharacterPlayWorldCompositeEffect>(client, "Character.PlayWorldCompositeEffect",
         {
           characterId: this.characterId,
@@ -210,11 +214,13 @@ export class Plant extends ItemObject {
     server: ZoneServer2016,
     client: ZoneClient2016
   ): void {
+    /*
     if (!this.isFertilized) return;
     server.sendData(client, "Command.PlayDialogEffect", {
       characterId: this.characterId,
       effectId: Effects.EFX_Crop_Fertilizer
     });
+    */
   }
 
   destroy(server: ZoneServer2016): boolean {

--- a/src/servers/ZoneServer2016/entities/plant.ts
+++ b/src/servers/ZoneServer2016/entities/plant.ts
@@ -126,21 +126,6 @@ export class Plant extends ItemObject {
         modelId: this.actorModelId
       }
     );
-    if (this.isFertilized) {
-      const pos = this.state.position;
-      server.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
-        // play burning effect & remove it after 15s
-        server._plants,
-        this.characterId,
-        "Character.PlayWorldCompositeEffect",
-        {
-          characterId: this.characterId,
-          effectId: Effects.EFX_Crop_Fertilizer,
-          position: new Float32Array([pos[0], pos[1], pos[2], 1]),
-          effectTime: 180
-        }
-      );
-    }
     const timeToAdd = this.isFertilized ? this.growTime / 2 : this.growTime; // 4 or 8h based on fertilized or not
     this.nextStateTime = new Date().getTime() + timeToAdd;
   }
@@ -203,6 +188,17 @@ export class Plant extends ItemObject {
   }
 
   OnInteractionString(server: ZoneServer2016, client: ZoneClient2016): void {
+    if (this.isFertilized) {
+      const pos = this.state.position;
+      server.sendData<CharacterPlayWorldCompositeEffect>(client, "Character.PlayWorldCompositeEffect",
+        {
+          characterId: this.characterId,
+          effectId: Effects.EFX_Crop_Fertilizer,
+          position: new Float32Array([pos[0], pos[1], pos[2], 1]),
+          effectTime: 180
+        }
+      );
+    }
     if (this.growState != 3) return;
     server.sendData(client, "Command.InteractionString", {
       guid: this.characterId,

--- a/src/servers/ZoneServer2016/entities/plant.ts
+++ b/src/servers/ZoneServer2016/entities/plant.ts
@@ -163,6 +163,7 @@ export class Plant extends ItemObject {
       this.parentObjectCharacterId
     ] as PlantingDiameter;
     delete parent.seedSlots[this.slot];
+    parent.disappearTimestamp = new Date().getTime() + 86400000;
 
     switch (this.item.itemDefinitionId) {
       case Items.SEED_WHEAT:

--- a/src/servers/ZoneServer2016/entities/plant.ts
+++ b/src/servers/ZoneServer2016/entities/plant.ts
@@ -78,7 +78,10 @@ export class Plant extends ItemObject {
     const parent = server._temporaryObjects[
       parentObjectCharacterId
     ] as PlantingDiameter;
-    if (parent.isFertilized) this.isFertilized = true;
+    if (parent.isFertilized) {
+      this.isFertilized = true;
+      this.nextStateTime = new Date().getTime() + this.growTime / 2;
+    }
     if (this.item.itemDefinitionId == Items.SEED_CORN) {
       this.nameId = StringIds.CORN;
     } else this.nameId = StringIds.WHEAT;

--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -37,7 +37,8 @@ import {
   characterTestKitLoadout,
   characterSkinsLoadout,
   characterKitLoadout,
-  characterVehicleKit
+  characterVehicleKit,
+  characterFarmKitLoadout
 } from "../../data/loadouts";
 import { emoteMap, emoteNames, defaultEmotes } from "../../data/emotes";
 import {
@@ -2788,6 +2789,13 @@ export const commands: Array<Command> = [
             server.generateItem(Items.FANNY_PACK_DEV)
           );
           client.character.equipLoadout(server, characterBuildKitLoadout, true);
+          break;
+        case "farm":
+          client.character.equipItem(
+            server,
+            server.generateItem(Items.FANNY_PACK_DEV)
+          );
+          client.character.equipLoadout(server, characterFarmKitLoadout, true);
           break;
         default:
           server.sendChatText(

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -2786,7 +2786,7 @@ export class ZonePacketHandlers {
 
       if (
         !isPosInRadius(
-          server.proximityItemsDistance,
+          server.proximityItemsDistance + 0.2, // It doesn't always reach otherwise
           client.character.state.position,
           sourceCharacter.state.position
         )

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -4549,7 +4549,8 @@ export class ZoneServer2016 extends EventEmitter {
         payload: {
           bufferData: {
             nameId: nameId,
-            componentName: "ClientNpcComponent"
+            componentName: "ClientNpcComponent",
+            worldItem: entity instanceof ItemObject
           }
         }
       }

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -7309,6 +7309,7 @@ export class ZoneServer2016 extends EventEmitter {
           plant.isFertilized = true;
           const roz = (plant.nextStateTime - new Date().getTime()) / 2;
           plant.nextStateTime = new Date().getTime() + roz;
+          plant.nextMoundTime = new Date().getTime() + 180000;
           this.sendDataToAllWithSpawnedEntity<CharacterPlayWorldCompositeEffect>(
             // play burning effect & remove it after 15s
             this._plants,


### PR DESCRIPTION
New feature to help identify what tillers have been fertilized. When looking on a plant on a tiller that has been fertilized the small mound will appear for 3 minutes for the player.

Fixed a bug where planting a new plant on a fertilized tiller didn't reduce the first growth stage.

Slightly increased the range where you can pick up proximity items so that you always reach the ones displayed inside the inventory. 

When sending createcomponent repdata to non world items we dont need to send the entire buffer since the last byte is not used. Now we only send the required amount of bytes to include name ID. (This doesn't appear to break anything but we'll see)