### PR TITLE
Observer-Based Broadcasts

### DIFF
--- a/src/servers/ZoneServer2016/entities/constructiondoor.ts
+++ b/src/servers/ZoneServer2016/entities/constructiondoor.ts
@@ -335,13 +335,18 @@ export class ConstructionDoor extends DoorEntity {
             this.isOpen &&
             allowedConstruction.includes(parent.itemDefinitionId)
           ) {
-            for (const a in server._clients) {
-              const client = server._clients[a];
-              if (client.character.isHidden == parent.characterId)
-                server.constructionManager.constructionPermissionsManager(
-                  server,
-                  client
-                );
+            // a hidden character stays subscribed to (spawned into) the
+            // shelter it's hiding in, so observers of the parent are the
+            // only clients that can possibly match isHidden below
+            const observers = server._entityObservers.get(parent.characterId);
+            if (observers) {
+              for (const client of observers) {
+                if (client.character.isHidden == parent.characterId)
+                  server.constructionManager.constructionPermissionsManager(
+                    server,
+                    client
+                  );
+              }
             }
           }
         }

--- a/src/servers/ZoneServer2016/entities/crate.ts
+++ b/src/servers/ZoneServer2016/entities/crate.ts
@@ -176,9 +176,11 @@ export class Crate extends BaseSimpleNpc {
       }
     );
 
-    for (const a in server._clients) {
-      const client = server._clients[a];
-      client.spawnedEntities.delete(server._crates[this.characterId]);
+    const observers = server._entityObservers.get(this.characterId);
+    if (observers) {
+      for (const client of Array.from(observers)) {
+        client.spawnedEntities.delete(server._crates[this.characterId]);
+      }
     }
     return true;
     // crates cannot get deleted from dictionarries, need separate function to despawn

--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -260,9 +260,9 @@ export abstract class Npc extends BaseFullCharacter {
           client.character.metrics.zombiesKilled++;
         else client.character.metrics.wildlifeKilled++;
       }
-      for (const a in server._clients) {
-        const c = server._clients[a];
-        if (c.spawnedEntities.has(this)) {
+      const observers = server._entityObservers.get(this.characterId);
+      if (observers) {
+        for (const c of observers) {
           if (!c.isLoading) {
             server.sendData(c, "Character.StartMultiStateDeath", {
               data: {

--- a/src/servers/ZoneServer2016/entities/vehicle.ts
+++ b/src/servers/ZoneServer2016/entities/vehicle.ts
@@ -1342,10 +1342,9 @@ export class Vehicle2016 extends BaseLootableEntity {
     this.isDestroyed = true;
     if (!server._vehicles[this.characterId]) return false;
     this._resources[ResourceIds.CONDITION] = 0;
-    for (const c in server._clients) {
-      if (this.characterId === server._clients[c].vehicle.mountedVehicle) {
-        server.dismountVehicle(server._clients[c]);
-      }
+    for (const passengerId of this.getPassengerList()) {
+      const client = server.getClientByCharId(passengerId);
+      if (client) server.dismountVehicle(client);
     }
     server.sendDataToAllWithSpawnedEntity(
       server._vehicles,


### PR DESCRIPTION

### Observer-Based Broadcasts

- NPC death broadcasts → entity observers.
- Crate destruction → entity observers.
- Vehicle destruction → entity observers.
- Shelter door hidden-player reveal → shelter observers.