### PR TITLE
feat: cycle crossbow projectile type with the fire mode switch keybind

### DIFF
--- a/src/servers/ZoneServer2016/classes/weapon.ts
+++ b/src/servers/ZoneServer2016/classes/weapon.ts
@@ -32,6 +32,9 @@ export class Weapon {
   /** Required for the reload packet to work every time (especially shotgun) */
   currentReloadCount = 0;
 
+  /** Index into the weapon definition's FIRE_GROUPS, selected via Weapon.SwitchFireModeRequest (e.g. crossbow projectile types) */
+  firegroupIndex = 0;
+
   constructor(item: BaseItem, ammoCount?: number) {
     this.itemGuid = item.itemGuid;
     this.itemDefinitionId = item.itemDefinitionId;
@@ -43,7 +46,7 @@ export class Weapon {
     client.character.lootItem(
       server,
       server.generateItem(
-        server.getWeaponAmmoId(this.itemDefinitionId),
+        server.getWeaponAmmoId(this.itemDefinitionId, this.firegroupIndex),
         this.ammoCount
       )
     );

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -3191,12 +3191,37 @@ export class ZonePacketHandlers {
       case "Weapon.ReloadInterrupt":
         server.reloadInterrupt(client, weaponItem);
         break;
-      case "Weapon.SwitchFireModeRequest":
+      case "Weapon.SwitchFireModeRequest": {
+        const firegroupCount = server.getWeaponFiregroupCount(
+          weaponItem.itemDefinitionId
+        );
+
+        // Weapons with multiple fire groups (e.g. crossbow projectile types) cycle
+        // through them instead of just toggling a visual fire mode / ADS state.
+        if (firegroupCount > 1) {
+          weaponItem.weapon.firegroupIndex =
+            (weaponItem.weapon.firegroupIndex + 1) % firegroupCount;
+          // Loaded ammo no longer matches the newly selected projectile type
+          weaponItem.weapon.ammoCount = 0;
+          server.sendWeaponReload(client, weaponItem);
+          server.sendRemoteWeaponUpdateDataToAllOthers(
+            client,
+            client.character.transientId,
+            weaponItem.itemGuid,
+            "Update.SwitchFireMode",
+            {
+              firegroupIndex: weaponItem.weapon.firegroupIndex,
+              firemodeIndex: 0
+            }
+          );
+          break;
+        }
+
         // workaround so aiming in doesn't sometimes make the shooting sound
         if (!weaponItem.weapon?.ammoCount) return;
 
         // temp workaround to fix 308 sound while aiming
-        // this workaround applies to all weapons
+        // this workaround applies to all single-firegroup weapons
         if (packet.packet.firemodeIndex == 1) return;
         server.sendRemoteWeaponUpdateDataToAllOthers(
           client,
@@ -3209,6 +3234,7 @@ export class ZonePacketHandlers {
           }
         );
         break;
+      }
       case "Weapon.WeaponFireHint":
         debug("WeaponFireHint");
         break;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -6673,13 +6673,17 @@ export class ZoneServer2016 extends EventEmitter {
    * Gets the ammoId for a given weapon.
    *
    * @param {number} itemDefinitionId - The itemDefinitionId of the weapon.
+   * @param {number} [firegroupIndex] - Index into the weapon's FIRE_GROUPS, e.g. the crossbow's selected projectile type.
    * @returns {number} The ammoId (0 if undefined).
    */
-  getWeaponAmmoId(itemDefinitionId: number): number {
+  getWeaponAmmoId(
+    itemDefinitionId: number,
+    firegroupIndex: number = 0
+  ): number {
     const itemDefinition = this.getItemDefinition(itemDefinitionId),
       weaponDefinition = this.getWeaponDefinition(itemDefinition?.PARAM1 || 0),
       firegroupDefinition = this.getFiregroupDefinition(
-        weaponDefinition?.FIRE_GROUPS[0]?.FIRE_GROUP_ID
+        weaponDefinition?.FIRE_GROUPS[firegroupIndex]?.FIRE_GROUP_ID
       ),
       firemodeDefinition = this.getFiremodeDefinition(
         firegroupDefinition?.FIRE_MODES[0]?.FIRE_MODE_ID
@@ -6692,19 +6696,36 @@ export class ZoneServer2016 extends EventEmitter {
    * Gets the reload time in milliseconds for a given weapon.
    *
    * @param {number} itemDefinitionId - The itemDefinitionId of the weapon.
+   * @param {number} [firegroupIndex] - Index into the weapon's FIRE_GROUPS, e.g. the crossbow's selected projectile type.
    * @returns {number} The reload time in milliseconds (0 if undefined).
    */
-  getWeaponReloadTime(itemDefinitionId: number): number {
+  getWeaponReloadTime(
+    itemDefinitionId: number,
+    firegroupIndex: number = 0
+  ): number {
     const itemDefinition = this.getItemDefinition(itemDefinitionId),
       weaponDefinition = this.getWeaponDefinition(itemDefinition?.PARAM1 || 0),
       firegroupDefinition = this.getFiregroupDefinition(
-        weaponDefinition?.FIRE_GROUPS[0]?.FIRE_GROUP_ID
+        weaponDefinition?.FIRE_GROUPS[firegroupIndex]?.FIRE_GROUP_ID
       ),
       firemodeDefinition = this.getFiremodeDefinition(
         firegroupDefinition?.FIRE_MODES[0]?.FIRE_MODE_ID
       );
 
     return firemodeDefinition?.RELOAD_TIME_MS || 0;
+  }
+
+  /**
+   * Gets the number of fire groups (e.g. selectable projectile types) a weapon has.
+   *
+   * @param {number} itemDefinitionId - The itemDefinitionId of the weapon.
+   * @returns {number} The amount of fire groups (0 if undefined).
+   */
+  getWeaponFiregroupCount(itemDefinitionId: number): number {
+    const itemDefinition = this.getItemDefinition(itemDefinitionId),
+      weaponDefinition = this.getWeaponDefinition(itemDefinition?.PARAM1 || 0);
+
+    return weaponDefinition?.FIRE_GROUPS?.length || 0;
   }
 
   /**
@@ -9129,8 +9150,14 @@ export class ZoneServer2016 extends EventEmitter {
       "Update.Reload",
       {}
     );
-    const weaponAmmoId = this.getWeaponAmmoId(weaponItem.itemDefinitionId),
-      reloadTime = this.getWeaponReloadTime(weaponItem.itemDefinitionId);
+    const weaponAmmoId = this.getWeaponAmmoId(
+        weaponItem.itemDefinitionId,
+        weaponItem.weapon.firegroupIndex
+      ),
+      reloadTime = this.getWeaponReloadTime(
+        weaponItem.itemDefinitionId,
+        weaponItem.weapon.firegroupIndex
+      );
 
     const itemDefinition = this.getItemDefinition(weaponItem.itemDefinitionId);
     if (!itemDefinition) return;


### PR DESCRIPTION
## Summary
- The crossbow's weapon definition (`weaponDefinitionId` 1414) has 3 fire groups, one per projectile type: Wooden Arrow, Flaming Arrow, Explosive Arrow.
- Pressing the switch-fire-mode keybind (default V) sends `Weapon.SwitchFireModeRequest`, but the handler only rebroadcast a cosmetic packet to other players and never changed which ammo the weapon actually consumed/reloaded with.
- Added a `firegroupIndex` to the `Weapon` class, and use it in `getWeaponAmmoId` / `getWeaponReloadTime` (previously hardcoded to fire group 0). `Weapon.SwitchFireModeRequest` now cycles through the weapon's fire groups for weapons that expose more than one (crossbow), resets the loaded ammo count (so the player has to reload with the newly selected arrow type), and syncs the change to the shooter and to other players.
- Weapons with a single fire group keep the previous behavior untouched, including the existing ADS-sound workaround.

---
🤖 *This PR was developed with the assistance of AI (Claude Code).*
