### PR TITLE
fix: validate emote ownership on keybind-triggered emotes

### DIFF
--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -16,6 +16,7 @@
 import { scheduler } from "node:timers/promises";
 import { ZoneClient2016 as Client } from "./classes/zoneclient";
 import { ZoneServer2016 } from "./zoneserver";
+import { defaultEmotes } from "./data/emotes";
 const apm = require("elastic-apm-node");
 const debug = require("debug")("ZoneServer");
 
@@ -599,7 +600,7 @@ export class ZonePacketHandlers {
       {}
     );
   }
-  CommandPlayDialogEffect(
+  async CommandPlayDialogEffect(
     server: ZoneServer2016,
     client: Client,
     packet: ReceivedPacket<CommandPlayDialogEffect>
@@ -614,6 +615,30 @@ export class ZonePacketHandlers {
     if (equippedItem && equippedItem.itemDefinitionId !== Items.WEAPON_FISTS) {
       // Player has a weapon equipped that is not fists, don't allow emote
       return;
+    }
+
+    // effectId 0 just means "cancel emote", no ownership check needed
+    if (effectId > 0 && !defaultEmotes.includes(effectId)) {
+      // Non-default emotes must be owned as an account item (e.g. case rewards)
+      let hasEmote = false;
+      const accountItems =
+        await server.accountInventoriesManager.getAccountItems(
+          client.loginSessionId
+        );
+      for (const accountItem of accountItems) {
+        if (accountItem && accountItem.itemDefinitionId) {
+          const itemDef = server.getItemDefinition(
+            accountItem.itemDefinitionId
+          );
+          if (itemDef && itemDef.PARAM1 === effectId) {
+            hasEmote = true;
+            break;
+          }
+        }
+      }
+      if (!hasEmote) {
+        return;
+      }
     }
 
     // Track that the player is playing an emote


### PR DESCRIPTION
## Summary
- `Command.PlayDialogEffect` (sent by the client when an emote keybind is pressed) only validated that the player had fists/hands equipped, without checking whether the player actually owns the emote.
- Non-default emotes (e.g. granted from cases) could be triggered with any `effectId` by a modified client, bypassing the ownership check already enforced by the `/emote` chat command.
- This mirrors the same account-item ownership check used by `/emote` in `handlers/commands/commands.ts`, applying it to the keybind path as well.

---
🤖 *This PR was developed with the assistance of AI (Claude Code).*
