### PR TITLE
Streaming fine navmesh via an in-RAM TileCache (h1emu pipeline)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin/*.exe
 config.yaml
 /navMeshDump.obj
 *.tsbuildinfo
+/data/2016/collision/

--- a/docs/navmesh-streaming.md
+++ b/docs/navmesh-streaming.md
@@ -1,0 +1,79 @@
+# Navmesh streaming (fine tilecache)
+
+Optional mode that loads a **fine, whole-map navmesh** as a compressed
+`TileCache` streamed from RAM, instead of the coarse pre-baked navmesh in
+`data/2016/navData/`. Enabled with the `NAV_STREAMING=1` environment variable.
+
+## Why streaming
+
+A fine monolithic navmesh of the whole map (~108k tiles) overflows Detour's
+32-bit `dtPolyRef` budget (`tileBits + polyBits = 22`), so only a handful of
+polys per tile survive and paths get truncated. Streaming keeps the **active**
+navmesh bounded: the full compressed tilecache is preloaded into RAM, but only
+the tiles within `STREAM_RADIUS` of a live player are materialised into the
+navmesh (`buildNavMeshTilesAt`); tiles leaving the window are removed. The
+navmesh therefore stays well under the polyref budget while covering the whole
+map at fine resolution.
+
+## Enabling it
+
+```bash
+NAV_STREAMING=1 npm start
+```
+
+At boot the server loads `data/2016/collision/z1_cache_*.bin` (TileCacheSet,
+magic `TSET`). If those files are **absent**, it logs a warning and falls back
+to the standard navmesh — no crash, but no streaming.
+
+Debug namespaces (via the `debug` module):
+
+- `DEBUG=nav:stream` — tile window changes (`+N -M columns (loaded: K)`)
+- `DEBUG=nav` — obstacle carving (`requests`, obstacle `total`)
+
+## Regenerating the tilecache
+
+The tilecache (~600 MB) is **gitignored** (`/data/2016/collision/`) and must be
+generated with the official h1emu pipeline (it replaces the old in-repo
+tooling). High-level steps:
+
+1. Build [`h1emu-map-data-extraction`](https://github.com/H1emu/h1emu-map-data-extraction)
+   (Rust) and [`h1emu-recast`](https://github.com/H1emu/h1emu-recast)
+   (C++/CMake).
+2. Extract the Z1 map (from the game's `Assets_*.pack`) to a `world.obj` with
+   `h1emu-map-data-extraction`.
+3. Set the **fine** parameters in `h1emu-recast/main.cpp` before building:
+   | Constant | Fine value |
+   |---|---|
+   | `CELL_SIZE` | `0.2f` |
+   | `CELL_HEIGHT` | `0.1f` |
+   | `AGENT_MAX_CLIMB` | `1.5f` |
+   | `AGENT_MAX_SLOPE` | `70.0f` |
+   | `TILE_SIZE` | `128` |
+   (On MSVC, wrap the GCC-only flags in `if(MSVC) ... else() ... endif()` in
+   `CMakeLists.txt`.)
+4. Run the builder on `world.obj`; it writes `z1_cache_*.bin` (the `TSET`
+   tilecache) next to the navmesh.
+5. Copy `z1_cache_*.bin` into `data/2016/collision/`.
+
+The default (coarse) parameters reproduce the stock `data/2016/navData` navmesh
+exactly, which is a good sanity check that the pipeline is set up correctly.
+
+## Runtime (`src/utils/recast.ts`)
+
+- **`loadNavStreaming`** — reads the `TSET` header, inits an empty `TileCache`
+  and an empty tiled `NavMesh`, then `addTile`s every compressed layer (~1 s for
+  ~108k layers / ~600 MB).
+- **`streamAround(playerPositions)`** — called from
+  `zoneserver.updatePathfindingPositions()`; materialises the column window
+  around players and removes columns that left it. Throttled by
+  `STREAM_INTERVAL`.
+- **Carving** — `addObstacle` / `removeObstacle` feed the tilecache
+  (`addBoxObstacle`) and `updt()` pumps `tilecache.update()`, so player
+  constructions carve the streamed navmesh natively (NPCs route around them).
+
+## Tunables (`src/utils/recast.ts`)
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `STREAM_RADIUS` | `300` | meters around a player kept materialised |
+| `STREAM_INTERVAL` | `1000` | ms between window updates |

--- a/src/servers/ZoneServer2016/handlers/commands/dev.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/dev.ts
@@ -784,6 +784,12 @@ const dev: any = {
     );
     const a = server.navManager.createAgent(zombie.state.position);
     zombie.navAgent = a;
+    if (!a) {
+      console.log(
+        "[ZOMBIE-DEBUG] no navmesh under spawn point, agent deferred"
+      );
+      return;
+    }
     // Sync zombie to its navmesh spawn point converted back to game coords
     const initialGamePos = NavManager.navToGame(a.position());
     zombie.state.position = initialGamePos;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -10606,8 +10606,24 @@ export class ZoneServer2016 extends EventEmitter {
   }
 
   updatePathfindingPositions(): void {
+    // streaming navmesh: load the fine tiles around live players, unload the rest
+    if (this.navManager.streaming) {
+      const playerPositions: Float32Array[] = [];
+      for (const k in this._characters) {
+        const c = this._characters[k];
+        if (c.isAlive) playerPositions.push(c.state.position);
+      }
+      this.navManager.streamAround(playerPositions);
+    }
     for (const k in this._npcs) {
       const npc = this._npcs[k];
+      if (!npc.navAgent) {
+        // streaming: an NPC spawned where no navmesh tile was loaded yet gets no
+        // agent; retry once a player's window has streamed its tile in (else
+        // natural world spawns far from any player simply stay agentless).
+        npc.navAgent =
+          this.navManager.createAgent(npc.state.position) ?? undefined;
+      }
       if (npc.navAgent) {
         const navPos = npc.navAgent.interpolatedPosition;
         const gamePos = NavManager.navToGame(navPos);
@@ -10615,6 +10631,17 @@ export class ZoneServer2016 extends EventEmitter {
           gamePos[0] != npc.state.position[0] ||
           gamePos[2] != npc.state.position[2]
         ) {
+          // guard: skip absurd / off-map agent positions. An agent placed
+          // off-navmesh can yield garbage interpolated coords, which crash
+          // PlayerUpdatePosition serialization (uint32 out of range).
+          if (
+            !Number.isFinite(gamePos[0]) ||
+            !Number.isFinite(gamePos[2]) ||
+            Math.abs(gamePos[0]) > 4096 ||
+            Math.abs(gamePos[2]) > 4096
+          ) {
+            continue;
+          }
           npc.goTo(gamePos);
         }
       }

--- a/src/utils/recast.ts
+++ b/src/utils/recast.ts
@@ -11,26 +11,49 @@
 //   Based on https://github.com/psemu/soe-network
 // ======================================================================
 
-import { createWriteStream, existsSync, readFileSync } from "node:fs";
+import {
+  createWriteStream,
+  existsSync,
+  readFileSync,
+  readdirSync
+} from "node:fs";
 import {
   BoxObstacle,
   CrowdAgent,
+  DetourTileCacheParams,
   getNavMeshPositionsAndIndices,
   importNavMesh,
   importTileCache,
   init as initRecast,
   NavMesh,
+  NavMeshParams,
+  Raw,
   statusToReadableString,
   TileCache,
+  UnsignedCharArray,
   Vector3
 } from "recast-navigation";
 import { NavMeshQuery } from "recast-navigation";
 import { Crowd } from "recast-navigation";
 import { createDefaultTileCacheMeshProcess } from "recast-navigation/generators";
 const debug = require("debug")("nav");
+// dedicated namespace for tile streaming (enable with DEBUG=nav:stream)
+const debugStream = require("debug")("nav:stream");
 
 const MAX_OBSTACLE = 20000;
 const MAX_PENDING_OBSTACLE = 50;
+
+// Streaming navmesh: a whole-map FINE navmesh stored as a compressed TileCache
+// on disk (data/2016/collision/z1_cache_*.bin, format "TSET", built by the
+// h1emu-recast pipeline compiled fine, cs=0.2). The whole compressed tilecache
+// (~600 MB / ~108k layers) is preloaded into RAM at boot; only the tiles within
+// STREAM_RADIUS of a player are materialised into the live navmesh
+// (buildNavMeshTilesAt), the rest are removed, so the navmesh stays bounded and
+// under the 32-bit polyref budget. Grid params (orig, tileWidth) come from the
+// TSET header. Construction obstacles carve natively via the tilecache.
+const STREAM_ENABLED = process.env.NAV_STREAMING === "1";
+const STREAM_RADIUS = 300; // materialise tiles within this many meters of a player
+const STREAM_INTERVAL = 1000; // ms between window updates
 
 export class NavManager {
   navmesh!: NavMesh;
@@ -41,8 +64,22 @@ export class NavManager {
   lastTimeCall: number = Date.now();
   updateFrequency = 1 / 5;
   obstacleCount = 0;
+  // streaming state
+  streaming = false;
+  private _tcOrigX = 0;
+  private _tcOrigZ = 0;
+  private _tcTileWidth = 25.6;
+  private _loadedCols = new Set<string>(); // materialised tile columns "tx,tz"
+  private _lastStreamMs = 0;
   constructor() {}
   async loadNav() {
+    if (STREAM_ENABLED) {
+      const storePath = __dirname + "/../../data/2016/collision/z1_cache_0.bin";
+      if (existsSync(storePath)) return this.loadNavStreaming();
+      console.warn(
+        "[NAV] NAV_STREAMING=1 but data/2016/collision/z1_cache_*.bin is missing - falling back to the standard navmesh"
+      );
+    }
     console.time("[NAV] Navmesh loaded");
     const mesh_parts: Buffer[] = [];
     const tc_parts: Buffer[] = [];
@@ -78,6 +115,152 @@ export class NavManager {
     this.navMeshQuery = new NavMeshQuery(this.navmesh);
     this.crowd = new Crowd(navMesh, { maxAgents, maxAgentRadius });
     console.timeEnd("[NAV] Navmesh loaded");
+  }
+
+  // Streaming mode: preload the whole compressed TileCache (z1_cache_*.bin, TSET
+  // format from h1emu-recast) into RAM, build an empty tiled navmesh, and add
+  // every compressed layer to the tilecache. Tiles are materialised on demand
+  // around players in streamAround() (buildNavMeshTilesAt).
+  private async loadNavStreaming() {
+    console.time("[NAV] streaming tilecache loaded");
+    await initRecast();
+    const dir = __dirname + "/../../data/2016/collision";
+    const parts = readdirSync(dir)
+      .filter((f) => /^z1_cache_\d+\.bin$/.test(f))
+      .sort(
+        (a, b) =>
+          parseInt(a.match(/\d+/)![0], 10) - parseInt(b.match(/\d+/)![0], 10)
+      );
+    const buf = Buffer.concat(parts.map((p) => readFileSync(`${dir}/${p}`)));
+
+    // parse TileCacheSetHeader (magic, version, numTiles, meshParams, cacheParams)
+    let o = 0;
+    const rI = () => {
+      const v = buf.readInt32LE(o);
+      o += 4;
+      return v;
+    };
+    const rF = () => {
+      const v = buf.readFloatLE(o);
+      o += 4;
+      return v;
+    };
+    const TSET =
+      ("T".charCodeAt(0) << 24) |
+      ("S".charCodeAt(0) << 16) |
+      ("E".charCodeAt(0) << 8) |
+      "T".charCodeAt(0);
+    if (rI() !== TSET) throw new Error("[NAV] bad tilecache TSET magic");
+    rI(); // version
+    const numTiles = rI();
+    const mesh = {
+      orig: { x: rF(), y: rF(), z: rF() },
+      tileWidth: rF(),
+      tileHeight: rF(),
+      maxTiles: rI(),
+      maxPolys: rI()
+    };
+    const cache = {
+      orig: [rF(), rF(), rF()],
+      cs: rF(),
+      ch: rF(),
+      width: rI(),
+      height: rI(),
+      walkableHeight: rF(),
+      walkableRadius: rF(),
+      walkableClimb: rF(),
+      maxSimplificationError: rF(),
+      maxTiles: rI(),
+      maxObstacles: rI()
+    };
+    this._tcOrigX = mesh.orig.x;
+    this._tcOrigZ = mesh.orig.z;
+    this._tcTileWidth = mesh.tileWidth;
+
+    const meshProcess = createDefaultTileCacheMeshProcess();
+    this.tilecache = new TileCache();
+    this.tilecache.init(
+      DetourTileCacheParams.create(cache),
+      new (Raw as any).RecastLinearAllocator(1 << 20),
+      new (Raw as any).RecastFastLZCompressor(),
+      meshProcess
+    );
+    this.navmesh = new NavMesh();
+    this.navmesh.initTiled(NavMeshParams.create(mesh));
+
+    const FREE = (Raw.Detour as any).DT_COMPRESSEDTILE_FREE_DATA ?? 1;
+    for (let i = 0; i < numTiles; i++) {
+      o += 4; // tileRef (recomputed by addTile)
+      const dataSize = buf.readInt32LE(o);
+      o += 4;
+      const arr = new UnsignedCharArray();
+      arr.copy(buf.subarray(o, o + dataSize));
+      o += dataSize;
+      this.tilecache.addTile(arr, FREE);
+    }
+
+    this.navMeshQuery = new NavMeshQuery(this.navmesh);
+    this.crowd = new Crowd(this.navmesh, {
+      maxAgents: 1000,
+      maxAgentRadius: 2.5
+    });
+    this.streaming = true;
+    console.timeEnd("[NAV] streaming tilecache loaded");
+    console.log(
+      `[NAV] streaming tilecache ready (${numTiles} layers, ${(buf.length / 1048576) | 0} MB in RAM)`
+    );
+  }
+
+  // Materialise the navmesh tiles within STREAM_RADIUS of any player from the
+  // in-RAM tilecache (buildNavMeshTilesAt) and remove the columns that left the
+  // window. Throttled. No-op unless streaming.
+  streamAround(positions: Float32Array[]): void {
+    if (!this.streaming) return;
+    const now = Date.now();
+    if (now - this._lastStreamMs < STREAM_INTERVAL) return;
+    this._lastStreamMs = now;
+    const tw = this._tcTileWidth;
+    const rad = Math.ceil(STREAM_RADIUS / tw);
+    const want = new Set<string>();
+    for (const p of positions) {
+      const cx = Math.floor((p[0] - this._tcOrigX) / tw),
+        cz = Math.floor((p[2] - this._tcOrigZ) / tw);
+      for (let dx = -rad; dx <= rad; dx++) {
+        for (let dz = -rad; dz <= rad; dz++) {
+          want.add(`${cx + dx},${cz + dz}`);
+        }
+      }
+    }
+    let removed = 0;
+    // unload columns outside the window
+    for (const k of this._loadedCols) {
+      if (!want.has(k)) {
+        const [tx, tz] = k.split(",").map(Number);
+        const res = this.navmesh.getTilesAt(tx, tz, 8);
+        for (let i = 0; i < res.tileCount(); i++) {
+          const ref = this.navmesh.getTileRef(res.tiles(i));
+          if (ref) this.navmesh.removeTile(ref);
+        }
+        this._loadedCols.delete(k);
+        removed++;
+      }
+    }
+    let added = 0;
+    // materialise columns entering the window; obstacles already registered in
+    // the tilecache are carved in automatically by buildNavMeshTilesAt
+    for (const k of want) {
+      if (this._loadedCols.has(k)) continue;
+      const [tx, tz] = k.split(",").map(Number);
+      this.tilecache.buildNavMeshTilesAt(tx, tz, this.navmesh);
+      this._loadedCols.add(k);
+      added++;
+    }
+    // only log when the window actually changed (no spam while standing still)
+    if ((added || removed) && debugStream.enabled) {
+      debugStream(
+        `+${added} -${removed} columns (loaded: ${this._loadedCols.size}, players: ${positions.length})`
+      );
+    }
   }
 
   static gameToNav(f: Float32Array): Vector3 {
@@ -141,6 +324,8 @@ export class NavManager {
   updt() {
     const now = Date.now();
     const timeSinceLastCalled = (now - this.lastTimeCall) / 1000;
+    // tilecache carving runs in both modes now: in streaming the obstacles are
+    // applied to the materialised window tiles, in normal mode to the whole mesh
     if (this.obstaclesRequestsPending) {
       let upToDate = false;
       while (!upToDate) {
@@ -168,8 +353,16 @@ export class NavManager {
     return n.nearestPoint;
   }
 
-  createAgent(gamePos: Float32Array): CrowdAgent {
-    const navPosition = this.getClosestNavPointVec3(gamePos);
+  createAgent(gamePos: Float32Array): CrowdAgent | undefined {
+    // In streaming mode the navmesh only exists around players; if no tile is
+    // loaded under this spawn point yet, defer (caller retries when it loads)
+    // instead of placing the agent at a garbage position.
+    const { nearestRef, nearestPoint } = this.navMeshQuery.findNearestPoly(
+      NavManager.gameToNav(gamePos),
+      { halfExtents: { x: 10, y: 10, z: 10 } }
+    );
+    if (!nearestRef) return undefined;
+    const navPosition = nearestPoint;
     debug(
       `createAgent: navPos=[${navPosition.x.toFixed(2)}, ${navPosition.y.toFixed(2)}, ${navPosition.z.toFixed(2)}]`
     );


### PR DESCRIPTION
## What

Adds an optional **fine, whole-map navmesh** streamed from a compressed
`TileCache` held in RAM, enabled with `NAV_STREAMING=1`. Only the tiles within
`STREAM_RADIUS` of a live player are materialised into the active navmesh,
keeping it under Detour's 32-bit `dtPolyRef` budget while covering the whole map
at fine resolution. When the tilecache files are absent it transparently falls
back to the existing navmesh, so default behaviour is unchanged.

## Why

A fine monolithic navmesh of the whole map (~108k tiles) overflows the 32-bit
polyref budget (`tileBits + polyBits = 22`) and truncates paths. Streaming keeps
the active navmesh bounded (~625 tile columns around a player at a time) while
covering the map at fine resolution.

## Changes

- **`src/utils/recast.ts`** — `loadNavStreaming` (preload + parse the `TSET`
  tilecache, init an empty `TileCache` + tiled navmesh, `addTile` every layer),
  `streamAround` (sliding tile window via `buildNavMeshTilesAt` / `removeTile`),
  native carving in streaming mode, and a `DEBUG=nav:stream` log.
- **`zoneserver.ts`** — `updatePathfindingPositions` streaming hook + a
  `createAgent` retry for NPCs spawned before their tile has streamed in.
- **`docs/navmesh-streaming.md`** — enabling the mode + regenerating the
  tilecache with the h1emu pipeline.

## Data

The tilecache (~600 MB) is **gitignored** and regenerated with the h1emu
pipeline (see `docs/navmesh-streaming.md`). Without it the server uses the
standard navmesh, so this is safe to merge without the data.

## Testing

- `tsc` build + `oxlint` + `prettier` clean; CI green (lint, prettier,
  linux/windows/mongo on Node 24/25/26, CodeQL).
- In-game (solo): tilecache loads in ~1 s (108 753 layers); sliding window
  verified via `DEBUG=nav:stream` (`+625` at spawn, `+25/-25` per column
  crossed, loaded count constant at 625); NPC pathfinding works; player
  constructions carve the navmesh (zombies route around a placed foundation).
