### PR TITLE
performance improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fix-signatures": "tsx ./scripts/fixSignatures.ts && npm run prettier_sources",
     "gen-doc": "npm run updt-doc-config && typedoc",
     "updt-doc-config": "tsx ./scripts/updateTypeDoc.ts",
-    "start": "node --no-warnings --env-file=.env --experimental-require-module ./scripts/h1z1-server-demo-2016.js",
+    "start": "node --no-warnings --experimental-require-module ./scripts/h1z1-server-demo-2016.js",
     "start-dev": "npm run build && npm start",
     "start-echo": "npm run build && npm run build-benchs && node --inspect ./benchmarks/out/echo/echo-server-start.js",
     "stress": "npm run build && npm run build-benchs && node benchmarks/out/zoneStress/zone-stress.js",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fix-signatures": "tsx ./scripts/fixSignatures.ts && npm run prettier_sources",
     "gen-doc": "npm run updt-doc-config && typedoc",
     "updt-doc-config": "tsx ./scripts/updateTypeDoc.ts",
-    "start": "node --no-warnings --experimental-require-module ./scripts/h1z1-server-demo-2016.js",
+    "start": "node --no-warnings --env-file=.env --experimental-require-module ./scripts/h1z1-server-demo-2016.js",
     "start-dev": "npm run build && npm start",
     "start-echo": "npm run build && npm run build-benchs && node --inspect ./benchmarks/out/echo/echo-server-start.js",
     "stress": "npm run build && npm run build-benchs && node benchmarks/out/zoneStress/zone-stress.js",

--- a/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
@@ -637,121 +637,114 @@ export function readPositionUpdateDataAndCheckLength(
 }
 
 export function packPositionUpdateData(obj: any) {
-  let data = Buffer.allocUnsafe(7),
-    flags = 0,
-    v;
-
-  data.writeUInt32LE(obj["sequenceTime"], 2);
-  data.writeUInt8(obj["unknown3_int8"], 6);
+  // Fields are collected into `chunks` and copied into a single pre-sized
+  // buffer at the end instead of repeated Buffer.concat (which recopies
+  // everything written so far on every call) — this is the packer for the
+  // highest-frequency broadcast packet in the game (position updates).
+  let flags = 0;
+  const chunks: Buffer[] = [];
+  let v: Buffer;
 
   if ("stance" in obj) {
     flags |= 1;
-    v = packUnsignedIntWith2bitLengthValue(obj["stance"]);
-    data = Buffer.concat([data, v]);
+    chunks.push(packUnsignedIntWith2bitLengthValue(obj["stance"]));
   }
 
   if ("position" in obj) {
     flags |= 2;
-    v = packSignedIntWith2bitLengthValue(obj["position"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][2] * 100));
   }
 
   if ("orientation" in obj) {
     flags |= 0x20;
     v = Buffer.allocUnsafe(4);
     v.writeFloatLE(obj["orientation"], 0);
-    data = Buffer.concat([data, v]);
+    chunks.push(v);
   }
 
   if ("frontTilt" in obj) {
     flags |= 0x40;
-    v = packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100));
   }
 
   if ("sideTilt" in obj) {
     flags |= 0x80;
-    v = packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100));
   }
 
   if ("angleChange" in obj) {
     flags |= 4;
-    v = packSignedIntWith2bitLengthValue(obj["angleChange"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["angleChange"] * 100));
   }
 
   if ("verticalSpeed" in obj) {
     flags |= 8;
-    v = packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100));
   }
 
   if ("horizontalSpeed" in obj) {
     flags |= 0x10;
-    v = packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10));
   }
 
   if ("unknown12_float" in obj) {
     flags |= 0x100;
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100)
+    );
   }
 
   if ("rotationRaw" in obj) {
     flags |= 0x200;
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100));
   }
 
   if ("direction" in obj) {
     flags |= 0x400;
-    v = packSignedIntWith2bitLengthValue(obj["direction"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["direction"] * 10));
   }
 
   if ("engineRPM" in obj) {
     flags |= 0x800;
-    v = packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10));
   }
 
   if ("PosAndRot" in obj) {
     flags |= 0x1000;
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][0] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][1] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][2] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][3] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][4] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][5] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][6] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][7] * 10000);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][0] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][1] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][2] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][3] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][4] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][5] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][6] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][7] * 10000));
   }
 
+  let bodyLength = 0;
+  for (const c of chunks) bodyLength += c.length;
+
+  const data = Buffer.allocUnsafe(7 + bodyLength);
   data.writeUInt16LE(flags, 0);
+  data.writeUInt32LE(obj["sequenceTime"], 2);
+  data.writeUInt8(obj["unknown3_int8"], 6);
+
+  let offset = 7;
+  for (const c of chunks) {
+    c.copy(data, offset);
+    offset += c.length;
+  }
 
   return data;
 }

--- a/src/packets/ClientProtocol/ClientProtocol_1080/weapon.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/weapon.ts
@@ -634,11 +634,12 @@ export function packWeaponPacket(obj: any): Buffer {
   if (weaponPacketDescriptors[subType]) {
     const subPacket = weaponPacketDescriptors[subType],
       subTypeData = writePacketType(subType);
-    let subData = DataSchema.pack(subPacket.schema, subObj).data;
-    subData = Buffer.concat([subTypeData.slice(1), subData]);
-    data = Buffer.allocUnsafe(subData.length + 4);
+    const subData = DataSchema.pack(subPacket.schema, subObj).data;
+    const typeBytes = subTypeData.length - 1;
+    data = Buffer.allocUnsafe(4 + typeBytes + subData.length);
     data.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-    subData.copy(data, 4);
+    subTypeData.copy(data, 4, 1);
+    subData.copy(data, 4 + typeBytes);
   } else {
     throw "Unknown weapon packet type: " + subType;
   }
@@ -646,40 +647,34 @@ export function packWeaponPacket(obj: any): Buffer {
 }
 
 function packFirestateUpdate(obj: any): Buffer {
-  let data = Buffer.alloc(1);
-  data.writeUInt8(obj.firestate);
-  if ((obj.firestate & 2) == 0) {
-    // transientId
-    data = Buffer.concat([
-      data,
-      DataSchema.pack(
-        [
-          {
-            name: "transientId",
-            type: "custom",
-            parser: readUnsignedIntWith2bitLengthValue,
-            packer: packUnsignedIntWith2bitLengthValue
-          }
-        ],
-        obj
-      ).data
-    ]);
-  } else {
-    // floatvector4
-    data = Buffer.concat([
-      data,
-      DataSchema.pack(
-        [
-          {
-            name: "position",
-            type: "floatvector4",
-            defaultValue: [1, 1, 1, 1]
-          }
-        ],
-        obj
-      ).data
-    ]);
-  }
+  const fieldData =
+    (obj.firestate & 2) == 0
+      ? // transientId
+        DataSchema.pack(
+          [
+            {
+              name: "transientId",
+              type: "custom",
+              parser: readUnsignedIntWith2bitLengthValue,
+              packer: packUnsignedIntWith2bitLengthValue
+            }
+          ],
+          obj
+        ).data
+      : // floatvector4
+        DataSchema.pack(
+          [
+            {
+              name: "position",
+              type: "floatvector4",
+              defaultValue: [1, 1, 1, 1]
+            }
+          ],
+          obj
+        ).data;
+  const data = Buffer.allocUnsafe(1 + fieldData.length);
+  data.writeUInt8(obj.firestate, 0);
+  fieldData.copy(data, 1);
   return data;
 }
 
@@ -692,20 +687,25 @@ export function packRemoteWeaponPacket(obj: any): Buffer {
   if (!remoteWeaponPacketDescriptors[subType]) {
     throw "Unknown weapon packet type: " + subType;
   }
-  let subData = Buffer.allocUnsafe(6);
+  const header = Buffer.allocUnsafe(6);
   const subTypeData = writePacketType(subType);
-  subData.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-  subData.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
-  subData.writeUInt8(subTypeData[0], 5); // remoteweapon sub opcode
+  header.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
+  header.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
+  header.writeUInt8(subTypeData[0], 5); // remoteweapon sub opcode
   const transientId = packUnsignedIntWith2bitLengthValue(
     obj["remoteWeaponPacket"]["transientId"]
   );
-  subData = Buffer.concat([subData, transientId]);
   const packetData = DataSchema.pack(
     remoteWeaponPacketDescriptors[subType].schema,
     subObj
   ).data;
-  return Buffer.concat([subData, packetData]);
+  const data = Buffer.allocUnsafe(
+    header.length + transientId.length + packetData.length
+  );
+  header.copy(data, 0);
+  transientId.copy(data, header.length);
+  packetData.copy(data, header.length + transientId.length);
+  return data;
 }
 
 export function packRemoteWeaponUpdatePacket(obj: any): Buffer {
@@ -715,15 +715,14 @@ export function packRemoteWeaponUpdatePacket(obj: any): Buffer {
   if (!remoteWeaponUpdatePacketDescriptors[subType]) {
     throw "Unknown weapon packet type: " + subType;
   }
-  let subData = Buffer.allocUnsafe(6);
+  const header = Buffer.allocUnsafe(6);
   const subTypeData = writePacketType(subType);
-  subData.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-  subData.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
-  subData.writeUInt8(0x04, 5); // "RemoteWeapon.Update" opcode
+  header.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
+  header.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
+  header.writeUInt8(0x04, 5); // "RemoteWeapon.Update" opcode
   const transientId = packUnsignedIntWith2bitLengthValue(
     obj["remoteWeaponPacket"]["transientId"]
   );
-  subData = Buffer.concat([subData, transientId]);
   const updateData = Buffer.allocUnsafe(9);
   updateData.writeUInt8(subTypeData[0], 0);
   for (let j = 0; j < 8; j++) {
@@ -737,12 +736,22 @@ export function packRemoteWeaponUpdatePacket(obj: any): Buffer {
       1 + j
     );
   }
-  subData = Buffer.concat([subData, updateData]);
   const packetData = DataSchema.pack(
     remoteWeaponUpdatePacketDescriptors[subType].schema,
     subObj
   ).data;
-  return Buffer.concat([subData, packetData]);
+  const data = Buffer.allocUnsafe(
+    header.length + transientId.length + updateData.length + packetData.length
+  );
+  let offset = 0;
+  header.copy(data, offset);
+  offset += header.length;
+  transientId.copy(data, offset);
+  offset += transientId.length;
+  updateData.copy(data, offset);
+  offset += updateData.length;
+  packetData.copy(data, offset);
+  return data;
 }
 
 const hitReportSchema = [

--- a/src/packets/ClientProtocol/ClientProtocol_860/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/shared.ts
@@ -254,101 +254,102 @@ export function readPositionUpdateData(data: Buffer, offset: number) {
 }
 
 export function packPositionUpdateData(obj: any) {
-  let data = Buffer.allocUnsafe(7),
-    flags = 0,
-    v;
-
-  data.writeUInt32LE(obj["sequenceTime"], 2);
-  data.writeUInt8(obj["unknown3_int8"], 6);
+  // Fields are collected into `chunks` and copied into a single pre-sized
+  // buffer at the end instead of repeated Buffer.concat (which recopies
+  // everything written so far on every call) — this is the packer for the
+  // highest-frequency broadcast packet in the game (position updates).
+  let flags = 0;
+  const chunks: Buffer[] = [];
+  let v: Buffer;
 
   if ("stance" in obj) {
     flags |= 1;
-    v = packUnsignedIntWith2bitLengthValue(obj["stance"]);
-    data = Buffer.concat([data, v]);
+    chunks.push(packUnsignedIntWith2bitLengthValue(obj["stance"]));
   }
 
   if ("position" in obj) {
     flags |= 2;
-    v = packSignedIntWith2bitLengthValue(obj["position"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][2] * 100));
   }
 
   if ("orientation" in obj) {
     flags |= 0x20;
     v = Buffer.allocUnsafe(4);
     v.writeFloatLE(obj["orientation"], 0);
-    data = Buffer.concat([data, v]);
+    chunks.push(v);
   }
 
   if ("frontTilt" in obj) {
     flags |= 0x40;
-    v = packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100));
   }
 
   if ("sideTilt" in obj) {
     flags |= 0x80;
-    v = packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100));
   }
 
   if ("angleChange" in obj) {
     flags |= 4;
-    v = packSignedIntWith2bitLengthValue(obj["angleChange"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["angleChange"] * 100));
   }
 
   if ("verticalSpeed" in obj) {
     flags |= 8;
-    v = packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100));
   }
 
   if ("horizontalSpeed" in obj) {
     flags |= 0x10;
-    v = packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10));
   }
 
   if ("unknown12_float" in obj) {
     flags |= 0x100;
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100)
+    );
   }
 
   if ("rotationRaw" in obj) {
     flags |= 0x200;
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100));
   }
 
   if ("direction" in obj) {
     flags |= 0x400;
-    v = packSignedIntWith2bitLengthValue(obj["direction"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["direction"] * 10));
   }
 
   if ("engineRPM" in obj) {
     flags |= 0x800;
-    v = packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10));
   }
 
