### PR TITLE
Fix melee weapon durability on NPC hits

### DIFF
--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -443,7 +443,7 @@ export class Npc extends BaseFullCharacter {
     const client = server.getClientByCharId(damageInfo.entity),
       weapon = client?.character.getEquippedWeapon();
 
-    if (!client || !weapon) return;
+    if (!weapon) return;
 
     const durabilityDamage = server.getDurabilityDamage(
       weapon.itemDefinitionId

--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -439,6 +439,17 @@ export class Npc extends BaseFullCharacter {
     if (!this.isAlive) return; // prevent dead npc despawning from melee dmg
     damageInfo.damage = damageInfo.damage / 1.5;
     this.damage(server, damageInfo);
+
+    const client = server.getClientByCharId(damageInfo.entity),
+      weapon = client?.character.getEquippedWeapon();
+
+    if (!client || !weapon) return;
+
+    const durabilityDamage = server.getDurabilityDamage(
+      weapon.itemDefinitionId
+    );
+
+    server.damageItem(client.character, weapon, durabilityDamage);
   }
 
   destroy(server: ZoneServer2016): boolean {


### PR DESCRIPTION
## Summary
- Apply weapon durability damage in Npc.OnMeleeHit when hitting zombies and other NPCs
- Matches existing behavior for destroyables and crates