### PR TITLE
fill bottles loop + consumable auto-loop

### DIFF
--- a/src/servers/ZoneServer2016/entities/watersource.ts
+++ b/src/servers/ZoneServer2016/entities/watersource.ts
@@ -119,12 +119,7 @@ export class WaterSource extends TaskProp {
     }
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  OnPlayerSelect(
-    server: ZoneServer2016,
-    client: ZoneClient2016
-    /* eslint-enable @typescript-eslint/no-unused-vars */
-  ) {
+  OnPlayerSelect(server: ZoneServer2016, client: ZoneClient2016) {
     if (this.actorModelId == ModelIds.FIRE_HYDRANT && !this.isHydrantGushing) {
       server.utilizeHudTimer(client, StringIds.FIRE_HYDRANT, 3000, 0, () => {
         if (this.isHydrantOnCooldown) {
@@ -138,15 +133,17 @@ export class WaterSource extends TaskProp {
       });
       return;
     }
-    const bottle = client.character.getItemById(Items.WATER_EMPTY),
-      infiniteSources = [
-        "Common_Props_Well.adr",
-        "Common_Props_Dam_WaterValve01.adr",
-        "Common_Props_FireHydrant.adr"
-      ],
-      hasUses =
-        infiniteSources.includes(this.actorModel) ||
-        (this.usesLeft && this.usesLeft > 0);
+
+    const infiniteSources = [
+      "Common_Props_Well.adr",
+      "Common_Props_Dam_WaterValve01.adr",
+      "Common_Props_FireHydrant.adr"
+    ];
+
+    const hasUses =
+      infiniteSources.includes(this.actorModel) ||
+      (this.usesLeft && this.usesLeft > 0);
+
     if (!hasUses) {
       server.utilizeHudTimer(client, StringIds.DIRTY_WATER, 250, 0, () => {
         server.sendAlert(client, "This water source is dry.");
@@ -154,7 +151,7 @@ export class WaterSource extends TaskProp {
       return;
     }
 
-    if (!bottle) {
+    if (!client.character.getItemById(Items.WATER_EMPTY)) {
       server.utilizeHudTimer(
         client,
         infiniteSources.includes(this.actorModel)
@@ -176,26 +173,34 @@ export class WaterSource extends TaskProp {
       );
       return;
     }
-    server.utilizeHudTimer(
-      client,
-      infiniteSources.includes(this.actorModel)
+
+    const fillNext = () => {
+      const bottle = client.character.getItemById(Items.WATER_EMPTY);
+      const sourceHasUses =
+        infiniteSources.includes(this.actorModel) ||
+        (this.usesLeft && this.usesLeft > 0);
+
+      if (!bottle || !sourceHasUses) return;
+
+      const stringId = infiniteSources.includes(this.actorModel)
         ? StringIds.WATER_WELL
-        : StringIds.DIRTY_WATER,
-      1000,
-      0,
-      () => {
+        : StringIds.DIRTY_WATER;
+      const filledItem = infiniteSources.includes(this.actorModel)
+        ? Items.WATER_STAGNANT
+        : Items.WATER_DIRTY;
+
+      server.utilizeHudTimer(client, stringId, 1000, 0, () => {
         if (!server.removeInventoryItem(client.character, bottle)) return;
         client.character.lootContainerItem(
           server,
-          server.generateItem(
-            infiniteSources.includes(this.actorModel)
-              ? Items.WATER_STAGNANT
-              : Items.WATER_DIRTY
-          )
+          server.generateItem(filledItem)
         );
         if (this.usesLeft) this.usesLeft--;
-      }
-    );
+        setTimeout(() => fillNext(), 0);
+      });
+    };
+
+    fillNext();
   }
 
   OnMeleeHit(server: ZoneServer2016, damageInfo: DamageInfo) {

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -7197,6 +7197,40 @@ export class ZoneServer2016 extends EventEmitter {
       return;
     }
 
+    const shouldStop = () => {
+      const res = client.character._resources;
+      if (healCount || bandagingCount) {
+        const ht = client.character.healType[healType];
+        const pendingHeal = (ht.healingMaxTicks - ht.healingTicks) * 100;
+        const healthWillBeFull = res[ResourceIds.HEALTH] + pendingHeal >= 10000;
+        const bleedingIsStopped = res[ResourceIds.BLEEDING] <= 0;
+        return healthWillBeFull && bleedingIsStopped;
+      }
+      const isCanned = [
+        Items.CANNED_FOOD01, Items.CANNED_FOOD02, Items.CANNED_FOOD03,
+        Items.CANNED_FOOD04, Items.CANNED_FOOD05, Items.CANNED_FOOD06,
+        Items.CANNED_FOOD07, Items.CANNED_FOOD08, Items.CANNED_FOOD09,
+        Items.CANNED_FOOD10, Items.CANNED_FOOD11, Items.CANNED_FOOD21,
+        Items.CANNED_FOOD25, Items.CANNED_FOOD26
+      ].includes(item.itemDefinitionId);
+      if (isCanned) return false;
+      if (eatCount > 0 && res[ResourceIds.HUNGER] < 10000) return false;
+      if (drinkCount > 0 && res[ResourceIds.HYDRATION] < 10000) return false;
+      if (comfortCount > 0 && res[ResourceIds.COMFORT] < 5000) return false;
+      return true;
+    };
+
+    if ((healCount || bandagingCount) && shouldStop()) {
+      const ht = client.character.healType[healType];
+      const pendingHeal = (ht.healingMaxTicks - ht.healingTicks) * 100;
+      if (pendingHeal > 0) {
+        this.sendAlert(client, "Your healing is already in progress and will reach 100% HP.");
+      } else {
+        this.sendAlert(client, "You are already at full health.");
+      }
+      return;
+    }
+
     this.utilizeHudTimer(client, itemDef.NAME_ID, timeout, animationId, () => {
       this.useComsumablePass(
         client,
@@ -7212,6 +7246,19 @@ export class ZoneServer2016 extends EventEmitter {
         enduranceCount,
         healType
       );
+      const consumeNext = () => {
+        if (shouldStop()) return;
+        const nextItem = character.getItemById(item.itemDefinitionId);
+        if (!nextItem) return;
+        this.utilizeHudTimer(client, itemDef.NAME_ID, timeout, animationId, () => {
+          this.useComsumablePass(
+            client, character, nextItem, eatCount, drinkCount, comfortCount,
+            staminaCount, givetrash, healCount, bandagingCount, enduranceCount, healType
+          );
+          setTimeout(() => consumeNext(), 0);
+        });
+      };
+      setTimeout(() => consumeNext(), 0);
     });
   }
 
@@ -7495,11 +7542,18 @@ export class ZoneServer2016 extends EventEmitter {
         );
     }
     switch (useoption) {
-      case "fill": // empty bottle
-        this.utilizeHudTimer(client, nameId, timeout, animationId, () => {
-          this.fillPass(client, character, item);
-        });
+      case "fill": { // empty bottle - auto-fill all bottles while in water
+        const fillNext = () => {
+          const bottle = character.getItemById(Items.WATER_EMPTY);
+          if (!bottle || !client.character.characterStates.inWater) return;
+          this.utilizeHudTimer(client, nameId, timeout, animationId, () => {
+            this.fillPass(client, character, bottle);
+            setTimeout(() => fillNext(), 0);
+          });
+        };
+        fillNext();
         break;
+      }
       case "sniff": // swizzle
         this.utilizeHudTimer(client, nameId, timeout, animationId, () => {
           this.sniffPass(client, character, item);


### PR DESCRIPTION
- Interacting with a water source auto-fills all empty bottles one by one, stops on move
- Using a bottle from inventory while standing in water auto-fills all bottles
- Using food/drink/comfort items now auto-loops until resources are full
- Canned food loops regardless of hunger or comfort (used for metal scrapping)
- Medical items auto-loop until full HP; shows correct message if already full or healing in progress