### PR TITLE
Network optimization

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
@@ -637,123 +637,106 @@ export function readPositionUpdateDataAndCheckLength(
 }
 
 export function packPositionUpdateData(obj: any) {
-  let data = Buffer.allocUnsafe(7),
-    flags = 0,
-    v;
-
-  data.writeUInt32LE(obj["sequenceTime"], 2);
-  data.writeUInt8(obj["unknown3_int8"], 6);
+  // Fields are collected into `chunks` and joined with a single Buffer.concat
+  // at the end instead of concatenating on every field (which recopies
+  // everything written so far on every call).
+  let flags = 0;
+  const chunks: Buffer[] = [];
+  let v: Buffer;
 
   if ("stance" in obj) {
     flags |= 1;
-    v = packUnsignedIntWith2bitLengthValue(obj["stance"]);
-    data = Buffer.concat([data, v]);
+    chunks.push(packUnsignedIntWith2bitLengthValue(obj["stance"]));
   }
 
   if ("position" in obj) {
     flags |= 2;
-    v = packSignedIntWith2bitLengthValue(obj["position"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][2] * 100));
   }
 
   if ("orientation" in obj) {
     flags |= 0x20;
     v = Buffer.allocUnsafe(4);
     v.writeFloatLE(obj["orientation"], 0);
-    data = Buffer.concat([data, v]);
+    chunks.push(v);
   }
 
   if ("frontTilt" in obj) {
     flags |= 0x40;
-    v = packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100));
   }
 
   if ("sideTilt" in obj) {
     flags |= 0x80;
-    v = packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100));
   }
 
   if ("angleChange" in obj) {
     flags |= 4;
-    v = packSignedIntWith2bitLengthValue(obj["angleChange"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["angleChange"] * 100));
   }
 
   if ("verticalSpeed" in obj) {
     flags |= 8;
-    v = packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100));
   }
 
   if ("horizontalSpeed" in obj) {
     flags |= 0x10;
-    v = packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10));
   }
 
   if ("unknown12_float" in obj) {
     flags |= 0x100;
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100)
+    );
   }
 
   if ("rotationRaw" in obj) {
     flags |= 0x200;
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100));
   }
 
   if ("direction" in obj) {
     flags |= 0x400;
-    v = packSignedIntWith2bitLengthValue(obj["direction"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["direction"] * 10));
   }
 
   if ("engineRPM" in obj) {
     flags |= 0x800;
-    v = packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10));
   }
 
   if ("PosAndRot" in obj) {
     flags |= 0x1000;
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][0] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][1] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][2] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][3] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][4] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][5] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][6] * 10000);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["PosAndRot"][7] * 10000);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][0] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][1] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][2] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][3] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][4] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][5] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][6] * 10000));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["PosAndRot"][7] * 10000));
   }
 
-  data.writeUInt16LE(flags, 0);
+  const header = Buffer.allocUnsafe(7);
+  header.writeUInt16LE(flags, 0);
+  header.writeUInt32LE(obj["sequenceTime"], 2);
+  header.writeUInt8(obj["unknown3_int8"], 6);
 