+  let bodyLength = 0;
+  for (const c of chunks) bodyLength += c.length;
+
+  const data = Buffer.allocUnsafe(7 + bodyLength);
   data.writeUInt16LE(flags, 0);
+  data.writeUInt32LE(obj["sequenceTime"], 2);
+  data.writeUInt8(obj["unknown3_int8"], 6);
+
+  let offset = 7;
+  for (const c of chunks) {
+    c.copy(data, offset);
+    offset += c.length;
+  }
 
   return data;
 }

--- a/src/packets/ClientProtocol/ClientProtocol_860/weapon.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/weapon.ts
@@ -263,11 +263,12 @@ export function packWeaponPacket(obj: any) {
   if (weaponPacketDescriptors[subType]) {
     const subPacket = weaponPacketDescriptors[subType],
       subTypeData = writePacketType(subType);
-    let subData = DataSchema.pack(subPacket.schema, subObj).data;
-    subData = Buffer.concat([subTypeData.slice(1), subData]);
-    data = Buffer.allocUnsafe(subData.length + 4);
+    const subData = DataSchema.pack(subPacket.schema, subObj).data;
+    const typeBytes = subTypeData.length - 1;
+    data = Buffer.allocUnsafe(4 + typeBytes + subData.length);
     data.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-    subData.copy(data, 4);
+    subTypeData.copy(data, 4, 1);
+    subData.copy(data, 4 + typeBytes);
   } else {
     throw "Unknown weapon packet type: " + subType;
   }

--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -159,26 +159,32 @@ export class SOEServer extends EventEmitter {
     const resends: LogicalPacket[] = [];
     const resendedSequences: Set<number> = new Set();
     for (const [sequence, time] of client.unAckData) {
+      // Map iteration order matches insertion order, which matches send order:
+      // entries are only ever appended fresh (_sendAndBuildPhysicalPacket /
+      // setupResendForQueuedPackets always run right after a delete() for any
+      // sequence being resent, never refresh a stale position in place), so
+      // once we reach an entry that isn't due yet, nothing after it is either.
+      if (time + this._resendTimeout + client.avgPing >= currentTime) {
+        break;
+      }
       // if the packet is too old then we resend it
-      if (time + this._resendTimeout + client.avgPing < currentTime) {
-        const dataCache = client.outputStream.getDataCache(sequence);
-        if (dataCache) {
-          if (dataCache.resendCounter >= this._maxResentTries) {
-            continue;
-          }
-          dataCache.resendCounter++;
-          client.stats.packetResend++;
-          const logicalPacket = this.createLogicalPacket(
-            dataCache.fragment ? SoeOpcode.DataFragment : SoeOpcode.Data,
-            { sequence: sequence, data: dataCache.data }
-          );
-          if (logicalPacket) {
-            resendedSequences.add(sequence);
-            resends.push(logicalPacket);
-          }
-        } else {
-          // If the data cache is not found it means that the packet has been acked
+      const dataCache = client.outputStream.getDataCache(sequence);
+      if (dataCache) {
+        if (dataCache.resendCounter >= this._maxResentTries) {
+          continue;
         }
+        dataCache.resendCounter++;
+        client.stats.packetResend++;
+        const logicalPacket = this.createLogicalPacket(
+          dataCache.fragment ? SoeOpcode.DataFragment : SoeOpcode.Data,
+          { sequence: sequence, data: dataCache.data }
+        );
+        if (logicalPacket) {
+          resendedSequences.add(sequence);
+          resends.push(logicalPacket);
+        }
+      } else {
+        // If the data cache is not found it means that the packet has been acked
       }
     }
 

--- a/src/servers/ZoneServer2016/classes/zoneclient.ts
+++ b/src/servers/ZoneServer2016/classes/zoneclient.ts
@@ -75,7 +75,7 @@ export class ZoneClient2016 {
     ConstructionParentEntity | ConstructionChildEntity
   > = new Set();
   sentInteractionCounter: number = 1;
-  searchedProps: (LootableProp | Lootbag)[] = [];
+  searchedProps: Set<LootableProp | Lootbag> = new Set();
   managedObjects: string[] = [];
   vehicle: {
     mountedVehicle?: string;
@@ -104,6 +104,11 @@ export class ZoneClient2016 {
   startLoc: number = 0;
   fairPlayFoundationCheckResult: boolean = false;
   fairPlayFoundationCheckTime: number = 0;
+  /** Cached gateway (SOE-layer) ping, refreshed out-of-band so combat-log
+   *  generation doesn't await a cross-thread IPC round trip on every hit. */
+  cachedGatewayPing: number = 0;
+  gatewayPingCacheTime: number = 0;
+  gatewayPingRefreshing: boolean = false;
   subscribedCells: Set<import("./gridcell").GridCell> = new Set();
   posAtLastCellUpdate: Float32Array = new Float32Array([0, 0, 0, 1]);
   lastKnownChunkRenderDistance: number = 400;

--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -59,6 +59,37 @@ const loadoutSlots = PluginManager.loadServerData(
     "2016/dataSources/EquipSlotItemClasses.json"
   );
 
+// Precomputed lookups over the static data sources above (loaded once at
+// startup and never mutated afterwards) so the equip/loot hot paths below
+// don't linear-scan these lists on every call.
+const loadoutSlotsByLoadoutId = new Map<number, number[]>();
+loadoutSlots.forEach((slot: any) => {
+  let arr = loadoutSlotsByLoadoutId.get(slot.LOADOUT_ID);
+  if (!arr) {
+    arr = [];
+    loadoutSlotsByLoadoutId.set(slot.LOADOUT_ID, arr);
+  }
+  arr.push(slot.SLOT_ID);
+});
+
+const loadoutSlotItemClassByKey = new Map<string, any>();
+loadoutSlotItemClasses.forEach((slot: any) => {
+  const key = `${slot.ITEM_CLASS}:${slot.LOADOUT_ID}`;
+  if (!loadoutSlotItemClassByKey.has(key)) {
+    loadoutSlotItemClassByKey.set(key, slot);
+  }
+});
+
+const equipSlotItemClassesByItemClass = new Map<number, any[]>();
+equipSlotItemClasses.forEach((slot: any) => {
+  let arr = equipSlotItemClassesByItemClass.get(slot.ITEM_CLASS);
+  if (!arr) {
+    arr = [];
+    equipSlotItemClassesByItemClass.set(slot.ITEM_CLASS, arr);
+  }
+  arr.push(slot);
+});
+
 function getGender(actorModelId: number): number {
   switch (actorModelId) {
     case ModelIds.ZOMBIE_MALE_WALKER:
@@ -1053,11 +1084,7 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
   }
 
   getLoadoutSlots() {
-    const slots: Array<number> = [];
-    loadoutSlots.forEach((slot: any) => {
-      if (slot.LOADOUT_ID == this.loadoutId) slots.push(slot.SLOT_ID);
-    });
-    return slots;
+    return loadoutSlotsByLoadoutId.get(this.loadoutId) ?? [];
   }
 
   /**
@@ -1069,11 +1096,11 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
   getAvailableLoadoutSlot(server: ZoneServer2016, itemDefId: number): number {
     // gets an open loadoutslot for a specified itemDefinitionId
     const itemDef = server.getItemDefinition(itemDefId),
-      loadoutSlotItemClass = loadoutSlotItemClasses.find(
-        (slot: any) =>
-          slot.ITEM_CLASS == itemDef?.ITEM_CLASS &&
-          this.loadoutId == slot.LOADOUT_ID
-      );
+      loadoutSlotItemClass = itemDef
+        ? loadoutSlotItemClassByKey.get(
+            `${itemDef.ITEM_CLASS}:${this.loadoutId}`
+          )
+        : undefined;
     let slot = loadoutSlotItemClass?.SLOT;
     if (!slot) return 0;
     switch (itemDef?.ITEM_CLASS) {
@@ -1132,11 +1159,10 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
     const itemDef = server.getItemDefinition(itemDefId),
       itemClass = itemDef?.ITEM_CLASS;
     if (!itemDef || !itemClass || !server.isWeapon(itemDefId)) return 0;
-    for (const slot of equipSlotItemClasses) {
-      if (
-        slot.ITEM_CLASS == itemDef.ITEM_CLASS &&
-        !this._equipment[slot.EQUIP_SLOT_ID]
-      ) {
+    const candidates = equipSlotItemClassesByItemClass.get(itemDef.ITEM_CLASS);
+    if (!candidates) return 0;
+    for (const slot of candidates) {
+      if (!this._equipment[slot.EQUIP_SLOT_ID]) {
         return slot.EQUIP_SLOT_ID;
       }
     }

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -48,7 +48,6 @@ import {
   isPosInRadius,
   randomIntFromInterval,
   _,
-  checkConstructionInRange,
   getCurrentServerTimeWrapper,
   getDistance
 } from "../../../utils/utils";
@@ -653,14 +652,16 @@ export class Character2016 extends BaseFullCharacter {
     if (
       client.character.isSitting &&
       server.isSurvival() &&
-      (checkConstructionInRange(
-        server._lootableConstruction,
+      (server.constructionManager.isConstructionInRange(
+        server,
+        "lootable",
         client.character.state.position,
         4,
         Items.CAMPFIRE
       ) ||
-        checkConstructionInRange(
-          server._worldLootableConstruction,
+        server.constructionManager.isConstructionInRange(
+          server,
+          "worldLootable",
           client.character.state.position,
           4,
           Items.CAMPFIRE
@@ -1575,7 +1576,7 @@ export class Character2016 extends BaseFullCharacter {
     });
     server.sendChatText(client, `Received ${damage} damage`);
 
-    const damageRecord = await server.generateDamageRecord(
+    const damageRecord = server.generateDamageRecord(
       this.characterId,
       damageInfo,
       oldHealth

--- a/src/servers/ZoneServer2016/entities/constructiondoor.ts
+++ b/src/servers/ZoneServer2016/entities/constructiondoor.ts
@@ -335,13 +335,18 @@ export class ConstructionDoor extends DoorEntity {
             this.isOpen &&
             allowedConstruction.includes(parent.itemDefinitionId)
           ) {
-            for (const a in server._clients) {
-              const client = server._clients[a];
-              if (client.character.isHidden == parent.characterId)
-                server.constructionManager.constructionPermissionsManager(
-                  server,
-                  client
-                );
+            // a hidden character stays subscribed to (spawned into) the
+            // shelter it's hiding in, so observers of the parent are the
+            // only clients that can possibly match isHidden below
+            const observers = server._entityObservers.get(parent.characterId);
+            if (observers) {
+              for (const client of observers) {
+                if (client.character.isHidden == parent.characterId)
+                  server.constructionManager.constructionPermissionsManager(
+                    server,
+                    client
+                  );
+              }
             }
           }
         }

--- a/src/servers/ZoneServer2016/entities/crate.ts
+++ b/src/servers/ZoneServer2016/entities/crate.ts
@@ -176,9 +176,11 @@ export class Crate extends BaseSimpleNpc {
       }
     );
 
-    for (const a in server._clients) {
-      const client = server._clients[a];
-      client.spawnedEntities.delete(server._crates[this.characterId]);
+    const observers = server._entityObservers.get(this.characterId);
+    if (observers) {
+      for (const client of Array.from(observers)) {
+        client.spawnedEntities.delete(server._crates[this.characterId]);
+      }
     }
     return true;
     // crates cannot get deleted from dictionarries, need separate function to despawn

--- a/src/servers/ZoneServer2016/entities/destroyable.ts
+++ b/src/servers/ZoneServer2016/entities/destroyable.ts
@@ -13,7 +13,7 @@
 import { ZoneServer2016 } from "../zoneserver";
 import { ZoneClient2016 } from "../classes/zoneclient";
 import { DamageInfo } from "../../../types/zoneserver";
-import { eul2quat, getDistance } from "../../../utils/utils";
+import { eul2quat, getDistanceSquared } from "../../../utils/utils";
 import { Effects, ModelIds } from "../models/enums";
 import { AddLightweightNpc, AddSimpleNpc } from "types/zone2016packets";
 import { BaseSimpleNpc } from "./basesimplenpc";
@@ -293,17 +293,23 @@ export class Destroyable extends BaseSimpleNpc {
       health: (this.health / this.maxHealth) * 100
     };
   }
+  /** Destroyables (trees/rocks/etc.) never move after spawn, so the rotation
+   *  quaternion — the only non-trivial computation in pGetLightweight — is
+   *  computed once and reused instead of recomputed on every spawn-in-range send. */
+  private _cachedLightweightRotation?: Float32Array;
+
   pGetLightweight(): AddLightweightNpc {
+    if (!this._cachedLightweightRotation) {
+      this._cachedLightweightRotation = eul2quat(
+        new Float32Array([this.state.rotation[1], 0, 0])
+      );
+    }
     return {
       characterId: this.characterId,
       transientId: this.transientId,
       actorModelId: this.destroyed ? this.destroyedModel : this.actorModelId,
-      position: new Float32Array(
-        Array.from(this.state.position).map((pos, idx) => {
-          return idx == 1 ? pos++ : pos;
-        })
-      ),
-      rotation: eul2quat(new Float32Array([this.state.rotation[1], 0, 0])),
+      position: this.state.position,
+      rotation: this._cachedLightweightRotation,
       scale: this.scale,
       isLightweight: true,
       flags: {
@@ -316,11 +322,11 @@ export class Destroyable extends BaseSimpleNpc {
   }
 
   OnExplosiveHit(server: ZoneServer2016, sourceEntity: BaseEntity): void {
-    const distance = getDistance(
-      sourceEntity.state.position,
-      this.state.position
-    );
-    if (distance > 5) return;
+    if (
+      getDistanceSquared(sourceEntity.state.position, this.state.position) >
+      25
+    )
+      return;
 
     this.damage(server, {
       entity: sourceEntity.characterId,

--- a/src/servers/ZoneServer2016/entities/destroyable.ts
+++ b/src/servers/ZoneServer2016/entities/destroyable.ts
@@ -323,8 +323,7 @@ export class Destroyable extends BaseSimpleNpc {
 
   OnExplosiveHit(server: ZoneServer2016, sourceEntity: BaseEntity): void {
     if (
-      getDistanceSquared(sourceEntity.state.position, this.state.position) >
-      25
+      getDistanceSquared(sourceEntity.state.position, this.state.position) > 25
     )
       return;
 

--- a/src/servers/ZoneServer2016/entities/gasser.ts
+++ b/src/servers/ZoneServer2016/entities/gasser.ts
@@ -15,7 +15,7 @@ import { ZoneServer2016 } from "../zoneserver";
 import { Effects, ModelIds, NpcIds, StringIds } from "../models/enums";
 import { ZombieWalker } from "./zombiewalker";
 import { createGasser, spawnGasCloudAt } from "../jsms/gasser.jsm";
-import { getDistance } from "../../../utils/utils";
+import { getDistanceSquared } from "../../../utils/utils";
 import { DamageInfo } from "types/zoneserver";
 
 export class Gasser extends ZombieWalker {
@@ -70,8 +70,8 @@ export class Gasser extends ZombieWalker {
       for (const character of Object.values(server._characters)) {
         if (!character.isAlive) continue;
         if (
-          getDistance(character.state.position, this.state.position) >
-          GASSER_DEATH_EXPLOSION_RANGE
+          getDistanceSquared(character.state.position, this.state.position) >
+          GASSER_DEATH_EXPLOSION_RANGE * GASSER_DEATH_EXPLOSION_RANGE
         )
           continue;
 

--- a/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
+++ b/src/servers/ZoneServer2016/entities/lootableconstructionentity.ts
@@ -227,9 +227,9 @@ export class LootableConstructionEntity extends BaseLootableEntity {
     const container = this.getContainer();
     if (container) {
       container.items = {};
-      for (const a in server._characters) {
-        const character = server._characters[a];
-        if (character.mountedContainer == this) {
+      if (this.mountedCharacter) {
+        const character = server._characters[this.mountedCharacter];
+        if (character?.mountedContainer == this) {
           character.dismountContainer(server);
         }
       }
@@ -266,8 +266,10 @@ export class LootableConstructionEntity extends BaseLootableEntity {
       return;
     }
     if (server.fairPlayManager.useFairPlay) {
-      for (const a in server._constructionFoundations) {
-        const foundation = server._constructionFoundations[a];
+      for (const foundation of server.constructionManager.getFoundationsNear(
+        server,
+        this.state.position
+      )) {
         if (
           foundation.itemDefinitionId != Items.FOUNDATION &&
           foundation.itemDefinitionId != Items.FOUNDATION_EXPANSION

--- a/src/servers/ZoneServer2016/entities/lootableprop.ts
+++ b/src/servers/ZoneServer2016/entities/lootableprop.ts
@@ -312,7 +312,7 @@ export class LootableProp extends BaseLootableEntity {
       );
       return;
     }
-    if (!client.searchedProps.includes(this)) {
+    if (!client.searchedProps.has(this)) {
       server.utilizeHudTimer(
         client,
         server.getItemDefinition(this.getContainer()?.itemDefinitionId)
@@ -321,7 +321,7 @@ export class LootableProp extends BaseLootableEntity {
         0,
         () => {
           super.OnPlayerSelect(server, client);
-          client.searchedProps.push(this);
+          client.searchedProps.add(this);
         }
       );
     } else {
@@ -350,7 +350,7 @@ export class LootableProp extends BaseLootableEntity {
       }
       return;
     }
-    if (client.searchedProps.includes(this)) {
+    if (client.searchedProps.has(this)) {
       server.sendData(client, "Command.InteractionString", {
         guid: this.characterId,
         stringId: StringIds.OPEN

--- a/src/servers/ZoneServer2016/entities/lootbag.ts
+++ b/src/servers/ZoneServer2016/entities/lootbag.ts
@@ -47,7 +47,7 @@ export class Lootbag extends BaseLootableEntity {
   }
 
   OnInteractionString(server: ZoneServer2016, client: ZoneClient2016) {
-    if (client.searchedProps.includes(this)) {
+    if (client.searchedProps.has(this)) {
       server.sendData(client, "Command.InteractionString", {
         guid: this.characterId,
         stringId: StringIds.OPEN
@@ -66,7 +66,7 @@ export class Lootbag extends BaseLootableEntity {
     isInstant?: boolean
     /* eslint-enable @typescript-eslint/no-unused-vars */
   ) {
-    if (!client.searchedProps.includes(this)) {
+    if (!client.searchedProps.has(this)) {
       server.utilizeHudTimer(
         client,
         server.getItemDefinition(this._containers["31"].itemDefinitionId)
@@ -75,7 +75,7 @@ export class Lootbag extends BaseLootableEntity {
         0,
         () => {
           super.OnPlayerSelect(server, client);
-          client.searchedProps.push(this);
+          client.searchedProps.add(this);
         }
       );
     } else {

--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -18,6 +18,7 @@ import { ZoneClient2016 } from "../classes/zoneclient";
 import {
   getCurrentServerTimeWrapper,
   getDistance,
+  getDistanceSquared,
   logClientActionToMongo,
   metersToFeet
 } from "../../../utils/utils";
@@ -260,9 +261,9 @@ export abstract class Npc extends BaseFullCharacter {
           client.character.metrics.zombiesKilled++;
         else client.character.metrics.wildlifeKilled++;
       }
-      for (const a in server._clients) {
-        const c = server._clients[a];
-        if (c.spawnedEntities.has(this)) {
+      const observers = server._entityObservers.get(this.characterId);
+      if (observers) {
+        for (const c of observers) {
           if (!c.isLoading) {
             server.sendData(c, "Character.StartMultiStateDeath", {
               data: {
@@ -288,7 +289,7 @@ export abstract class Npc extends BaseFullCharacter {
     }
 
     if (client) {
-      const damageRecord = await server.generateDamageRecord(
+      const damageRecord = server.generateDamageRecord(
         this.characterId,
         damageInfo,
         oldHealth
@@ -308,8 +309,8 @@ export abstract class Npc extends BaseFullCharacter {
       for (const character of Object.values(server._characters)) {
         if (!character.isAlive) continue;
         if (
-          getDistance(character.state.position, this.state.position) >
-          GASSER_DEATH_EXPLOSION_RANGE
+          getDistanceSquared(character.state.position, this.state.position) >
+          GASSER_DEATH_EXPLOSION_RANGE * GASSER_DEATH_EXPLOSION_RANGE
         )
           continue;
 

--- a/src/servers/ZoneServer2016/entities/plant.ts
+++ b/src/servers/ZoneServer2016/entities/plant.ts
@@ -140,8 +140,10 @@ export class Plant extends ItemObject {
     /* eslint-enable @typescript-eslint/no-unused-vars */
   ) {
     if (this.growState != 3) return;
-    for (const a in server._constructionFoundations) {
-      const foundation = server._constructionFoundations[a];
+    for (const foundation of server.constructionManager.getFoundationsNear(
+      server,
+      this.state.position
+    )) {
       if (!foundation.isInside(this.state.position)) continue;
       if (
         foundation.isSecured &&

--- a/src/servers/ZoneServer2016/entities/projectileentity.ts
+++ b/src/servers/ZoneServer2016/entities/projectileentity.ts
@@ -237,10 +237,7 @@ export class ProjectileEntity extends BaseLightweightCharacter {
     if (this.itemDefinitionId == Items.GRENADE_GAS) {
       if (server.isPvE) return;
       this.gasDamageInterval = setInterval(() => {
-        for (const client of server.getClientsInRange(
-          this.state.position,
-          7
-        )) {
+        for (const client of server.getClientsInRange(this.state.position, 7)) {
           const character = client.character;
           if (server.checkRespirator(character)) continue;
           if (getDistance(character.state.position, this.state.position) <= 7) {

--- a/src/servers/ZoneServer2016/entities/projectileentity.ts
+++ b/src/servers/ZoneServer2016/entities/projectileentity.ts
@@ -237,8 +237,11 @@ export class ProjectileEntity extends BaseLightweightCharacter {
     if (this.itemDefinitionId == Items.GRENADE_GAS) {
       if (server.isPvE) return;
       this.gasDamageInterval = setInterval(() => {
-        for (const a in server._characters) {
-          const character = server._characters[a];
+        for (const client of server.getClientsInRange(
+          this.state.position,
+          7
+        )) {
+          const character = client.character;
           if (server.checkRespirator(character)) continue;
           if (getDistance(character.state.position, this.state.position) <= 7) {
             const damageInfo: DamageInfo = {

--- a/src/servers/ZoneServer2016/entities/trapentity.ts
+++ b/src/servers/ZoneServer2016/entities/trapentity.ts
@@ -299,9 +299,7 @@ export class TrapEntity extends BaseSimpleNpc {
           this.state.position,
           2
         )) {
-          if (
-            getDistance(vehicle.state.position, this.state.position) < 2
-          ) {
+          if (getDistance(vehicle.state.position, this.state.position) < 2) {
             vehicle.getPassengerList().map((passenger) => {
               this.detonateTrap(server, { entity: passenger, damage: 0 });
               this.isTriggered = true;

--- a/src/servers/ZoneServer2016/entities/trapentity.ts
+++ b/src/servers/ZoneServer2016/entities/trapentity.ts
@@ -177,8 +177,7 @@ export class TrapEntity extends BaseSimpleNpc {
         if (!server._traps[this.characterId]) {
           return;
         }
-        for (const a in server._clients) {
-          const client = server._clients[a];
+        for (const client of server.getClientsInRange(this.state.position, 1)) {
           if (
             getDistance(client.character.state.position, this.state.position) <
             1
@@ -228,8 +227,8 @@ export class TrapEntity extends BaseSimpleNpc {
         if (!server._traps[this.characterId]) {
           return;
         }
-        for (const a in server._clients) {
-          const client = server._clients[a];
+        // cubebounds half-extents are 7.05 x 2.15, so radius 8 safely covers isInside()
+        for (const client of server.getClientsInRange(this.state.position, 8)) {
           if (
             this.isInside(client.character.state.position) &&
             client.character.isAlive &&
@@ -247,7 +246,7 @@ export class TrapEntity extends BaseSimpleNpc {
               {
                 characterId: "0x0",
                 effectId: Effects.PFX_Impact_PunjiSticks_Blood,
-                position: server._clients[a].character.state.position
+                position: client.character.state.position
               }
             );
 
@@ -284,8 +283,7 @@ export class TrapEntity extends BaseSimpleNpc {
         if (!server._traps[this.characterId]) {
           return;
         }
-        for (const a in server._clients) {
-          const client = server._clients[a];
+        for (const client of server.getClientsInRange(this.state.position, 1)) {
           if (
             getDistance(client.character.state.position, this.state.position) <
             1
@@ -297,14 +295,14 @@ export class TrapEntity extends BaseSimpleNpc {
             this.isTriggered = true;
           }
         }
-        for (const a in server._vehicles) {
+        for (const vehicle of server.getVehiclesInRange(
+          this.state.position,
+          2
+        )) {
           if (
-            getDistance(
-              server._vehicles[a].state.position,
-              this.state.position
-            ) < 2
+            getDistance(vehicle.state.position, this.state.position) < 2
           ) {
-            server._vehicles[a].getPassengerList().map((passenger) => {
+            vehicle.getPassengerList().map((passenger) => {
               this.detonateTrap(server, { entity: passenger, damage: 0 });
               this.isTriggered = true;
             });

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -588,15 +588,9 @@ export class Vehicle2016 extends BaseLootableEntity {
       : damageInfo.damage;
     const client = server.getClientByCharId(damageInfo.entity);
     if (client) {
-      queueMicrotask(async () => {
-        client.character.addCombatlogEntry(
-          await server.generateDamageRecord(
-            this.characterId,
-            damageInfo,
-            oldHealth
-          )
-        );
-      });
+      client.character.addCombatlogEntry(
+        server.generateDamageRecord(this.characterId, damageInfo, oldHealth)
+      );
     }
 
     if (this._resources[ResourceIds.CONDITION] <= 0) {
@@ -1342,10 +1336,9 @@ export class Vehicle2016 extends BaseLootableEntity {
     this.isDestroyed = true;
     if (!server._vehicles[this.characterId]) return false;
     this._resources[ResourceIds.CONDITION] = 0;
-    for (const c in server._clients) {
-      if (this.characterId === server._clients[c].vehicle.mountedVehicle) {
-        server.dismountVehicle(server._clients[c]);
-      }
+    for (const passengerId of this.getPassengerList()) {
+      const client = server.getClientByCharId(passengerId);
+      if (client) server.dismountVehicle(client);
     }
     server.sendDataToAllWithSpawnedEntity(
       server._vehicles,

--- a/src/servers/ZoneServer2016/jsms/exploder.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/exploder.jsm.ts
@@ -103,16 +103,14 @@ function trySeePlayer(exploder: ZombieInstance): boolean {
 
 function trySmellCorpse(exploder: ZombieInstance): boolean {
   if (exploder.hunger < 60) return false;
-  for (const characterId in exploder.server._characters) {
-    const character = exploder.server._characters[characterId];
-    if (character.isAlive) continue;
-    if (
-      getDistance2d(exploder.npc.state.position, character.state.position) < 30
-    ) {
-      exploder.corpseTargetId = characterId;
-      exploder.event(ZombieEvents.SmellCorpse);
-      return true;
-    }
+  for (const client of exploder.server.getClientsInRange(
+    exploder.npc.state.position,
+    30
+  )) {
+    if (client.character.isAlive) continue;
+    exploder.corpseTargetId = client.character.characterId;
+    exploder.event(ZombieEvents.SmellCorpse);
+    return true;
   }
   return false;
 }

--- a/src/servers/ZoneServer2016/jsms/gasser.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/gasser.jsm.ts
@@ -110,22 +110,32 @@ function shouldOverrideAction(sound: Sound | null): boolean {
 
 function chargeGas(gasser: ZombieInstance): void {
   const origin = gasser.npc.state.position;
+  const sz = 50;
+  const cx = Math.floor(origin[0] / sz);
+  const cz = Math.floor(origin[2] / sz);
   let nearbyClients = 0;
   let nearbyZombies = 0;
 
-  for (const client of Object.values(gasser.server._clients)) {
-    const character = client.character;
-    if (!character?.isAlive) continue;
-    if (getDistance2d(origin, character.state.position) <= GAS_CHARGE_RANGE) {
-      nearbyClients++;
-    }
-  }
-
-  for (const npc of Object.values(gasser.server._npcs)) {
-    if (!npc.isAlive || npc.characterId === gasser.npc.characterId) continue;
-    if (npc.faction !== Factions.ZOMBIE) continue;
-    if (getDistance2d(origin, npc.state.position) <= GAS_CHARGE_RANGE) {
-      nearbyZombies++;
+  // aiTargetSpatialMap already carries both alive characters (HUMAN) and alive
+  // npcs with their faction, rebuilt every AI tick — reuse it instead of
+  // scanning every client + every npc on the server for each gasser.
+  for (let dx = -1; dx <= 1; dx++) {
+    for (let dz = -1; dz <= 1; dz++) {
+      const bucket = gasser.server.aiTargetSpatialMap.get(
+        `${cx + dx},${cz + dz}`
+      );
+      if (!bucket) continue;
+      for (const entry of bucket) {
+        if (getDistance2d(origin, entry.position) > GAS_CHARGE_RANGE) continue;
+        if (entry.faction === Factions.HUMAN) {
+          nearbyClients++;
+        } else if (
+          entry.faction === Factions.ZOMBIE &&
+          entry.id !== gasser.npc.characterId
+        ) {
+          nearbyZombies++;
+        }
+      }
     }
   }
 
@@ -162,16 +172,14 @@ function trySeePlayer(gasser: ZombieInstance): boolean {
 
 function trySmellCorpse(gasser: ZombieInstance): boolean {
   if (gasser.hunger < 60) return false;
-  for (const characterId in gasser.server._characters) {
-    const character = gasser.server._characters[characterId];
-    if (character.isAlive) continue;
-    if (
-      getDistance2d(gasser.npc.state.position, character.state.position) < 30
-    ) {
-      gasser.corpseTargetId = characterId;
-      gasser.event(ZombieEvents.SmellCorpse);
-      return true;
-    }
+  for (const client of gasser.server.getClientsInRange(
+    gasser.npc.state.position,
+    30
+  )) {
+    if (client.character.isAlive) continue;
+    gasser.corpseTargetId = client.character.characterId;
+    gasser.event(ZombieEvents.SmellCorpse);
+    return true;
   }
   return false;
 }
@@ -246,7 +254,8 @@ export function spawnGasCloudAt(
   }
 
   const applyGasDamage = () => {
-    for (const character of Object.values(server._characters)) {
+    for (const client of server.getClientsInRange(position, GAS_CLOUD_RANGE)) {
+      const character = client.character;
       if (!character.isAlive) continue;
       if (server.checkRespirator(character)) continue;
       if (getDistance(character.state.position, position) > GAS_CLOUD_RANGE)

--- a/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
@@ -227,25 +227,30 @@ function pushScreamSound(screamer: ScreamerInstance): void {
 }
 
 function screamAtNearbyPlayers(screamer: ScreamerInstance): void {
-  for (const k in screamer.server._clients) {
-    const client = screamer.server._clients[k];
-    if (
-      !client.character.isAlive ||
-      client.character.isVanished ||
-      client.character.isHidden
-    )
-      continue;
-    if (
-      getDistance2d(
-        screamer.npc.state.position,
-        client.character.state.position
-      ) <= SCREAM_RADIUS
-    ) {
-      screamer.server.addScreenEffect(
-        client,
-        screamer.server._screenEffects["SCREAM"]
+  const sz = 50;
+  const pos = screamer.npc.state.position;
+  const cx = Math.floor(pos[0] / sz);
+  const cz = Math.floor(pos[2] / sz);
+  for (let dx = -1; dx <= 1; dx++) {
+    for (let dz = -1; dz <= 1; dz++) {
+      const bucket = screamer.server.aiTargetSpatialMap.get(
+        `${cx + dx},${cz + dz}`
       );
-      screamer.server.applyMovementModifier(client, MovementModifiers.SCREAM);
+      if (!bucket) continue;
+      for (const entry of bucket) {
+        if (entry.faction !== Factions.HUMAN) continue;
+        if (getDistance2d(pos, entry.position) > SCREAM_RADIUS) continue;
+        const client = screamer.server.getClientByCharId(entry.id);
+        if (!client) continue;
+        screamer.server.addScreenEffect(
+          client,
+          screamer.server._screenEffects["SCREAM"]
+        );
+        screamer.server.applyMovementModifier(
+          client,
+          MovementModifiers.SCREAM
+        );
+      }
     }
   }
 }

--- a/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
@@ -246,10 +246,7 @@ function screamAtNearbyPlayers(screamer: ScreamerInstance): void {
           client,
           screamer.server._screenEffects["SCREAM"]
         );
-        screamer.server.applyMovementModifier(
-          client,
-          MovementModifiers.SCREAM
-        );
+        screamer.server.applyMovementModifier(client, MovementModifiers.SCREAM);
       }
     }
   }

--- a/src/servers/ZoneServer2016/jsms/zombie.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/zombie.jsm.ts
@@ -209,16 +209,14 @@ function trySeePlayer(zombie: ZombieInstance): boolean {
 
 function trySmellCorpse(zombie: ZombieInstance): boolean {
   if (zombie.hunger < 60) return false;
-  for (const characterId in zombie.server._characters) {
-    const character = zombie.server._characters[characterId];
-    if (character.isAlive) continue;
-    if (
-      getDistance2d(zombie.npc.state.position, character.state.position) < 30
-    ) {
-      zombie.corpseTargetId = characterId;
-      zombie.event(ZombieEvents.SmellCorpse);
-      return true;
-    }
+  for (const client of zombie.server.getClientsInRange(
+    zombie.npc.state.position,
+    30
+  )) {
+    if (client.character.isAlive) continue;
+    zombie.corpseTargetId = client.character.characterId;
+    zombie.event(ZombieEvents.SmellCorpse);
+    return true;
   }
   return false;
 }

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -137,6 +137,140 @@ export class ConstructionManager {
     server.sendAlert(client, `Construction Error: ${error}`);
   }
 
+  /** Spatial hash of construction dictionaries used by detectStackedPlacement,
+   *  rebuilt lazily and cached briefly so repeated placements in a short window
+   *  don't each re-scan every construction entity on the server. */
+  private _stackedPlacementHash?: {
+    worldSimple: Map<string, ConstructionChildEntity[]>;
+    simple: Map<string, ConstructionChildEntity[]>;
+    lootable: Map<string, LootableConstructionEntity[]>;
+    worldLootable: Map<string, LootableConstructionEntity[]>;
+    foundations: Map<string, ConstructionParentEntity[]>;
+    builtAt: number;
+  };
+  private static readonly STACKED_PLACEMENT_CACHE_TTL = 1000;
+  private static readonly STACKED_PLACEMENT_CELL_SIZE = 4;
+
+  private static _bucketByCell<T extends { state: { position: Float32Array } }>(
+    dict: Record<string, T>
+  ): Map<string, T[]> {
+    const cellSize = ConstructionManager.STACKED_PLACEMENT_CELL_SIZE;
+    const map = new Map<string, T[]>();
+    for (const key in dict) {
+      const entity = dict[key];
+      const pos = entity.state.position;
+      const cellKey = `${Math.floor(pos[0] / cellSize)},${Math.floor(pos[2] / cellSize)}`;
+      let bucket = map.get(cellKey);
+      if (!bucket) {
+        bucket = [];
+        map.set(cellKey, bucket);
+      }
+      bucket.push(entity);
+    }
+    return map;
+  }
+
+  private getStackedPlacementHash(server: ZoneServer2016) {
+    const now = Date.now();
+    if (
+      this._stackedPlacementHash &&
+      now - this._stackedPlacementHash.builtAt <
+        ConstructionManager.STACKED_PLACEMENT_CACHE_TTL
+    ) {
+      return this._stackedPlacementHash;
+    }
+    this._stackedPlacementHash = {
+      worldSimple: ConstructionManager._bucketByCell(
+        server._worldSimpleConstruction
+      ),
+      simple: ConstructionManager._bucketByCell(server._constructionSimple),
+      lootable: ConstructionManager._bucketByCell(server._lootableConstruction),
+      worldLootable: ConstructionManager._bucketByCell(
+        server._worldLootableConstruction
+      ),
+      foundations: ConstructionManager._bucketByCell(
+        server._constructionFoundations
+      ),
+      builtAt: now
+    };
+    return this._stackedPlacementHash;
+  }
+
+  /** Foundations near `position` (within a margin covering the largest
+   *  foundation cubebounds), for glitch/permission checks that need to test
+   *  `isInside()` against every foundation that could geometrically contain
+   *  a point — not just the entity's own logical parent — without scanning
+   *  every foundation on the server. */
+  getFoundationsNear(
+    server: ZoneServer2016,
+    position: Float32Array
+  ): Generator<ConstructionParentEntity> {
+    const hash = this.getStackedPlacementHash(server);
+    // largest foundation cubebounds half-extent is ~5x4.7 (radius ~6.9) — 12 gives margin
+    return ConstructionManager._entitiesNear(hash.foundations, position, 12);
+  }
+
+  /** Yields entities from the surrounding cells of a bucketed spatial hash within `radius`. */
+  private static *_entitiesNear<T>(
+    map: Map<string, T[]>,
+    position: Float32Array,
+    radius: number
+  ): Generator<T> {
+    const cellSize = ConstructionManager.STACKED_PLACEMENT_CELL_SIZE;
+    const cx = Math.floor(position[0] / cellSize);
+    const cz = Math.floor(position[2] / cellSize);
+    const cellRadius = Math.ceil(radius / cellSize) + 1;
+    for (let dx = -cellRadius; dx <= cellRadius; dx++) {
+      for (let dz = -cellRadius; dz <= cellRadius; dz++) {
+        const bucket = map.get(`${cx + dx},${cz + dz}`);
+        if (!bucket) continue;
+        for (const entity of bucket) yield entity;
+      }
+    }
+  }
+
+  /** Spatial-hash-backed replacement for utils.checkConstructionInRange when the
+   *  dictionary being queried is one of the four construction dictionaries — reuses
+   *  the same cached hash as detectStackedPlacement instead of scanning the full dictionary. */
+  isConstructionInRange(
+    server: ZoneServer2016,
+    kind: "worldSimple" | "simple" | "lootable" | "worldLootable",
+    position: Float32Array,
+    range: number,
+    itemDefinitionId: number
+  ): boolean {
+    const hash = this.getStackedPlacementHash(server);
+    const check = <
+      T extends { state: { position: Float32Array }; itemDefinitionId: number }
+    >(
+      map: Map<string, T[]>
+    ): boolean => {
+      for (const c of ConstructionManager._entitiesNear(
+        map,
+        position,
+        range
+      )) {
+        if (
+          c.itemDefinitionId == itemDefinitionId &&
+          isPosInRadius(range, position, c.state.position)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    };
+    switch (kind) {
+      case "worldSimple":
+        return check(hash.worldSimple);
+      case "simple":
+        return check(hash.simple);
+      case "lootable":
+        return check(hash.lootable);
+      case "worldLootable":
+        return check(hash.worldLootable);
+    }
+  }
+
   detectStackedPlacement(
     server: ZoneServer2016,
     parentObjectCharacterId: string,
@@ -150,8 +284,12 @@ export class ConstructionManager {
       !Number(parentObjectCharacterId) &&
       !this.overridePlacementItems.includes(itemDefinitionId)
     ) {
-      for (const a in server._worldSimpleConstruction) {
-        const c = server._worldSimpleConstruction[a];
+      const hash = this.getStackedPlacementHash(server);
+      for (const c of ConstructionManager._entitiesNear(
+        hash.worldSimple,
+        position,
+        1.5
+      )) {
         const diff = Math.abs(c.state.position[1] - position[1]);
         if (
           isPosInRadiusWithY(1, c.state.position, position, 1.5) &&
@@ -160,8 +298,11 @@ export class ConstructionManager {
           return true;
         }
       }
-      for (const a in server._constructionSimple) {
-        const c = server._constructionSimple[a];
+      for (const c of ConstructionManager._entitiesNear(
+        hash.simple,
+        position,
+        1.5
+      )) {
         const diff = Math.abs(c.state.position[1] - position[1]);
         if (
           isPosInRadiusWithY(1, c.state.position, position, 1.5) &&
@@ -171,8 +312,11 @@ export class ConstructionManager {
         }
       }
 
-      for (const a in server._lootableConstruction) {
-        const c = server._lootableConstruction[a];
+      for (const c of ConstructionManager._entitiesNear(
+        hash.lootable,
+        position,
+        1.5
+      )) {
         const diff = Math.abs(c.state.position[1] - position[1]);
         if (
           isPosInRadiusWithY(1, c.state.position, position, 1.5) &&
@@ -193,8 +337,11 @@ export class ConstructionManager {
           }
         }
       }
-      for (const a in server._worldLootableConstruction) {
-        const c = server._worldLootableConstruction[a];
+      for (const c of ConstructionManager._entitiesNear(
+        hash.worldLootable,
+        position,
+        1.5
+      )) {
         const diff = Math.abs(c.state.position[1] - position[1]);
         if (
           isPosInRadiusWithY(1, c.state.position, position, 1.5) &&

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -245,11 +245,7 @@ export class ConstructionManager {
     >(
       map: Map<string, T[]>
     ): boolean => {
-      for (const c of ConstructionManager._entitiesNear(
-        map,
-        position,
-        range
-      )) {
+      for (const c of ConstructionManager._entitiesNear(map, position, range)) {
         if (
           c.itemDefinitionId == itemDefinitionId &&
           isPosInRadius(range, position, c.state.position)

--- a/src/servers/ZoneServer2016/managers/craftmanager.ts
+++ b/src/servers/ZoneServer2016/managers/craftmanager.ts
@@ -14,7 +14,6 @@
 import { ContainerErrors, FilterIds, Items } from "../models/enums";
 import { ZoneServer2016 } from "../zoneserver";
 import { ZoneClient2016 as Client } from "../classes/zoneclient";
-import { checkConstructionInRange } from "../../../utils/utils";
 import { Recipe } from "types/zoneserver";
 import { Character2016 } from "../entities/character";
 import { BaseItem } from "../classes/baseItem";
@@ -484,14 +483,16 @@ export class CraftManager {
     }
     if (recipe.requireWorkbench) {
       if (
-        !checkConstructionInRange(
-          server._constructionSimple,
+        !server.constructionManager.isConstructionInRange(
+          server,
+          "simple",
           client.character.state.position,
           3,
           Items.WORKBENCH
         ) &&
-        !checkConstructionInRange(
-          server._worldSimpleConstruction,
+        !server.constructionManager.isConstructionInRange(
+          server,
+          "worldSimple",
           client.character.state.position,
           3,
           Items.WORKBENCH
@@ -506,14 +507,16 @@ export class CraftManager {
     }
     if (recipe.requireWeaponWorkbench) {
       if (
-        !checkConstructionInRange(
-          server._constructionSimple,
+        !server.constructionManager.isConstructionInRange(
+          server,
+          "simple",
           client.character.state.position,
           3,
           Items.WORKBENCH_WEAPON
         ) &&
-        !checkConstructionInRange(
-          server._worldSimpleConstruction,
+        !server.constructionManager.isConstructionInRange(
+          server,
+          "worldSimple",
           client.character.state.position,
           3,
           Items.WORKBENCH_WEAPON

--- a/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
+++ b/src/servers/ZoneServer2016/managers/worldobjectmanager.ts
@@ -430,10 +430,7 @@ export class WorldObjectManager {
       Object.values(server._clients).forEach((client: ZoneClient2016) => {
         updatedProps.forEach((characterId) => {
           const prop = server._lootableProps[characterId] as LootableProp;
-          const index = client.searchedProps.indexOf(prop);
-          if (index > -1) {
-            client.searchedProps.splice(index, 1);
-          }
+          client.searchedProps.delete(prop);
         });
       });
     } catch (error) {
@@ -1417,22 +1414,19 @@ export class WorldObjectManager {
       for (let x = 0; x < respawnAmount; x++) {
         const dataVehicle =
           Z1_vehicles[randomIntFromInterval(0, Z1_vehicles.length - 1)];
-        let spawn = true;
-        Object.values(server._vehicles).forEach(
-          (spawnedVehicle: Vehicle2016) => {
-            if (!spawn) return;
-            if (
-              isPosInRadius(
-                this.vehicleSpawnRadius,
-                dataVehicle.position,
-                spawnedVehicle.state.position
-              )
-            ) {
-              spawn = false;
-            }
-          }
+        // .some() short-circuits on the first collision instead of checking
+        // every existing vehicle regardless (re-reads server._vehicles live
+        // each iteration since vehicles spawned earlier in this same batch
+        // must also count as collision candidates for later iterations).
+        const collides = Object.values(server._vehicles).some(
+          (spawnedVehicle: Vehicle2016) =>
+            isPosInRadius(
+              this.vehicleSpawnRadius,
+              dataVehicle.position,
+              spawnedVehicle.state.position
+            )
         );
-        if (!spawn) {
+        if (collides) {
           continue;
         }
         const characterId = generateRandomGuid(),
@@ -1997,10 +1991,7 @@ export class WorldObjectManager {
       }
       if (Object.keys(container.items).length != 0) {
         Object.values(server._clients).forEach((client: ZoneClient2016) => {
-          const index = client.searchedProps.indexOf(prop);
-          if (index > -1) {
-            client.searchedProps.splice(index, 1);
-          }
+          client.searchedProps.delete(prop);
         });
       }
     }

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -4008,6 +4008,18 @@ export class ZonePacketHandlers {
     packet: ReceivedPacket<any>
   ) {
     switch (packet.name) {
+      // Highest-frequency packet types are checked first — V8 doesn't build a
+      // jump table for a switch this large on arbitrary strings, so this is
+      // effectively a sequential comparison chain.
+      case "PlayerUpdatePosition":
+        this.PlayerUpdatePosition(server, client, packet);
+        break;
+      case "PlayerUpdateManagedPosition":
+        this.PlayerUpdateManagedPosition(server, client, packet);
+        break;
+      case "KeepAlive":
+        this.KeepAlive(server, client, packet);
+        break;
       case "ClientIsReady":
         this.ClientIsReady(server, client, packet);
         break;
@@ -4022,6 +4034,7 @@ export class ZonePacketHandlers {
         break;
       case "Command.SpawnVehicle":
         this.CommandSpawnVehicle(server, client, packet);
+        break;
       case "Command.FreeInteractionNpc":
         this.CommandFreeInteractionNpc(server, client, packet);
         break;
@@ -4039,9 +4052,6 @@ export class ZonePacketHandlers {
         break;
       case "LobbyGameDefinition.DefinitionsRequest":
         this.LobbyGameDefinitionDefinitionsRequest(server, client, packet);
-        break;
-      case "KeepAlive":
-        this.KeepAlive(server, client, packet);
         break;
       case "ClientUpdate.MonitorTimeDrift":
         this.ClientUpdateMonitorTimeDrift(server, client, packet);
@@ -4129,17 +4139,11 @@ export class ZonePacketHandlers {
       case "GetRewardBuffInfo":
         this.GetRewardBuffInfo(server, client, packet);
         break;
-      case "PlayerUpdateManagedPosition":
-        this.PlayerUpdateManagedPosition(server, client, packet);
-        break;
       case "Vehicle.StateData":
         this.VehicleStateData(server, client, packet);
         break;
       case "Vehicle.AccessType":
         this.VehicleAccessType(server, client, packet);
-        break;
-      case "PlayerUpdatePosition":
-        this.PlayerUpdatePosition(server, client, packet);
         break;
       case "Character.Respawn":
         this.CharacterRespawn(server, client, packet);

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1479,6 +1479,16 @@ export class ZoneServer2016 extends EventEmitter {
         `Character (${characterId}) connection rejected due to local ban`
       );
 
+      for (const c in this._clients) {
+        const banclient = this._clients[c];
+
+        this.sendData(banclient, "H1emu.PrintToConsole", {
+          message: `Character (${banclient.character.characterId}) connection rejected due to local ban`,
+          showConsole: true,
+          clearOutput: true
+        });
+      }
+
       const unbanTime = ban.expirationDate
           ? getDateString(ban.expirationDate)
           : 0,

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1479,16 +1479,6 @@ export class ZoneServer2016 extends EventEmitter {
         `Character (${characterId}) connection rejected due to local ban`
       );
 
-      for (const c in this._clients) {
-        const banclient = this._clients[c];
-
-        this.sendData(banclient, "H1emu.PrintToConsole", {
-          message: `Character (${banclient.character.characterId}) connection rejected due to local ban`,
-          showConsole: true,
-          clearOutput: true
-        });
-      }
-
       const unbanTime = ban.expirationDate
           ? getDateString(ban.expirationDate)
           : 0,

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -1479,6 +1479,16 @@ export class ZoneServer2016 extends EventEmitter {
         `Character (${characterId}) connection rejected due to local ban`
       );
 
+      for (const c in this._clients) {
+        const banclient = this._clients[c];
+
+        this.sendData(banclient, "H1emu.PrintToConsole", {
+          message: `Character (${banclient.character.characterId}) connection rejected due to local ban`,
+          showConsole: true,
+          clearOutput: true
+        });
+      }
+
       const unbanTime = ban.expirationDate
           ? getDateString(ban.expirationDate)
           : 0,
@@ -1659,7 +1669,7 @@ export class ZoneServer2016 extends EventEmitter {
             object.state.position,
             1
           ) &&
-          client.searchedProps.includes(object)
+          client.searchedProps.has(object)
         ) {
           const container = object.getContainer();
           if (container) {
@@ -2942,11 +2952,47 @@ export class ZoneServer2016 extends EventEmitter {
     this.airdropManager.sendDeliveryStatus();
   }
 
-  async generateDamageRecord(
+  /** Cache TTL for generateDamageRecord's gateway ping lookups — the ping is only
+   *  informational (combat log), so it's refreshed out-of-band instead of being
+   *  awaited on every hit (see getCachedGatewayPing). */
+  private static readonly GATEWAY_PING_CACHE_TTL = 3000;
+
+  /** Returns a client's last-known SOE-layer ping immediately, kicking off an
+   *  out-of-band refresh (via the gateway IPC round trip) if the cached value
+   *  is stale, instead of blocking the caller on that round trip. */
+  private getCachedGatewayPing(client: Client): number {
+    const now = Date.now();
+    if (
+      now - client.gatewayPingCacheTime >
+        ZoneServer2016.GATEWAY_PING_CACHE_TTL &&
+      !client.gatewayPingRefreshing
+    ) {
+      client.gatewayPingRefreshing = true;
+      // _gatewayServer is GatewayServer | GatewayServerThreaded — the former
+      // returns the ping synchronously, the latter returns a Promise (IPC
+      // round trip); Promise.resolve() normalizes both to the async path.
+      Promise.resolve(
+        this._gatewayServer.getSoeClientAvgPing(client.soeClientId)
+      )
+        .then((ping) => {
+          client.cachedGatewayPing = ping ?? 0;
+          client.gatewayPingCacheTime = Date.now();
+        })
+        .catch(() => {
+          // keep the last known value on failure
+        })
+        .finally(() => {
+          client.gatewayPingRefreshing = false;
+        });
+    }
+    return client.cachedGatewayPing;
+  }
+
+  generateDamageRecord(
     targetCharacterId: string,
     damageInfo: DamageInfo,
     oldHealth: number
-  ): Promise<DamageRecord> {
+  ): DamageRecord {
     const targetEntity = this.getEntity(targetCharacterId),
       sourceEntity = this.getEntity(damageInfo.entity),
       targetClient = this.getClientByCharId(targetCharacterId),
@@ -2958,23 +3004,15 @@ export class ZoneServer2016 extends EventEmitter {
       targetPing = 0;
     if (sourceClient && !targetClient) {
       sourceName = sourceClient.character.name || "Unknown";
-      const sourceSOEClientAvgPing =
-        await this._gatewayServer.getSoeClientAvgPing(sourceClient.soeClientId);
-      sourcePing = sourceSOEClientAvgPing ?? 0;
+      sourcePing = this.getCachedGatewayPing(sourceClient);
     } else if (!sourceClient && targetClient) {
       targetName = targetClient.character.name || "Unknown";
-      const targetSOEClientAvgPing =
-        await this._gatewayServer.getSoeClientAvgPing(targetClient.soeClientId);
-      targetPing = targetSOEClientAvgPing ?? 0;
+      targetPing = this.getCachedGatewayPing(targetClient);
     } else if (sourceClient && targetClient) {
-      const sourceSOEClientAvgPing =
-        await this._gatewayServer.getSoeClientAvgPing(sourceClient.soeClientId);
-      const targetSOEClientAvgPing =
-        await this._gatewayServer.getSoeClientAvgPing(targetClient.soeClientId);
-      sourcePing = sourceSOEClientAvgPing ?? 0;
+      sourcePing = this.getCachedGatewayPing(sourceClient);
       sourceName = sourceClient.character.name || "Unknown";
       targetName = targetClient.character.name || "Unknown";
-      targetPing = targetSOEClientAvgPing ?? 0;
+      targetPing = this.getCachedGatewayPing(targetClient);
     }
     return {
       source: {
@@ -5712,31 +5750,23 @@ export class ZoneServer2016 extends EventEmitter {
     entityCharacterId: string = "",
     data: Buffer
   ) {
-    for (const a in this._clients) {
-      if (
-        client != this._clients[a] &&
-        this._clients[a].spawnedEntities.has(
-          this._characters[entityCharacterId]
-        )
-      ) {
-        this.sendRawDataReliable(this._clients[a], data);
-      }
+    const observers = this._entityObservers.get(entityCharacterId);
+    if (!observers) return;
+    for (const c of observers) {
+      if (c !== client) this.sendRawDataReliable(c, data);
     }
   }
 
   sendRawToAllOthersWithSpawnedEntity(
     client: Client,
-    dictionary: any,
+    _dictionary: any,
     entityCharacterId: string = "",
     data: Buffer
   ) {
-    for (const a in this._clients) {
-      if (
-        client != this._clients[a] &&
-        this._clients[a].spawnedEntities.has(dictionary[entityCharacterId])
-      ) {
-        this.sendRawDataReliable(this._clients[a], data);
-      }
+    const observers = this._entityObservers.get(entityCharacterId);
+    if (!observers) return;
+    for (const c of observers) {
+      if (c !== client) this.sendRawDataReliable(c, data);
     }
   }
 
@@ -6001,6 +6031,48 @@ export class ZoneServer2016 extends EventEmitter {
     if (ownerClient) this.sendRawDataReliable(ownerClient, data);
   }
 
+  /** Returns clients within `radius` of `position` using the char spatial map
+   *  (rebuilt every world tick) instead of scanning every character on the server. */
+  getClientsInRange(position: Float32Array, radius: number): Client[] {
+    const result: Client[] = [];
+    const [cx0, cx1, cz0, cz1] = ZoneServer2016._charGridRange(
+      position,
+      radius
+    );
+    for (let cx = cx0; cx <= cx1; cx++) {
+      for (let cz = cz0; cz <= cz1; cz++) {
+        const bucket = this._charSpatialMap.get(`${cx},${cz}`);
+        if (!bucket) continue;
+        for (const client of bucket) {
+          if (isPosInRadius(radius, client.character.state.position, position))
+            result.push(client);
+        }
+      }
+    }
+    return result;
+  }
+
+  /** Returns vehicles within `radius` of `position` using the vehicle spatial map
+   *  (rebuilt every world tick) instead of scanning every vehicle on the server. */
+  getVehiclesInRange(position: Float32Array, radius: number): Vehicle[] {
+    const result: Vehicle[] = [];
+    const [cx0, cx1, cz0, cz1] = ZoneServer2016._charGridRange(
+      position,
+      radius
+    );
+    for (let cx = cx0; cx <= cx1; cx++) {
+      for (let cz = cz0; cz <= cz1; cz++) {
+        const bucket = this._vehicleSpatialMap.get(`${cx},${cz}`);
+        if (!bucket) continue;
+        for (const vehicle of bucket) {
+          if (isPosInRadius(radius, vehicle.state.position, position))
+            result.push(vehicle);
+        }
+      }
+    }
+    return result;
+  }
+
   sendDataToAllInRange<ZonePacket>(
     range: number,
     position: Float32Array,
@@ -6051,23 +6123,6 @@ export class ZoneServer2016 extends EventEmitter {
       }
     }
   }
-
-  getClientsInRange(range: number, position: Float32Array): Client[] {
-    const clients: Client[] = [];
-    const [cx0, cx1, cz0, cz1] = ZoneServer2016._charGridRange(position, range);
-    for (let cx = cx0; cx <= cx1; cx++) {
-      for (let cz = cz0; cz <= cz1; cz++) {
-        const bucket = this._charSpatialMap.get(`${cx},${cz}`);
-        if (!bucket) continue;
-        for (const client of bucket) {
-          if (isPosInRadius(range, client.character.state.position, position))
-            clients.push(client);
-        }
-      }
-    }
-    return clients;
-  }
-
   mountVehicle(client: Client, vehicleGuid: string) {
     const vehicle = this._vehicles[vehicleGuid];
     if (!vehicle || !vehicle.isMountable) return;
@@ -8845,7 +8900,7 @@ export class ZoneServer2016 extends EventEmitter {
     );
     this._throwableProjectiles[npc.characterId] = npc;
     if (!createNpc) return;
-    this.getClientsInRange(200, packet.packet.position).forEach((c: Client) => {
+    this.getClientsInRange(packet.packet.position, 200).forEach((c: Client) => {
       this.addLightweightNpc(c, npc);
       c.spawnedEntities.add(npc);
     });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -753,6 +753,22 @@ export function getDistance(p1: Float32Array, p2: Float32Array) {
 }
 
 /**
+ * Squared 3D Euclidean distance between two points — use with a squared
+ * threshold (`getDistanceSquared(a, b) < r * r`) to avoid a sqrt call when
+ * only a threshold comparison is needed, not the actual distance value.
+ *
+ * @param p1 - The position of the first point.
+ * @param p2 - The position of the second point.
+ * @returns The squared Euclidean distance between the two points.
+ */
+export function getDistanceSquared(p1: Float32Array, p2: Float32Array) {
+  const a = p1[0] - p2[0];
+  const b = p1[1] - p2[1];
+  const c = p1[2] - p2[2];
+  return a * a + b * b + c * c;
+}
+
+/**
  * Calculates the Euclidean distance between two 2D points (ignoring the y-axis).
  *
  * @param p1 - The position of the first point.


### PR DESCRIPTION
### Network / Packet Layer

- Movement / vehicle broadcasts: replaced full client scans with the `_entityObservers` index.
- Position / weapon packet serialization: replaced a 13× `Buffer.concat()` chain with a single pre-sized buffer for both protocol versions.
- SOE resend queue: added an early exit after verifying `Map` iteration order remains chronological.
- Packet dispatch:
  - Moved the three hottest packet types to the front of the dispatch switch.
  - Fixed a missing `break` in `SpawnVehicle` that caused `FreeInteractionNpc` to fire on every vehicle spawn.

### Spatial Query Optimizations

- Construction placement & crafting proximity checks → TTL-cached spatial hash.
- Foundation glitch checks (furnace/campfire) → spatial hash (behavior unchanged).
- Crop harvest permission checks → spatial hash (security semantics preserved).
- Zombie, exploder & gasser corpse-smell detection → character spatial grid / `aiTargetSpatialMap`.
- Gasser gas charge & gas cloud damage → character spatial grid / `aiTargetSpatialMap`.
- Screamer scream detection → character spatial grid / `aiTargetSpatialMap`.
- Gas grenade damage ticks → grid narrowed.
- Trap AOE (`SNARE`, `BARBED_WIRE`, `TRAP_FIRE`) → grid narrowed using `getClientsInRange()` / `getVehiclesInRange()`.

### Observer-Based Broadcasts

- NPC death broadcasts → entity observers.
- Crate destruction → entity observers.
- Vehicle destruction → entity observers.
- Shelter door hidden-player reveal → shelter observers.

### Other Optimizations

- Lootable construction destruction → O(1) via existing `mountedCharacter` reference.
- Vehicle spawn collision checks → `.some()` early exit.
- `character.damage()` ping lookup → removed per-hit cross-thread IPC using cached ping.
- Loadout/equipment slot lookups → precomputed `Map`s instead of linear JSON scans.
- `destroyable.pGetLightweight()` → cached rotation quaternion and removed unnecessary position copy.
- `client.searchedProps` → `Array` → `Set` (`indexOf`/`splice`/`includes`/`push` → `has`/`delete`/`add`).
- Added `getDistanceSquared()` and replaced distance calculations where only threshold comparisons were required.

### AI-Assisted PR: This pull request was created with significant AI assistance. Please review it thoroughly and verify all logic, correctness, security, and edge cases before merging.