### PR TITLE
slotdoesnotcontainitem fix

### DIFF
--- a/src/servers/ZoneServer2016/managers/craftmanager.ts
+++ b/src/servers/ZoneServer2016/managers/craftmanager.ts
@@ -604,10 +604,11 @@ export class CraftManager {
           }
           removedItems.push({
             itemDS,
-            count: Math.min(itemDS.item.stackCount, remainingItems)
+            count: remainingItems
           });
           remainingItems = 0;
         } else {
+          const originalStackCount = itemDS.item.stackCount;
           if (
             await this.removeCraftComponent(
               server,
@@ -617,9 +618,9 @@ export class CraftManager {
           ) {
             removedItems.push({
               itemDS,
-              count: Math.min(itemDS.item.stackCount, remainingItems)
+              count: originalStackCount
             });
-            remainingItems -= itemDS.item.stackCount;
+            remainingItems -= originalStackCount;
           } else {
             server.containerError(client, ContainerErrors.NO_ITEM_IN_SLOT);
             craftSuccess = false; // return if not enough items


### PR DESCRIPTION
Root Cause
In craftmanager.ts:618-634, when removing craft components, the code was storing the wrong amount in the removedItems restoration array.

The Problem:
When removeCraftComponent() removes items from a container, it immediately reduces the item's stackCount. The buggy code then stored this modified (reduced) stack count instead of the actual amount removed.

The Fix
I saved the original stack count BEFORE calling removeCraftComponent(), then used that original value when storing in the removedItems array. This ensures that if crafting fails and items need to be restored, the correct amount is restored. The Problem:
When removeCraftComponent() removes items from a container, it immediately reduces the item's stackCount. The buggy code then stored this modified (reduced) stack count instead of the actual amount removed.