### PR TITLE
fix: stop corrupting uint64string fields with unpadded hex (lastLoginDate/creationDate)

### DIFF
--- a/src/servers/ZoneServer2016/classes/weapon.ts
+++ b/src/servers/ZoneServer2016/classes/weapon.ts
@@ -11,7 +11,7 @@
 //   Based on https://github.com/psemu/soe-network
 // ======================================================================
 
-import { toHex } from "../../../utils/utils";
+import { Int64String } from "../../../utils/utils";
 import { ZoneServer2016 } from "../zoneserver";
 import { BaseItem } from "./baseItem";
 import { ZoneClient2016 } from "./zoneclient";
@@ -55,7 +55,7 @@ export class Weapon {
         unknownDword1: 0,
         ammoCount: 0,
         unknownDword3: 0,
-        currentReloadCount: toHex(++this.currentReloadCount)
+        currentReloadCount: Int64String(++this.currentReloadCount)
       });
     }
   }

--- a/src/servers/ZoneServer2016/handlers/commands/commands.ts
+++ b/src/servers/ZoneServer2016/handlers/commands/commands.ts
@@ -24,7 +24,7 @@ import {
   _,
   getDifference,
   isPosInRadius,
-  toHex,
+  Int64String,
   randomIntFromInterval,
   getCurrentServerTimeWrapper,
   getDateString
@@ -1168,7 +1168,7 @@ export const commands: Array<Command> = [
       });
       client.isLoading = true;
       client.characterReleased = false;
-      client.character.lastLoginDate = toHex(Date.now());
+      client.character.lastLoginDate = Int64String(Date.now());
       server.dropAllManagedObjects(client);
       server.sendData(client, "ClientUpdate.UpdateLocation", {
         position,
@@ -1200,7 +1200,7 @@ export const commands: Array<Command> = [
       });
       targetClient.isLoading = true;
       targetClient.characterReleased = false;
-      targetClient.character.lastLoginDate = toHex(Date.now());
+      targetClient.character.lastLoginDate = Int64String(Date.now());
       server.dropAllManagedObjects(targetClient);
       const triggerLoadingScreen = !isPosInRadius(
         250,
@@ -1241,7 +1241,7 @@ export const commands: Array<Command> = [
       });
       client.isLoading = true;
       client.characterReleased = false;
-      client.character.lastLoginDate = toHex(Date.now());
+      client.character.lastLoginDate = Int64String(Date.now());
       server.dropAllManagedObjects(client);
       const triggerLoadingScreen = !isPosInRadius(
         250,

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -22,7 +22,7 @@ const debug = require("debug")("ZoneServer");
 import {
   _,
   isPosInRadius,
-  toHex,
+  Int64String,
   quat2matrix,
   eul2quat,
   isPosInRadiusWithY,
@@ -481,7 +481,7 @@ export class ZonePacketHandlers {
     }
 
     if (client.firstLoading) {
-      client.character.lastLoginDate = toHex(Date.now());
+      client.character.lastLoginDate = Int64String(Date.now());
       server.setGodMode(client, false);
       if (client.banType != "") {
         server.sendChatTextToAdmins(
@@ -1110,7 +1110,7 @@ export class ZonePacketHandlers {
     }
     if (client.isSynced) return;
     client.isSynced = true;
-    client.character.lastLoginDate = toHex(Date.now());
+    client.character.lastLoginDate = Int64String(Date.now());
     server.constructionManager.constructionPermissionsManager(server, client);
   }
   CommandExecuteCommand(

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -97,7 +97,6 @@ import {
   getRandomFromArray,
   getRandomKeyFromAnObject,
   toBigHex,
-  toHex,
   calculate_falloff,
   resolveHostAddress,
   getDifference,
@@ -1365,8 +1364,8 @@ export class ZoneServer2016 extends EventEmitter {
       character = {
         ...character,
         serverId: characterData.serverId,
-        creationDate: toHex(Date.now()),
-        lastLoginDate: toHex(Date.now()),
+        creationDate: Int64String(Date.now()),
+        lastLoginDate: Int64String(Date.now()),
         characterId: characterData.characterId,
         ownerId: characterData.ownerId,
         characterName: characterData.payload.characterName,
@@ -3595,7 +3594,7 @@ export class ZoneServer2016 extends EventEmitter {
     client.isLoading = true;
     client.characterReleased = false;
     client.blockedPositionUpdates = 0;
-    client.character.lastLoginDate = toHex(Date.now());
+    client.character.lastLoginDate = Int64String(Date.now());
     client.character.resetMetrics();
     client.character.isAlive = true;
     client.character.isRunning = false;
@@ -6366,7 +6365,7 @@ export class ZoneServer2016 extends EventEmitter {
       unknownDword1: weaponItem.weapon.ammoCount,
       ammoCount: weaponItem.weapon.ammoCount,
       unknownDword3: weaponItem.weapon.ammoCount,
-      currentReloadCount: toHex(++weaponItem.weapon.currentReloadCount)
+      currentReloadCount: Int64String(++weaponItem.weapon.currentReloadCount)
     });
     this.sendRemoteWeaponUpdateDataToAllOthers(
       client,
@@ -7592,7 +7591,7 @@ export class ZoneServer2016 extends EventEmitter {
       unknownDword1: maxAmmo,
       ammoCount: ammoCount || weaponItem.weapon.ammoCount,
       unknownDword3: maxAmmo,
-      currentReloadCount: toHex(++weaponItem.weapon.currentReloadCount)
+      currentReloadCount: Int64String(++weaponItem.weapon.currentReloadCount)
     });
   }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1241,16 +1241,6 @@ export const toBigHex = (bigInt: bigint): string => {
 };
 
 /**
- * Converts a number to a hexadecimal string.
- *
- * @param number - The number to convert.
- * @returns The hexadecimal string representation of the number.
- */
-export const toHex = (number: number): string => {
-  return `0x${number.toString(16)}`;
-};
-
-/**
  * Retrieves a random element from an array.
  *
  * @param array - The array from which to retrieve a random element.


### PR DESCRIPTION
## Summary
- `h1z1-dataschema`'s packer for `uint64string`/`int64string` fields slices fixed 2-char chunks out of the value string, assuming it is always exactly `"0x"` + 16 hex digits:
  ```js
  for (let j = 0; j < 8; j++) {
      data.writeUInt8(parseInt(value.substr(2 + (7 - j) * 2, 2), 16), offset + j);
  }
  ```
- `toHex()` (`src/utils/utils.ts`) built that string as `` `0x${number.toString(16)}` `` with **no zero-padding**. Any value whose hex representation is shorter than 16 digits — which `Date.now()` always is — packs into the wrong byte positions instead of throwing, silently corrupting the value instead of erroring out.
- `toHex()` was used for `lastLoginDate`, `creationDate` (both `uint64string` fields on the character, persisted to Mongo) and `currentReloadCount`. Once a corrupted `lastLoginDate`/`creationDate` gets saved for a character, every future attempt to send that character's data (`SendSelfToClient`) re-packs the same bad value, so the character can never load again.
- `Int64String()` already existed in the same file and pads correctly to 16 hex digits, it just wasn't used for these fields. Switched every `toHex()` call site to `Int64String()` and removed the now-unused `toHex()`.

## How this was found
Repro'd in isolation with `h1z1-dataschema` directly (no game client needed):
```
Int64String(Date.now()) -> pack -> parse : round-trips identical
toHex(Date.now())       -> pack -> parse : comes back as a completely different value
```
This matches what was already narrowed down in #2645.

---
🤖 *This PR was developed with the assistance of AI (Claude Code).*
