### PR TITLE
fix: clamp NPC turn rate while attacking so they don't snap instantly

### DIFF
--- a/src/servers/ZoneServer2016/entities/npc.ts
+++ b/src/servers/ZoneServer2016/entities/npc.ts
@@ -565,15 +565,29 @@ export abstract class Npc extends BaseFullCharacter {
     );
   }
 
-  lookAt(targetPosition: Float32Array) {
+  /**
+   * Turns the NPC to face a target, clamped to maxTurnRateRadPerSec so a
+   * stationary NPC (e.g. attacking a player it can't reach, like one on top
+   * of a car) doesn't snap its facing instantly every AI tick.
+   */
+  lookAt(
+    targetPosition: Float32Array,
+    dt: number = 0,
+    maxTurnRateRadPerSec: number = Math.PI
+  ) {
     const dx = targetPosition[0] - this.state.position[0];
     const dz = targetPosition[2] - this.state.position[2];
     const dy = targetPosition[1] - this.state.position[1];
     const horizontalDist = Math.sqrt(dx * dx + dz * dz);
-    const orientation = Math.atan2(dx, dz);
-    const prevOrientation = this.state.yaw ?? orientation;
-    let angleChange = orientation - prevOrientation;
+    const targetOrientation = Math.atan2(dx, dz);
+    const prevOrientation = this.state.yaw ?? targetOrientation;
+    let angleChange = targetOrientation - prevOrientation;
     angleChange = Math.atan2(Math.sin(angleChange), Math.cos(angleChange));
+    if (dt > 0) {
+      const maxStep = maxTurnRateRadPerSec * dt;
+      angleChange = Math.max(-maxStep, Math.min(maxStep, angleChange));
+    }
+    const orientation = prevOrientation + angleChange;
     this.state.yaw = orientation;
     const frontTilt = Math.atan2(dy, horizontalDist);
     const sinO = Math.sin(orientation);

--- a/src/servers/ZoneServer2016/jsms/bear.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/bear.jsm.ts
@@ -260,7 +260,7 @@ export function createBear(npc: Npc, server: ZoneServer2016): BearInstance {
 
         const target = getTarget(bear);
         if (target) {
-          bear.npc.lookAt(target.position);
+          bear.npc.lookAt(target.position, dt);
         }
 
         if (bear.stateTimer >= 2) {

--- a/src/servers/ZoneServer2016/jsms/gasser.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/gasser.jsm.ts
@@ -545,7 +545,7 @@ export function createGasser(npc: Npc, server: ZoneServer2016): ZombieInstance {
 
         const attackTarget = getChaseTarget(gasser);
         if (attackTarget) {
-          gasser.npc.lookAt(attackTarget.position);
+          gasser.npc.lookAt(attackTarget.position, dt);
         }
 
         if (gasser.stateTimer >= 2) {

--- a/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
@@ -410,7 +410,7 @@ export function createScreamer(
 
         const attackTarget = getChaseTarget(screamer);
         if (attackTarget) {
-          screamer.npc.lookAt(attackTarget.state.position);
+          screamer.npc.lookAt(attackTarget.state.position, dt);
         }
 
         if (screamer.stateTimer >= 2) {

--- a/src/servers/ZoneServer2016/jsms/wolf.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/wolf.jsm.ts
@@ -303,7 +303,7 @@ export function createWolf(npc: Npc, server: ZoneServer2016): WolfInstance {
 
         const target = getTarget(wolf);
         if (target) {
-          wolf.npc.lookAt(target.position);
+          wolf.npc.lookAt(target.position, dt);
         }
 
         if (wolf.stateTimer >= 2) {

--- a/src/servers/ZoneServer2016/jsms/zombie.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/zombie.jsm.ts
@@ -504,7 +504,7 @@ export function createZombie(npc: Npc, server: ZoneServer2016): ZombieInstance {
 
         const attackTarget = getChaseTarget(zombie);
         if (attackTarget) {
-          zombie.npc.lookAt(attackTarget.position);
+          zombie.npc.lookAt(attackTarget.position, dt);
         }
 
         if (zombie.stateTimer >= 2) {


### PR DESCRIPTION
## Summary
- `Npc.lookAt()` set the NPC's yaw directly to the angle toward its target with no rate limit. When an NPC gets stuck in the Attacking state against a target it can't actually reach (e.g. a player standing on top of a car), it recomputes and snaps its facing on every AI tick, which reads as an almost instant 180-degree turn.
- The same `lookAt()` call from the Attacking state exists identically in 5 melee AIs (zombie, bear, screamer, gasser, wolf), so this wasn't zombie-specific.
- `lookAt()` now accepts an optional `dt` and `maxTurnRateRadPerSec` (default 180deg/s), and clamps the per-call angle change accordingly. All 5 Attacking states now pass their tick's `dt` through. Calls that don't pass `dt` keep the previous instant-snap behavior, so nothing else is affected.

## Test plan
- [x] `npm run lint-quiet`
- [x] `npm run check_prettier`
- [x] `npx tsc -p ./tsconfig.json --noEmit`
- [x] `npm test` (74 tests, 69 passed, 5 skipped requiring Mongo, 0 failed)

---
🤖 *This PR was developed with the assistance of AI (Claude Code).*