-  return data;
+  return Buffer.concat([header, ...chunks]);
 }
 
 export interface MultiDeathData {

--- a/src/packets/ClientProtocol/ClientProtocol_1080/weapon.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/weapon.ts
@@ -634,11 +634,10 @@ export function packWeaponPacket(obj: any): Buffer {
   if (weaponPacketDescriptors[subType]) {
     const subPacket = weaponPacketDescriptors[subType],
       subTypeData = writePacketType(subType);
-    let subData = DataSchema.pack(subPacket.schema, subObj).data;
-    subData = Buffer.concat([subTypeData.slice(1), subData]);
-    data = Buffer.allocUnsafe(subData.length + 4);
-    data.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-    subData.copy(data, 4);
+    const subData = DataSchema.pack(subPacket.schema, subObj).data;
+    const header = Buffer.allocUnsafe(4);
+    header.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
+    data = Buffer.concat([header, subTypeData.subarray(1), subData]);
   } else {
     throw "Unknown weapon packet type: " + subType;
   }
@@ -646,41 +645,34 @@ export function packWeaponPacket(obj: any): Buffer {
 }
 
 function packFirestateUpdate(obj: any): Buffer {
-  let data = Buffer.alloc(1);
-  data.writeUInt8(obj.firestate);
-  if ((obj.firestate & 2) == 0) {
-    // transientId
-    data = Buffer.concat([
-      data,
-      DataSchema.pack(
-        [
-          {
-            name: "transientId",
-            type: "custom",
-            parser: readUnsignedIntWith2bitLengthValue,
-            packer: packUnsignedIntWith2bitLengthValue
-          }
-        ],
-        obj
-      ).data
-    ]);
-  } else {
-    // floatvector4
-    data = Buffer.concat([
-      data,
-      DataSchema.pack(
-        [
-          {
-            name: "position",
-            type: "floatvector4",
-            defaultValue: [1, 1, 1, 1]
-          }
-        ],
-        obj
-      ).data
-    ]);
-  }
-  return data;
+  const fieldData =
+    (obj.firestate & 2) == 0
+      ? // transientId
+        DataSchema.pack(
+          [
+            {
+              name: "transientId",
+              type: "custom",
+              parser: readUnsignedIntWith2bitLengthValue,
+              packer: packUnsignedIntWith2bitLengthValue
+            }
+          ],
+          obj
+        ).data
+      : // floatvector4
+        DataSchema.pack(
+          [
+            {
+              name: "position",
+              type: "floatvector4",
+              defaultValue: [1, 1, 1, 1]
+            }
+          ],
+          obj
+        ).data;
+  const header = Buffer.allocUnsafe(1);
+  header.writeUInt8(obj.firestate, 0);
+  return Buffer.concat([header, fieldData]);
 }
 
 export function packRemoteWeaponPacket(obj: any): Buffer {
@@ -692,20 +684,19 @@ export function packRemoteWeaponPacket(obj: any): Buffer {
   if (!remoteWeaponPacketDescriptors[subType]) {
     throw "Unknown weapon packet type: " + subType;
   }
-  let subData = Buffer.allocUnsafe(6);
+  const header = Buffer.allocUnsafe(6);
   const subTypeData = writePacketType(subType);
-  subData.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-  subData.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
-  subData.writeUInt8(subTypeData[0], 5); // remoteweapon sub opcode
+  header.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
+  header.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
+  header.writeUInt8(subTypeData[0], 5); // remoteweapon sub opcode
   const transientId = packUnsignedIntWith2bitLengthValue(
     obj["remoteWeaponPacket"]["transientId"]
   );
-  subData = Buffer.concat([subData, transientId]);
   const packetData = DataSchema.pack(
     remoteWeaponPacketDescriptors[subType].schema,
     subObj
   ).data;
-  return Buffer.concat([subData, packetData]);
+  return Buffer.concat([header, transientId, packetData]);
 }
 
 export function packRemoteWeaponUpdatePacket(obj: any): Buffer {
@@ -715,15 +706,14 @@ export function packRemoteWeaponUpdatePacket(obj: any): Buffer {
   if (!remoteWeaponUpdatePacketDescriptors[subType]) {
     throw "Unknown weapon packet type: " + subType;
   }
-  let subData = Buffer.allocUnsafe(6);
+  const header = Buffer.allocUnsafe(6);
   const subTypeData = writePacketType(subType);
-  subData.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-  subData.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
-  subData.writeUInt8(0x04, 5); // "RemoteWeapon.Update" opcode
+  header.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
+  header.writeUInt8(0x15, 4); // "Weapon.RemoteWeapon" opcode
+  header.writeUInt8(0x04, 5); // "RemoteWeapon.Update" opcode
   const transientId = packUnsignedIntWith2bitLengthValue(
     obj["remoteWeaponPacket"]["transientId"]
   );
-  subData = Buffer.concat([subData, transientId]);
   const updateData = Buffer.allocUnsafe(9);
   updateData.writeUInt8(subTypeData[0], 0);
   for (let j = 0; j < 8; j++) {
@@ -737,12 +727,11 @@ export function packRemoteWeaponUpdatePacket(obj: any): Buffer {
       1 + j
     );
   }
-  subData = Buffer.concat([subData, updateData]);
   const packetData = DataSchema.pack(
     remoteWeaponUpdatePacketDescriptors[subType].schema,
     subObj
   ).data;
-  return Buffer.concat([subData, packetData]);
+  return Buffer.concat([header, transientId, updateData, packetData]);
 }
 
 const hitReportSchema = [

--- a/src/packets/ClientProtocol/ClientProtocol_860/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/shared.ts
@@ -254,103 +254,94 @@ export function readPositionUpdateData(data: Buffer, offset: number) {
 }
 
 export function packPositionUpdateData(obj: any) {
-  let data = Buffer.allocUnsafe(7),
-    flags = 0,
-    v;
-
-  data.writeUInt32LE(obj["sequenceTime"], 2);
-  data.writeUInt8(obj["unknown3_int8"], 6);
+  // Fields are collected into `chunks` and joined with a single Buffer.concat
+  // at the end instead of concatenating on every field (which recopies
+  // everything written so far on every call).
+  let flags = 0;
+  const chunks: Buffer[] = [];
+  let v: Buffer;
 
   if ("stance" in obj) {
     flags |= 1;
-    v = packUnsignedIntWith2bitLengthValue(obj["stance"]);
-    data = Buffer.concat([data, v]);
+    chunks.push(packUnsignedIntWith2bitLengthValue(obj["stance"]));
   }
 
   if ("position" in obj) {
     flags |= 2;
-    v = packSignedIntWith2bitLengthValue(obj["position"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["position"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["position"][2] * 100));
   }
 
   if ("orientation" in obj) {
     flags |= 0x20;
     v = Buffer.allocUnsafe(4);
     v.writeFloatLE(obj["orientation"], 0);
-    data = Buffer.concat([data, v]);
+    chunks.push(v);
   }
 
   if ("frontTilt" in obj) {
     flags |= 0x40;
-    v = packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["frontTilt"] * 100));
   }
 
   if ("sideTilt" in obj) {
     flags |= 0x80;
-    v = packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["sideTilt"] * 100));
   }
 
   if ("angleChange" in obj) {
     flags |= 4;
-    v = packSignedIntWith2bitLengthValue(obj["angleChange"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["angleChange"] * 100));
   }
 
   if ("verticalSpeed" in obj) {
     flags |= 8;
-    v = packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["verticalSpeed"] * 100));
   }
 
   if ("horizontalSpeed" in obj) {
     flags |= 0x10;
-    v = packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["horizontalSpeed"] * 10));
   }
 
   if ("unknown12_float" in obj) {
     flags |= 0x100;
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][0] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][1] * 100)
+    );
+    chunks.push(
+      packSignedIntWith2bitLengthValue(obj["unknown12_float"][2] * 100)
+    );
   }
 
   if ("rotationRaw" in obj) {
     flags |= 0x200;
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100);
-    data = Buffer.concat([data, v]);
-    v = packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][0] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][1] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][2] * 100));
+    chunks.push(packSignedIntWith2bitLengthValue(obj["rotationRaw"][3] * 100));
   }
 
   if ("direction" in obj) {
     flags |= 0x400;
-    v = packSignedIntWith2bitLengthValue(obj["direction"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["direction"] * 10));
   }
 
   if ("engineRPM" in obj) {
     flags |= 0x800;
-    v = packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10);
-    data = Buffer.concat([data, v]);
+    chunks.push(packSignedIntWith2bitLengthValue(obj["engineRPM"] * 10));
   }
 
