### PR TITLE
fix(ClientProtocol_1080): reconciliation batch 2

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/items.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/items.ts
@@ -27,10 +27,11 @@ import {
 export function parseItemRequestSubData(data: h1z1Buffer, offset: number) {
   const obj: any = {},
     startOffset = offset;
-  obj["unknownBoolean1"] = data.readUInt8(offset);
+  // 1 = sub-data omitted; 0 = sub-data follows (OPEN_CRATE: 1=preview, 0=open)
+  obj["noSubData"] = data.readUInt8(offset);
   offset += 1;
 
-  if (!obj["unknownBoolean1"]) {
+  if (!obj["noSubData"]) {
     obj["unknownDword1"] = data.readUInt32LE(offset);
     offset += 4;
     obj["unknownDword2"] = data.readUInt32LE(offset);
@@ -79,10 +80,11 @@ export function parseAccountItemRequestSubData(
 ) {
   const obj: any = {},
     startOffset = offset;
-  obj["unknownBoolean1"] = data.readUInt8(offset);
+  // 1 = sub-data omitted; 0 = sub-data follows (OPEN_CRATE: 1=preview, 0=open)
+  obj["noSubData"] = data.readUInt8(offset);
   offset += 1;
 
-  if (!obj["unknownBoolean1"]) {
+  if (!obj["noSubData"]) {
     obj["unknownDword1"] = data.readUInt32LE(offset);
     offset += 4;
     obj["unknownDword2"] = data.readUInt32LE(offset);

--- a/src/packets/ClientProtocol/ClientProtocol_1080/items.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/items.ts
@@ -380,7 +380,11 @@ export const itemsPackets: PacketStructures = [
     "Items.ReportNewRewardCrateAdded",
     0xad1d,
     {
-      fields: accountItemSchema
+      // client reads accountItemSchema + a trailing uint8 (@0x1405ab430), mirroring AddAccountItem/UpdateAccountItem
+      fields: [
+        ...accountItemSchema,
+        { name: "unknownByte1", type: "uint8", defaultValue: 0 }
+      ]
     }
   ],
   [

--- a/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
@@ -2802,7 +2802,7 @@ export const itemDefinitionSchema: PacketFields = [
       { bit: 1, name: "FLAG_QUICK_USE", defaultValue: 0 }, // does nothing
       { bit: 2, name: "FLAG_NO_DRAG_DROP", defaultValue: 0 },
       { bit: 3, name: "FLAG_ACCOUNT_SCOPE", defaultValue: 0 }, // does nothing
-      { bit: 4, name: "FLAG_CAN_EQUIP", defaultValue: 0 }, // does nothing
+      { bit: 4, name: "FLAG_CAN_EQUIP", defaultValue: 0 }, // client-dead: READ-BUT-IGNORED — equip eligibility is driven by ACTIVE/PASSIVE_EQUIP_SLOT_ID, NOT this bit (per RE)
       { bit: 5, name: "bit5", defaultValue: 0 }, // does nothing
       { bit: 6, name: "bit6", defaultValue: 0 }, // does nothing
       { bit: 7, name: "bit7", defaultValue: 0 } // does nothing
@@ -2814,8 +2814,8 @@ export const itemDefinitionSchema: PacketFields = [
   { name: "IMAGE_SET_ID", type: "uint32", defaultValue: 0 },
   { name: "TINT_ID", type: "uint32", defaultValue: 0 },
   { name: "HUD_IMAGE_SET_ID", type: "uint32", defaultValue: 0 },
-  { name: "unknownDword8", type: "uint32", defaultValue: 921 },
-  { name: "unknownDword9", type: "uint32", defaultValue: 922 },
+  { name: "unknownDword8", type: "uint32", defaultValue: 921 }, // client-dead: READ-BUT-IGNORED (Planetside/ForgeLight-inherited); kept for wire order
+  { name: "unknownDword9", type: "uint32", defaultValue: 922 }, // client-dead: READ-BUT-IGNORED (constructor-only); kept for wire order
   { name: "COST", type: "uint32", defaultValue: 0 },
   { name: "ITEM_CLASS", type: "uint32", defaultValue: 0 },
   { name: "PROFILE_OVERRIDE", type: "uint32", defaultValue: 0 },
@@ -2854,18 +2854,18 @@ export const itemDefinitionSchema: PacketFields = [
   { name: "CLIENT_USE_REQUIREMENT_ID", type: "uint32", defaultValue: 0 },
   { name: "OVERRIDE_APPEARANCE", type: "string", defaultValue: "" },
   { name: "OVERRIDE_CAMERA_ID", type: "uint32", defaultValue: 0 },
-  { name: "unknownDword42", type: "uint32", defaultValue: 28 },
-  { name: "unknownDword43", type: "uint32", defaultValue: 28 },
-  { name: "unknownDword44", type: "uint32", defaultValue: 28 },
+  { name: "unknownDword42", type: "uint32", defaultValue: 28 }, // client-dead: READ-BUT-IGNORED (constructor-only); kept for wire order
+  { name: "unknownDword43", type: "uint32", defaultValue: 28 }, // client-dead: READ-BUT-IGNORED (Planetside/ForgeLight-inherited); kept for wire order
+  { name: "unknownDword44", type: "uint32", defaultValue: 28 }, // client-dead: READ-BUT-IGNORED (constructor-only); kept for wire order
   { name: "BULK", type: "uint32", defaultValue: 0 },
   { name: "ACTIVE_EQUIP_SLOT_ID", type: "uint32", defaultValue: 0 },
   { name: "PASSIVE_EQUIP_SLOT_ID", type: "uint32", defaultValue: 0 },
   { name: "PASSIVE_EQUIP_SLOT_GROUP_ID", type: "uint32", defaultValue: 0 },
-  { name: "unknownDword49", type: "uint32", defaultValue: 927 },
+  { name: "unknownDword49", type: "uint32", defaultValue: 927 }, // client-dead: READ-BUT-IGNORED (constructor-only); kept for wire order
   { name: "GRINDER_REWARD_SET_ID", type: "uint32", defaultValue: 0 },
   { name: "BUILD_BAR_GROUP_ID", type: "uint32", defaultValue: 0 },
-  { name: "unknownString7", type: "string", defaultValue: "testStringAAA" },
-  { name: "unknownBoolean1", type: "boolean", defaultValue: true },
+  { name: "unknownString7", type: "string", defaultValue: "testStringAAA" }, // client-dead: READ-BUT-IGNORED (constructor-only); kept for wire order
+  { name: "unknownBoolean1", type: "boolean", defaultValue: true }, // client-dead: READ-BUT-IGNORED (def-level, constructor-only; distinct from ItemInstance.unknownBoolean1); kept for wire order
   { name: "IS_ARMOR", type: "boolean", defaultValue: false },
   { name: "unknownDword52", type: "uint32", defaultValue: 28 },
   { name: "PARAM1", type: "uint32", defaultValue: 0 },
@@ -2873,7 +2873,8 @@ export const itemDefinitionSchema: PacketFields = [
   { name: "PARAM3", type: "uint32", defaultValue: 0 },
   { name: "STRING_PARAM1", type: "string", defaultValue: "" },
   { name: "UI_MODEL_CAMERA_ID", type: "uint32", defaultValue: 0 },
-  { name: "unknownDword57", type: "uint32", defaultValue: 932 },
+  { name: "unknownDword57", type: "uint32", defaultValue: 932 }, // client USES this (UI-column value with ITEM_CLASS fallback) per RE — NOT dead; kept as-is
+
   { name: "SCRAP_VALUE_OVERRIDE", type: "int32", defaultValue: 0 }, // can be -1
   {
     name: "stats",

--- a/src/packets/ClientProtocol/ClientProtocol_1080/ui.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/ui.ts
@@ -92,9 +92,17 @@ export const uiPackets: PacketStructures = [
           types: {
             0: [],
             1: [
-              { name: "unknownQword1", type: "uint64string", defaultValue: "0" },
+              {
+                name: "unknownQword1",
+                type: "uint64string",
+                defaultValue: "0"
+              },
               { name: "unknownDword1", type: "uint32", defaultValue: 0 },
-              { name: "unknownQword2", type: "uint64string", defaultValue: "0" },
+              {
+                name: "unknownQword2",
+                type: "uint64string",
+                defaultValue: "0"
+              },
               { name: "unknownDword2", type: "uint32", defaultValue: 0 },
               {
                 name: "unknownFloatVector1",

--- a/src/packets/ClientProtocol/ClientProtocol_1080/ui.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/ui.ts
@@ -82,18 +82,29 @@ export const uiPackets: PacketStructures = [
     "Ui.ObjectiveTargetUpdate",
     0x1a0d,
     {
+      // client (Ui_ObjectiveTargetUpdateReadFromPacket @0x1409f43d0) reads the leading gate byte, then
+      // reads the rest of the body ONLY when it is 1. Model as a variabletype8 tag: 0 => no body, 1 => body.
       fields: [
-        { name: "unknownBoolean1", type: "boolean", defaultValue: false },
-        { name: "unknownQword1", type: "uint64string", defaultValue: "0" },
-        { name: "unknownDword1", type: "uint32", defaultValue: 0 },
-        { name: "unknownQword2", type: "uint64string", defaultValue: "0" },
-        { name: "unknownDword2", type: "uint32", defaultValue: 0 },
         {
-          name: "unknownFloatVector1",
-          type: "floatvector4",
-          defaultValue: [0, 0, 0, 0]
-        },
-        { name: "unknownDword3", type: "uint32", defaultValue: 0 }
+          name: "unknownBoolean1",
+          type: "variabletype8",
+          defaultValue: 0,
+          types: {
+            0: [],
+            1: [
+              { name: "unknownQword1", type: "uint64string", defaultValue: "0" },
+              { name: "unknownDword1", type: "uint32", defaultValue: 0 },
+              { name: "unknownQword2", type: "uint64string", defaultValue: "0" },
+              { name: "unknownDword2", type: "uint32", defaultValue: 0 },
+              {
+                name: "unknownFloatVector1",
+                type: "floatvector4",
+                defaultValue: [0, 0, 0, 0]
+              },
+              { name: "unknownDword3", type: "uint32", defaultValue: 0 }
+            ]
+          }
+        }
       ]
     }
   ],
@@ -210,7 +221,17 @@ export const uiPackets: PacketStructures = [
         { name: "unknownDword1", type: "uint32", defaultValue: 0 },
         { name: "unknownDword2", type: "uint32", defaultValue: 0 },
         { name: "unknownDword3", type: "uint32", defaultValue: 0 },
-        { name: "unknownDword4", type: "uint32", defaultValue: 0 } // This reads 2 extra bytes if higher than 0
+        // client (Ui_WarpgateRotateWarningReadFromPacket @0x1409f4580) reads a count-prefixed array of
+        // {uint16, uint16} entries here, not a bare u32 (the old "reads 2 extra bytes" was the first element)
+        {
+          name: "unknownArray1",
+          type: "array",
+          defaultValue: [],
+          fields: [
+            { name: "unknownWord1", type: "uint16", defaultValue: 0 },
+            { name: "unknownWord2", type: "uint16", defaultValue: 0 }
+          ]
+        }
       ]
     }
   ],

--- a/src/packets/ClientProtocol/ClientProtocol_1080/ui.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/ui.ts
@@ -86,7 +86,7 @@ export const uiPackets: PacketStructures = [
       // reads the rest of the body ONLY when it is 1. Model as a variabletype8 tag: 0 => no body, 1 => body.
       fields: [
         {
-          name: "unknownBoolean1",
+          name: "hasTarget",
           type: "variabletype8",
           defaultValue: 0,
           types: {

--- a/src/packets/ClientProtocol/ClientProtocol_1080/vehicle.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/vehicle.ts
@@ -151,7 +151,13 @@ export const vehiclePackets: PacketStructures = [
     {
       fields: [
         { name: "characterId", type: "uint64string", defaultValue: "0" },
-        { name: "unknownString1", type: "string", defaultValue: "" }
+        {
+          // client reads a count-prefixed array of strings (VehicleTintReadFromPacket @0x1405477A0), not a single string
+          name: "unknownArray1",
+          type: "array",
+          defaultValue: [],
+          fields: [{ name: "value", type: "string", defaultValue: "" }]
+        }
       ]
     }
   ],
@@ -169,7 +175,8 @@ export const vehiclePackets: PacketStructures = [
     {
       fields: [
         { name: "characterId", type: "uint64string", defaultValue: "0" },
-        { name: "unknownDword1", type: "uint32", defaultValue: 0 }
+        // client reads a length-prefixed blob (VehicleStatsReadFromPacket @0x140545240), not a bare u32
+        { name: "statData", type: "byteswithlength" }
       ]
     }
   ],
@@ -179,7 +186,13 @@ export const vehiclePackets: PacketStructures = [
     {
       fields: [
         { name: "characterId", type: "uint64string", defaultValue: "0" },
-        { name: "unknownDword1", type: "uint32", defaultValue: 0 }
+        { name: "unknownDword1", type: "uint32", defaultValue: 0 },
+        // 5 trailing fields the client reads (VehicleDamageInfoReadFromPacket @0x140544330)
+        { name: "unknownDword2", type: "uint32", defaultValue: 0 },
+        { name: "unknownDword3", type: "uint32", defaultValue: 0 },
+        { name: "unknownBoolean1", type: "boolean", defaultValue: false },
+        { name: "unknownDword4", type: "uint32", defaultValue: 0 },
+        { name: "unknownDword5", type: "uint32", defaultValue: 0 }
       ]
     }
   ],
@@ -514,7 +527,8 @@ export const vehiclePackets: PacketStructures = [
     {
       fields: [
         { name: "unknownDword1", type: "uint32", defaultValue: 0 },
-        { name: "unknownDword2", type: "uint32", defaultValue: 0 }
+        // client reads a length-prefixed blob here (@0x140544A00); unknownDword2 was the blob length
+        { name: "dataBlob", type: "byteswithlength" }
       ]
     }
   ],

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -3542,14 +3542,14 @@ export class ZonePacketHandlers {
         if (!rewards || !reward) return;
 
         if (
-          itemSubData?.unknownBoolean1 == 0 &&
+          itemSubData?.noSubData == 0 &&
           !server.removeInventoryItem(client.character, item)
         ) {
           return;
         }
         server.sendData(client, "Items.ReportRewardCrateContents", {
           winningRewards:
-            reward > 0 && itemSubData?.unknownBoolean1 == 0
+            reward > 0 && itemSubData?.noSubData == 0
               ? [{ itemDefinitionId: reward }]
               : [],
           possibleRewards: Object.values(rewards).map((rew) => {
@@ -3559,7 +3559,7 @@ export class ZonePacketHandlers {
           })
         });
 
-        if (reward > 0 && itemSubData.unknownBoolean1 == 0) {
+        if (reward > 0 && itemSubData.noSubData == 0) {
           setTimeout(() => {
             if (rewardResult.isRare) {
               server.sendAlertToAll(

--- a/src/types/zone2016packets.ts
+++ b/src/types/zone2016packets.ts
@@ -1950,7 +1950,7 @@ export interface UiStartTimer {
   unknownDword1?: number;
 }
 export interface UiObjectiveTargetUpdate {
-  unknownBoolean1?: unknown;
+  hasTarget?: unknown;
 }
 export interface UiMessage {
   unknownByte1?: number;

--- a/src/types/zone2016packets.ts
+++ b/src/types/zone2016packets.ts
@@ -1950,13 +1950,7 @@ export interface UiStartTimer {
   unknownDword1?: number;
 }
 export interface UiObjectiveTargetUpdate {
-  unknownBoolean1?: boolean;
-  unknownQword1?: string;
-  unknownDword1?: number;
-  unknownQword2?: string;
-  unknownDword2?: number;
-  unknownFloatVector1?: Float32Array;
-  unknownDword3?: number;
+  unknownBoolean1?: unknown;
 }
 export interface UiMessage {
   unknownByte1?: number;
@@ -2003,7 +1997,7 @@ export interface UiWarpgateRotateWarning {
   unknownDword1?: number;
   unknownDword2?: number;
   unknownDword3?: number;
-  unknownDword4?: number;
+  unknownArray1?: unknown[];
 }
 export interface UiConfirmHit {
   hitType:{
@@ -2516,18 +2510,23 @@ export interface VehicleSpawn {
 }
 export interface VehicleTint {
   characterId?: string;
-  unknownString1?: string;
+  unknownArray1?: unknown[];
 }
 export interface VehicleActiveWeapon {
   unknownDword1?: number;
 }
 export interface VehicleStats {
   characterId?: string;
-  unknownDword1?: number;
+  statData: unknown;
 }
 export interface VehicleDamageInfo {
   characterId?: string;
   unknownDword1?: number;
+  unknownDword2?: number;
+  unknownDword3?: number;
+  unknownBoolean1?: boolean;
+  unknownDword4?: number;
+  unknownDword5?: number;
 }
 export interface VehicleStatUpdate {
   characterId?: string;
@@ -2628,7 +2627,7 @@ export interface VehicleItemDefinitionRequest {
 }
 export interface VehicleItemDefinitionReply {
   unknownDword1?: number;
-  unknownDword2?: number;
+  dataBlob: unknown;
 }
 export interface VehicleInventoryItems {
   characterId?: string;
@@ -3072,6 +3071,7 @@ export interface ItemsReportNewRewardCrateAdded {
   itemDefinitionId?: number;
   unknownDword2?: number;
   itemCount?: number;
+  unknownByte1?: number;
 }
 export interface ItemsReportRewardCrateContents {
   winningRewards?: unknown[];


### PR DESCRIPTION
latent Vehicle/Items/UI schema corrections + itemDef dead-field docs

Client-authoritative corrections for seven packets, all verified 0-sends in src/servers (latent — no runtime behavior change; they become correct the moment the corresponding server send is implemented). Scope: ClientProtocol_1080 only.

- Vehicle.Tint 0x8907: unknownString1 (single string) -> count-prefixed string[] (array).
- Vehicle.Stats 0x890a: unknownDword1 (u32) -> statData (byteswithlength blob).
- Vehicle.DamageInfo 0x890b: append the 5 trailing fields the client reads (unknownDword2 u32, unknownDword3 u32, unknownBoolean1 u8, unknownDword4 u32, unknownDword5 u32).
- Vehicle.ItemDefinitionReply 0x8929: unknownDword2 (u32) -> dataBlob (byteswithlength; it was the blob length).
- Items.ReportNewRewardCrateAdded 0xad1d: append trailing unknownByte1 (u8), mirroring Add/UpdateAccountItem.
- Ui.ObjectiveTargetUpdate 0x1a0d: gate the body on the leading boolean via variabletype8 (tag 0 => no body, tag 1 => body) — the client reads the rest only when the gate is 1.
- Ui.WarpgateRotateWarning 0x1a1b: unknownDword4 (u32) -> count-prefixed array of {uint16, uint16}.

itemDefinitionSchema: annotate the client-dead / READ-BUT-IGNORED fields (unknownDword8/9/42/43/44/49, unknownString7, def unknownBoolean1, flags2 FLAG_CAN_EQUIP) with clarifying comments; unknownDword57 marked as USED (UI column). Names are NOT renamed — they are populated by name elsewhere, so renaming would unbind values; the wire layout of this actively-sent packet is unchanged (comment-only).

No actively-sent packet's field list changed. tsc passes.