### PR TITLE
remove custom poolsize size (my bad)

### DIFF
--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -61,7 +61,6 @@ export class SOEServer extends EventEmitter {
   constructor(serverPort: number, cryptoKey: Uint8Array) {
     super();
     const oneMb = 1024 * 1024;
-    Buffer.poolSize = oneMb;
     this._serverPort = serverPort;
     this._serverAddress = process.env.SERVER_BIND_ADDRESS || "0.0.0.0";
     this._serverAddressV6 = process.env.SERVER_BIND_ADDRESS_V6 || "::";


### PR DESCRIPTION
So I found this PR on the Node.js repository today: https://github.com/nodejs/node/pull/63597

When I changed the buffer pool size years ago, it was at the same time that I increased the UDP socket buffers so we would lose fewer packets. I was kinda clueless about what I was doing. I thought, "If I make the pool size bigger, it'll only increase the initial memory usage a bit and allow us to reuse more memory, making things more efficient, blah blah."

Well, I was wrong.

Here's a benchmark I ran: 100 clients sending 500 packets of 512 bytes per second, with the server echoing the same packet back to the clients.

Even though my benchmark isn’t perfect, it’s the only parameter I changed between runs.

The packet exchange rate was the same, and we used a little less CPU (about 4%), but the big thing here is the memory usage:

On Node.js 26.2 (so before the pool size was changed to 64 KB):

| Metric | 1 MB pool | 8 KB pool | Reduction |
|---|---|---|---|
| RSS mean | 714.6 MB | 373.3 MB | **-47.8%** |
| RSS peak | 1174.1 MB | 514.9 MB | **-56.2%** |
| heapUsed mean | 103.1 MB | 117.0 MB | **+13.5% worse** |
| heapUsed peak | 186.4 MB | 231.3 MB | **+24.1% worse** |
| external mean | 446.7 MB | 71.5 MB | **-84.1%** |
| external peak | 857.1 MB | 130.6 MB | **-84.8%** |
| arrayBuffers mean | 444.7 MB | 69.6 MB | **-84.3%** |
| arrayBuffers peak | 855.1 MB | 128.6 MB | **-85.0%** |

And on Node.js 26.3, it performs so much better in every way without the 1 MB pool, using the new default 64 KB pool instead. ( I mean even the packet exchange rate was better )

| Metric | 8 KB pool | 64 KB pool | Reduction |
|---|---|---|---|
| RSS mean | 373.3 MB | 144.6 MB | **-61.3%** |
| RSS peak | 514.9 MB | 146.5 MB | **-71.6%** |
| heapUsed mean | 117.0 MB | 23.6 MB | **-79.8%** |
| heapUsed peak | 231.3 MB | 43.5 MB | **-81.2%** |
| external mean | 71.5 MB | 5.1 MB | **-92.9%** |
| external peak | 130.6 MB | 8.7 MB | **-93.3%** |
| arrayBuffers mean | 69.6 MB | 3.1 MB | **-95.5%** |
| arrayBuffers peak | 128.6 MB | 6.7 MB | **-94.8%** |

Even if we’re at less than 40k or 10k or even 1k where the difference will probably not be seen, the fact is using a 1 MB pool will always be bad.