### PR TITLE
Reset shutdown timer when aborting shutdown

### DIFF
--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -949,6 +949,7 @@ export class ZoneServer2016 extends EventEmitter {
     if (this.abortShutdown) {
       this.abortShutdown = false;
       this.shutdownStarted = false;
+      this.shutdownStartedTime = 0;
       this.sendAlertToAll(`Server shutdown aborted.`);
       return;
     }


### PR DESCRIPTION
When aborting a pending shutdown, also reset shutdownStartedTime to 0 so any stored shutdown start timestamp is cleared. This prevents stale timestamps from affecting subsequent shutdown logic or timers.