-  data.writeUInt16LE(flags, 0);
+  const header = Buffer.allocUnsafe(7);
+  header.writeUInt16LE(flags, 0);
+  header.writeUInt32LE(obj["sequenceTime"], 2);
+  header.writeUInt8(obj["unknown3_int8"], 6);
 
-  return data;
+  return Buffer.concat([header, ...chunks]);
 }
 
 export function packItemDefinitionData(obj: any) {

--- a/src/packets/ClientProtocol/ClientProtocol_860/weapon.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_860/weapon.ts
@@ -263,11 +263,10 @@ export function packWeaponPacket(obj: any) {
   if (weaponPacketDescriptors[subType]) {
     const subPacket = weaponPacketDescriptors[subType],
       subTypeData = writePacketType(subType);
-    let subData = DataSchema.pack(subPacket.schema, subObj).data;
-    subData = Buffer.concat([subTypeData.slice(1), subData]);
-    data = Buffer.allocUnsafe(subData.length + 4);
-    data.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
-    subData.copy(data, 4);
+    const subData = DataSchema.pack(subPacket.schema, subObj).data;
+    const header = Buffer.allocUnsafe(4);
+    header.writeUInt32LE((obj.gameTime & 0xffffffff) >>> 0, 0);
+    data = Buffer.concat([header, subTypeData.subarray(1), subData]);
   } else {
     throw "Unknown weapon packet type: " + subType;
   }

--- a/src/servers/SoeServer/soeserver.ts
+++ b/src/servers/SoeServer/soeserver.ts
@@ -159,26 +159,32 @@ export class SOEServer extends EventEmitter {
     const resends: LogicalPacket[] = [];
     const resendedSequences: Set<number> = new Set();
     for (const [sequence, time] of client.unAckData) {
+      // Map iteration order matches insertion order, which matches send order:
+      // entries are only ever appended fresh (_sendAndBuildPhysicalPacket /
+      // setupResendForQueuedPackets always run right after a delete() for any
+      // sequence being resent, never refresh a stale position in place), so
+      // once we reach an entry that isn't due yet, nothing after it is either.
+      if (time + this._resendTimeout + client.avgPing >= currentTime) {
+        break;
+      }
       // if the packet is too old then we resend it
-      if (time + this._resendTimeout + client.avgPing < currentTime) {
-        const dataCache = client.outputStream.getDataCache(sequence);
-        if (dataCache) {
-          if (dataCache.resendCounter >= this._maxResentTries) {
-            continue;
-          }
-          dataCache.resendCounter++;
-          client.stats.packetResend++;
-          const logicalPacket = this.createLogicalPacket(
-            dataCache.fragment ? SoeOpcode.DataFragment : SoeOpcode.Data,
-            { sequence: sequence, data: dataCache.data }
-          );
-          if (logicalPacket) {
-            resendedSequences.add(sequence);
-            resends.push(logicalPacket);
-          }
-        } else {
-          // If the data cache is not found it means that the packet has been acked
+      const dataCache = client.outputStream.getDataCache(sequence);
+      if (dataCache) {
+        if (dataCache.resendCounter >= this._maxResentTries) {
+          continue;
         }
+        dataCache.resendCounter++;
+        client.stats.packetResend++;
+        const logicalPacket = this.createLogicalPacket(
+          dataCache.fragment ? SoeOpcode.DataFragment : SoeOpcode.Data,
+          { sequence: sequence, data: dataCache.data }
+        );
+        if (logicalPacket) {
+          resendedSequences.add(sequence);
+          resends.push(logicalPacket);
+        }
+      } else {
+        // If the data cache is not found it means that the packet has been acked
       }
     }
 

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -4008,6 +4008,18 @@ export class ZonePacketHandlers {
     packet: ReceivedPacket<any>
   ) {
     switch (packet.name) {
+      // Highest-frequency packet types are checked first — V8 doesn't build a
+      // jump table for a switch this large on arbitrary strings, so this is
+      // effectively a sequential comparison chain.
+      case "PlayerUpdatePosition":
+        this.PlayerUpdatePosition(server, client, packet);
+        break;
+      case "PlayerUpdateManagedPosition":
+        this.PlayerUpdateManagedPosition(server, client, packet);
+        break;
+      case "KeepAlive":
+        this.KeepAlive(server, client, packet);
+        break;
       case "ClientIsReady":
         this.ClientIsReady(server, client, packet);
         break;
@@ -4022,6 +4034,7 @@ export class ZonePacketHandlers {
         break;
       case "Command.SpawnVehicle":
         this.CommandSpawnVehicle(server, client, packet);
+        break;
       case "Command.FreeInteractionNpc":
         this.CommandFreeInteractionNpc(server, client, packet);
         break;
@@ -4039,9 +4052,6 @@ export class ZonePacketHandlers {
         break;
       case "LobbyGameDefinition.DefinitionsRequest":
         this.LobbyGameDefinitionDefinitionsRequest(server, client, packet);
-        break;
-      case "KeepAlive":
-        this.KeepAlive(server, client, packet);
         break;
       case "ClientUpdate.MonitorTimeDrift":
         this.ClientUpdateMonitorTimeDrift(server, client, packet);
@@ -4129,17 +4139,11 @@ export class ZonePacketHandlers {
       case "GetRewardBuffInfo":
         this.GetRewardBuffInfo(server, client, packet);
         break;
-      case "PlayerUpdateManagedPosition":
-        this.PlayerUpdateManagedPosition(server, client, packet);
-        break;
       case "Vehicle.StateData":
         this.VehicleStateData(server, client, packet);
         break;
       case "Vehicle.AccessType":
         this.VehicleAccessType(server, client, packet);
-        break;
-      case "PlayerUpdatePosition":
-        this.PlayerUpdatePosition(server, client, packet);
         break;
       case "Character.Respawn":
         this.CharacterRespawn(server, client, packet);

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -5712,31 +5712,23 @@ export class ZoneServer2016 extends EventEmitter {
     entityCharacterId: string = "",
     data: Buffer
   ) {
-    for (const a in this._clients) {
-      if (
-        client != this._clients[a] &&
-        this._clients[a].spawnedEntities.has(
-          this._characters[entityCharacterId]
-        )
-      ) {
-        this.sendRawDataReliable(this._clients[a], data);
-      }
+    const observers = this._entityObservers.get(entityCharacterId);
+    if (!observers) return;
+    for (const c of observers) {
+      if (c !== client) this.sendRawDataReliable(c, data);
     }
   }
 
   sendRawToAllOthersWithSpawnedEntity(
     client: Client,
-    dictionary: any,
+    _dictionary: any,
     entityCharacterId: string = "",
     data: Buffer
   ) {
-    for (const a in this._clients) {
-      if (
-        client != this._clients[a] &&
-        this._clients[a].spawnedEntities.has(dictionary[entityCharacterId])
-      ) {
-        this.sendRawDataReliable(this._clients[a], data);
-      }
+    const observers = this._entityObservers.get(entityCharacterId);
+    if (!observers) return;
+    for (const c of observers) {
+      if (c !== client) this.sendRawDataReliable(c, data);
     }
   }
 


### PR DESCRIPTION
Network / Packet Layer

- zoneserver.ts — sendRawToAllOthersWithSpawnedCharacter / sendRawToAllOthersWithSpawnedEntity narrowed to _entityObservers instead of scanning every client.
- soeserver.ts — SOE resend queue: early exit once Map iteration order is confirmed chronological.
- zonepackethandlers.ts — moved the 3 hottest packet types to the front of the dispatch switch; fixed a missing break after Command.SpawnVehicle that was falling through into Command.FreeInteractionNpc on every vehicle spawn.
