### PR TITLE
feat(weapons): crossbow firemode / ammo-type switching + fire/explosive arrow effects

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/shared.ts
@@ -1500,8 +1500,8 @@ export function packItemWeaponData(obj: any) {
               defaultValue: [],
               fields: [
                 { name: "unknownByte1", type: "uint8", defaultValue: 0 },
-                { name: "unknownDword1", type: "uint32", defaultValue: 0 },
-                { name: "unknownDword2", type: "uint32", defaultValue: 0 },
+                { name: "firemodeIndex", type: "uint32", defaultValue: 0 },
+                { name: "firemodeId", type: "uint32", defaultValue: 0 },
                 { name: "unknownDword3", type: "uint32", defaultValue: 0 }
               ]
             }
@@ -1828,12 +1828,12 @@ export const remoteWeaponSchema: PacketFields = [
         defaultValue: [],
         fields: [
           {
-            name: "unknownDword1",
+            name: "firemodeIndex",
             type: "uint32",
             defaultValue: 0
           },
           {
-            name: "unknownDword2",
+            name: "firemodeId",
             type: "uint32",
             defaultValue: 0
           }
@@ -1892,8 +1892,8 @@ export const remoteWeaponSchema: PacketFields = [
 ];
 
 export const remoteWeaponExtraSchema: PacketFields = [
-  { name: "unknownByte1", type: "int8", defaultValue: 0 },
-  { name: "unknownByte2", type: "int8", defaultValue: 0 },
+  { name: "firegroupIndex", type: "int8", defaultValue: 0 },
+  { name: "firemodeIndex", type: "int8", defaultValue: 0 },
   { name: "unknownByte3", type: "int8", defaultValue: 0 },
   { name: "unknownByte4", type: "int8", defaultValue: 0 },
   { name: "unknownByte5", type: "uint8", defaultValue: 0 },

--- a/src/servers/ZoneServer2016/classes/weapon.ts
+++ b/src/servers/ZoneServer2016/classes/weapon.ts
@@ -32,6 +32,17 @@ export class Weapon {
   /** Required for the reload packet to work every time (especially shotgun) */
   currentReloadCount = 0;
 
+  /**
+   * Selected firegroup - index into the weapon definition's FIRE_GROUPS array. For multi-firegroup
+   * weapons (e.g. the crossbow: 0=wooden, 1=flaming, 2=explosive arrow) the client cycles this with "B"
+   * and notifies the server via Weapon.SwitchFireModeRequest (0x830c); it drives which ammo/projectile is
+   * used. Single-firegroup weapons stay at 0 and behave exactly as before.
+   */
+  currentFiregroupIndex = 0;
+
+  /** Selected firemode within the current firegroup (hip 0 / ADS 1). Index into the firegroup's FIRE_MODES. */
+  currentFiremodeIndex = 0;
+
   constructor(item: BaseItem, ammoCount?: number) {
     this.itemGuid = item.itemGuid;
     this.itemDefinitionId = item.itemDefinitionId;
@@ -43,7 +54,11 @@ export class Weapon {
     client.character.lootItem(
       server,
       server.generateItem(
-        server.getWeaponAmmoId(this.itemDefinitionId),
+        server.getWeaponAmmoId(
+          this.itemDefinitionId,
+          this.currentFiregroupIndex,
+          this.currentFiremodeIndex
+        ),
         this.ammoCount
       )
     );

--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -1228,8 +1228,8 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
               unknownArray1: firemodes.map((firemode: any, j: number) => {
                 return {
                   unknownByte1: 0,
-                  unknownDword1: j,
-                  unknownDword2: firemode.FIRE_MODE_ID,
+                  firemodeIndex: j,
+                  firemodeId: firemode.FIRE_MODE_ID,
                   unknownDword3: 0
                 };
               })

--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -1194,6 +1194,10 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
 
   pGetItemWeaponData(server: ZoneServer2016, slot: BaseItem) {
     if (slot.weapon) {
+      const weaponDefinition = server.getWeaponDefinition(
+          server.getItemDefinition(slot.itemDefinitionId)?.PARAM1 ?? 0
+        ),
+        firegroups: Array<any> = weaponDefinition?.FIRE_GROUPS || [];
       return {
         isWeapon: true, // not sent to client, only used as a flag for pack function
         unknownData1: {
@@ -1207,29 +1211,30 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
           )
             ? [{ ammoSlot: slot.weapon?.ammoCount }]
             : [],
-          firegroups: [
-            {
-              firegroupId: server.getWeaponDefinition(
-                server.getItemDefinition(slot.itemDefinitionId)?.PARAM1 ?? 0
-              )?.FIRE_GROUPS[slot.weapon?.currentFiregroupIndex ?? 0]
-                ?.FIRE_GROUP_ID,
-              unknownArray1: [
-                // maybe firemodes?
-                {
+          // Emit ONE entry per weapon-def firegroup (mirrors pGetRemoteWeaponData). The client reads this
+          // array8's LENGTH as weapon.arrayFireGroupLength; IsFireModeValid requires it >= 2 for "B"
+          // (SwitchFireGroup) to cycle to group 1/2 and send Weapon.SwitchFireModeRequest (0x830c). The
+          // previous length-1 array made every multi-firegroup weapon (crossbow: wooden/flaming/explosive)
+          // report a single firegroup, so B no-op'd. Single-firegroup weapons still emit exactly 1 entry ->
+          // no behavior change. Firemodes mirror the remote path (client also repopulates from ReferenceData
+          // by FIRE_MODE_ID).
+          firegroups: firegroups.map((firegroup: any) => {
+            const firegroupDef = server.getFiregroupDefinition(
+                firegroup.FIRE_GROUP_ID
+              ),
+              firemodes = firegroupDef?.FIRE_MODES || [];
+            return {
+              firegroupId: firegroup.FIRE_GROUP_ID,
+              unknownArray1: firemodes.map((firemode: any, j: number) => {
+                return {
                   unknownByte1: 0,
-                  unknownDword1: 0,
-                  unknownDword2: 0,
+                  unknownDword1: j,
+                  unknownDword2: firemode.FIRE_MODE_ID,
                   unknownDword3: 0
-                },
-                {
-                  unknownByte1: 0,
-                  unknownDword1: 0,
-                  unknownDword2: 0,
-                  unknownDword3: 0
-                }
-              ]
-            }
-          ],
+                };
+              })
+            };
+          }),
           equipmentSlotId: this.getActiveEquipmentSlot(slot),
           unknownByte2: 1,
           unknownDword1: 0,

--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -417,8 +417,10 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
         item.itemGuid,
         "Update.SwitchFireMode",
         {
-          firegroupIndex: 0,
-          firemodeIndex: 0
+          // Re-send the weapon's tracked selection rather than a hard 0/0, so a firegroup chosen
+          // before this (re-)equip survives. The Weapon runtime is carried across equip by LoadoutItem.
+          firegroupIndex: item.weapon?.currentFiregroupIndex ?? 0,
+          firemodeIndex: item.weapon?.currentFiremodeIndex ?? 0
         }
       );
     }
@@ -574,7 +576,11 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
 
     if (loadoutItem.weapon) {
       const ammo = server.generateItem(
-        server.getWeaponAmmoId(loadoutItem.itemDefinitionId),
+        server.getWeaponAmmoId(
+          loadoutItem.itemDefinitionId,
+          loadoutItem.weapon.currentFiregroupIndex,
+          loadoutItem.weapon.currentFiremodeIndex
+        ),
         loadoutItem.weapon.ammoCount
       );
       if (
@@ -1194,14 +1200,19 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
           unknownBoolean1: false
         },
         unknownData2: {
-          ammoSlots: server.getWeaponAmmoId(slot.itemDefinitionId)
+          ammoSlots: server.getWeaponAmmoId(
+            slot.itemDefinitionId,
+            slot.weapon?.currentFiregroupIndex ?? 0,
+            slot.weapon?.currentFiremodeIndex ?? 0
+          )
             ? [{ ammoSlot: slot.weapon?.ammoCount }]
             : [],
           firegroups: [
             {
               firegroupId: server.getWeaponDefinition(
                 server.getItemDefinition(slot.itemDefinitionId)?.PARAM1 ?? 0
-              )?.FIRE_GROUPS[0]?.FIRE_GROUP_ID,
+              )?.FIRE_GROUPS[slot.weapon?.currentFiregroupIndex ?? 0]
+                ?.FIRE_GROUP_ID,
               unknownArray1: [
                 // maybe firemodes?
                 {

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1238,8 +1238,8 @@ export class Character2016 extends BaseFullCharacter {
       firegroups = weaponDefinition.FIRE_GROUPS;
     return {
       guid: item.itemGuid,
-      unknownByte1: 0, // firegroupIndex (default 0)?
-      unknownByte2: 0, // MOST LIKELY firemodeIndex?
+      unknownByte1: item.weapon?.currentFiregroupIndex ?? 0, // firegroupIndex
+      unknownByte2: item.weapon?.currentFiremodeIndex ?? 0, // firemodeIndex
       unknownByte3: -1,
       unknownByte4: -1,
       unknownByte5: 1,
@@ -1949,8 +1949,8 @@ export class Character2016 extends BaseFullCharacter {
         item.itemGuid,
         "Update.SwitchFireMode",
         {
-          firegroupIndex: 0,
-          firemodeIndex: 0
+          firegroupIndex: item.weapon?.currentFiregroupIndex ?? 0,
+          firemodeIndex: item.weapon?.currentFiremodeIndex ?? 0
         }
       );
     });

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1220,8 +1220,8 @@ export class Character2016 extends BaseFullCharacter {
           unknownArray1: firegroup
             ? firemodes.map((firemode: any, j: number) => {
                 return {
-                  unknownDword1: j,
-                  unknownDword2: firemode.FIRE_MODE_ID
+                  firemodeIndex: j,
+                  firemodeId: firemode.FIRE_MODE_ID
                 };
               })
             : [] // probably firemodes
@@ -1238,8 +1238,8 @@ export class Character2016 extends BaseFullCharacter {
       firegroups = weaponDefinition.FIRE_GROUPS;
     return {
       guid: item.itemGuid,
-      unknownByte1: item.weapon?.currentFiregroupIndex ?? 0, // firegroupIndex
-      unknownByte2: item.weapon?.currentFiremodeIndex ?? 0, // firemodeIndex
+      firegroupIndex: item.weapon?.currentFiregroupIndex ?? 0,
+      firemodeIndex: item.weapon?.currentFiremodeIndex ?? 0,
       unknownByte3: -1,
       unknownByte4: -1,
       unknownByte5: 1,

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -2586,7 +2586,11 @@ export class ZonePacketHandlers {
             return;
           }
           if (item.weapon) {
-            const weaponAmmoId = server.getWeaponAmmoId(item.itemDefinitionId);
+            const weaponAmmoId = server.getWeaponAmmoId(
+              item.itemDefinitionId,
+              item.weapon.currentFiregroupIndex,
+              item.weapon.currentFiremodeIndex
+            );
             if (item.itemDefinitionId != weaponAmmoId) {
               const ammo = server.generateItem(
                 weaponAmmoId,
@@ -3192,6 +3196,19 @@ export class ZonePacketHandlers {
         server.reloadInterrupt(client, weaponItem);
         break;
       case "Weapon.SwitchFireModeRequest":
+        // Persist the client's firegroup/firemode selection FIRST, before any of the early-returns
+        // below. The client is authoritative for cycling firegroups (e.g. crossbow "B":
+        // wooden -> flaming -> explosive) and only notifies us here; if we bailed before recording it
+        // (empty clip, or the ADS firemodeIndex==1 workaround) the server would keep using the old
+        // arrow. The stored selection drives ammo/projectile resolution (getWeaponAmmoId,
+        // createProjectileNpc). Single-firegroup weapons simply keep {0, 0}.
+        if (weaponItem.weapon) {
+          weaponItem.weapon.currentFiregroupIndex =
+            packet.packet.firegroupIndex ?? 0;
+          weaponItem.weapon.currentFiremodeIndex =
+            packet.packet.firemodeIndex ?? 0;
+        }
+
         // workaround so aiming in doesn't sometimes make the shooting sound
         if (!weaponItem.weapon?.ammoCount) return;
 

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -3212,10 +3212,6 @@ export class ZonePacketHandlers {
             newFiregroupIndex !== weapon.currentFiregroupIndex &&
             weapon.ammoCount > 0
           ) {
-            // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
-            console.log(
-              `[crossbow-reload] firegroup change ${weapon.currentFiregroupIndex}->${newFiregroupIndex}; unloading ${weapon.ammoCount} of ammoId=${server.getWeaponAmmoId(weaponItem.itemDefinitionId, weapon.currentFiregroupIndex, weapon.currentFiremodeIndex)}`
-            );
             weapon.unload(server, client);
           }
 

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -3195,37 +3195,56 @@ export class ZonePacketHandlers {
       case "Weapon.ReloadInterrupt":
         server.reloadInterrupt(client, weaponItem);
         break;
-      case "Weapon.SwitchFireModeRequest":
-        // Persist the client's firegroup/firemode selection FIRST, before any of the early-returns
-        // below. The client is authoritative for cycling firegroups (e.g. crossbow "B":
-        // wooden -> flaming -> explosive) and only notifies us here; if we bailed before recording it
-        // (empty clip, or the ADS firemodeIndex==1 workaround) the server would keep using the old
-        // arrow. The stored selection drives ammo/projectile resolution (getWeaponAmmoId,
-        // createProjectileNpc). Single-firegroup weapons simply keep {0, 0}.
-        if (weaponItem.weapon) {
-          weaponItem.weapon.currentFiregroupIndex =
-            packet.packet.firegroupIndex ?? 0;
-          weaponItem.weapon.currentFiremodeIndex =
-            packet.packet.firemodeIndex ?? 0;
+      case "Weapon.SwitchFireModeRequest": {
+        const weapon = weaponItem.weapon,
+          newFiregroupIndex = packet.packet.firegroupIndex ?? 0,
+          newFiremodeIndex = packet.packet.firemodeIndex ?? 0;
+
+        if (weapon) {
+          // A multi-firegroup weapon (e.g. crossbow) changes the LOADED ammo TYPE when the client cycles
+          // to a different firegroup (wooden -> flaming -> explosive). The already-loaded arrow must be
+          // unloaded first: unload() refunds it to inventory (resolved via the weapon's CURRENT/old
+          // firegroup index) and resets the magazine to 0 + re-syncs the client. Without this the magazine
+          // still counts the old arrow, so the follow-up reload hits `ammoCount >= clipSize` and
+          // early-returns in handleWeaponReload, leaving the new type stuck at 0/clip. Do it BEFORE
+          // overwriting the index (unload resolves the refund ammo from the current selection).
+          if (
+            newFiregroupIndex !== weapon.currentFiregroupIndex &&
+            weapon.ammoCount > 0
+          ) {
+            // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
+            console.log(
+              `[crossbow-reload] firegroup change ${weapon.currentFiregroupIndex}->${newFiregroupIndex}; unloading ${weapon.ammoCount} of ammoId=${server.getWeaponAmmoId(weaponItem.itemDefinitionId, weapon.currentFiregroupIndex, weapon.currentFiremodeIndex)}`
+            );
+            weapon.unload(server, client);
+          }
+
+          // Persist the client's firegroup/firemode selection (before the early-returns below) so
+          // ammo/projectile resolution always reflects the client's choice, even on an empty clip or ADS.
+          // Single-firegroup weapons simply keep {0, 0}.
+          weapon.currentFiregroupIndex = newFiregroupIndex;
+          weapon.currentFiremodeIndex = newFiremodeIndex;
         }
 
         // workaround so aiming in doesn't sometimes make the shooting sound
-        if (!weaponItem.weapon?.ammoCount) return;
+        // (also skips the broadcast right after an ammo-type unload, when the weapon is momentarily empty)
+        if (!weapon?.ammoCount) return;
 
         // temp workaround to fix 308 sound while aiming
         // this workaround applies to all weapons
-        if (packet.packet.firemodeIndex == 1) return;
+        if (newFiremodeIndex == 1) return;
         server.sendRemoteWeaponUpdateDataToAllOthers(
           client,
           client.character.transientId,
           weaponItem.itemGuid,
           "Update.SwitchFireMode",
           {
-            firegroupIndex: packet.packet.firegroupIndex,
-            firemodeIndex: packet.packet.firemodeIndex
+            firegroupIndex: newFiregroupIndex,
+            firemodeIndex: newFiremodeIndex
           }
         );
         break;
+      }
       case "Weapon.WeaponFireHint":
         debug("WeaponFireHint");
         break;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -9138,17 +9138,7 @@ export class ZoneServer2016 extends EventEmitter {
     if (!weaponItem.weapon) return;
     if (weaponItem.weapon.reloadTimer) return;
     const maxAmmo = this.getWeaponMaxAmmo(weaponItem.itemDefinitionId); // max clip size
-    // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
-    console.log(
-      `[crossbow-reload] reload req item=${weaponItem.itemDefinitionId} fg=${weaponItem.weapon.currentFiregroupIndex} fm=${weaponItem.weapon.currentFiremodeIndex} ammoCount=${weaponItem.weapon.ammoCount} maxAmmo=${maxAmmo} ammoId=${this.getWeaponAmmoId(weaponItem.itemDefinitionId, weaponItem.weapon.currentFiregroupIndex, weaponItem.weapon.currentFiremodeIndex)}`
-    );
-    if (weaponItem.weapon.ammoCount >= maxAmmo) {
-      // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
-      console.log(
-        `[crossbow-reload] EARLY RETURN: ammoCount ${weaponItem.weapon.ammoCount} >= maxAmmo ${maxAmmo} (magazine still holds old ammo type?)`
-      );
-      return;
-    }
+    if (weaponItem.weapon.ammoCount >= maxAmmo) return;
     // force 0 firestate so gun doesnt shoot randomly after reloading
     this.sendRemoteWeaponUpdateDataToAllOthers(
       client,
@@ -9293,24 +9283,11 @@ export class ZoneServer2016 extends EventEmitter {
         reloadAmount =
           reserveAmmo >= maxReloadAmount ? maxReloadAmount : reserveAmmo; // actual amount able to reload
 
-      // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
-      console.log(
-        `[crossbow-reload] generic reload ammoId=${weaponAmmoId} reserve=${reserveAmmo} maxReload=${maxReloadAmount} reloadAmount=${reloadAmount}`
-      );
-
       if (
         !this.removeInventoryItems(client.character, weaponAmmoId, reloadAmount)
       ) {
-        // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
-        console.log(
-          `[crossbow-reload] removeInventoryItems FAILED ammoId=${weaponAmmoId} amount=${reloadAmount}`
-        );
         return;
       }
-      // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
-      console.log(
-        `[crossbow-reload] loaded ${reloadAmount} of ammoId=${weaponAmmoId}; new ammoCount=${weaponItem.weapon.ammoCount + reloadAmount}`
-      );
       this.sendWeaponReload(
         client,
         weaponItem,

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -3541,6 +3541,98 @@ export class ZoneServer2016 extends EventEmitter {
       await vehicle.OnExplosiveHit(this, sourceEntity);
     }
   }
+
+  igniteArrowTarget(target: BaseEntity) {
+    // reuse the molotov on-fire effect for players; NPCs have no character-effect loop so run a
+    // bounded burn mirroring it (same effect id + damage cadence)
+    if (target instanceof Character) {
+      this.applyCharacterEffect(
+        target,
+        Effects.PFX_Fire_Person_loop,
+        700,
+        10000
+      );
+      return;
+    }
+    if (!(target instanceof Npc)) return;
+    let ticks = 10;
+    const burn = setInterval(() => {
+      if (ticks-- <= 0 || !target.isAlive || !this._npcs[target.characterId]) {
+        clearInterval(burn);
+        return;
+      }
+      target.damage(this, {
+        entity: "Character.CharacterEffect",
+        damage: 700
+      });
+      this.sendDataToAllWithSpawnedEntity(
+        this._npcs,
+        target.characterId,
+        "Command.PlayDialogEffect",
+        {
+          characterId: target.characterId,
+          effectId: Effects.PFX_Fire_Person_loop
+        }
+      );
+    }, 1000);
+  }
+
+  explosiveArrowDetonate(target: BaseEntity, client: Client) {
+    const position = target.state.position;
+
+    // networked blast visual
+    this.sendCompositeEffectToAllInRange(
+      600,
+      target.characterId,
+      position,
+      Effects.PFX_Impact_Explosion_FragGrenade_Default_08m
+    );
+
+    // players (biofuel/ethanol-style AoE, radius 5) - reuse the explosive damage model
+    if (!this.isPvE) {
+      const [cx0, cx1, cz0, cz1] = ZoneServer2016._charGridRange(position, 5);
+      for (let cx = cx0; cx <= cx1; cx++) {
+        for (let cz = cz0; cz <= cz1; cz++) {
+          const bucket = this._charSpatialMap.get(`${cx},${cz}`);
+          if (!bucket) continue;
+          for (const c of bucket) {
+            if (isPosInRadiusWithY(5, c.character.state.position, position, 3))
+              c.character.OnExplosiveHit(this, target);
+          }
+        }
+      }
+    }
+
+    // zombies / npcs
+    for (const npcId in this._npcs) {
+      const npc = this._npcs[npcId];
+      if (isPosInRadius(5, npc.state.position, position))
+        npc.OnExplosiveHit(this, target);
+    }
+
+    // construction / structures the arrow hits
+    const explosiveArrowConstructionDamage = this.baseConstructionDamage / 22;
+    for (const gridCell of this.getGridCellsInRadius(position, 10)) {
+      for (const object of gridCell.objects) {
+        if (
+          !(
+            object instanceof ConstructionChildEntity ||
+            object instanceof ConstructionDoor ||
+            object instanceof LootableConstructionEntity
+          )
+        )
+          continue;
+        if (getDistance(object.state.position, position) > object.damageRange)
+          continue;
+        object.damage(this, {
+          entity: client.character.characterId,
+          damage: explosiveArrowConstructionDamage,
+          explosive: true
+        });
+      }
+    }
+  }
+
   createProjectileNpc(client: Client, data: any) {
     const fireHint = client.fireHints[data.projectileId];
     if (!fireHint) return;
@@ -4370,6 +4462,23 @@ export class ZoneServer2016 extends EventEmitter {
       hitReport: packet.hitReport,
       message: hitValidation.message
     });
+
+    if (!hitValidation.isValid) return;
+    // per-arrow on-hit effects for multi-firegroup weapons (crossbow flaming/explosive arrows)
+    switch (
+      this.getWeaponAmmoId(
+        weaponItem.itemDefinitionId,
+        weaponItem.weapon?.currentFiregroupIndex ?? 0,
+        weaponItem.weapon?.currentFiremodeIndex ?? 0
+      )
+    ) {
+      case Items.AMMO_ARROW_FLAMING:
+        this.igniteArrowTarget(entity);
+        break;
+      case Items.AMMO_ARROW_EXPLOSIVE:
+        this.explosiveArrowDetonate(entity, client);
+        break;
+    }
   }
 
   setGodMode(client: Client, godMode: boolean) {

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -3611,7 +3611,7 @@ export class ZoneServer2016 extends EventEmitter {
     }
 
     // construction / structures the arrow hits
-    const explosiveArrowConstructionDamage = this.baseConstructionDamage / 22;
+    const explosiveArrowConstructionDamage = this.baseConstructionDamage / 18; // /22 previous value
     for (const gridCell of this.getGridCellsInRadius(position, 10)) {
       for (const object of gridCell.objects) {
         if (

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -3250,7 +3250,11 @@ export class ZoneServer2016 extends EventEmitter {
         // need to find a better way later, if out of bulk ammo will be outside of lootbag
         if (slot.weapon) {
           const ammo = this.generateItem(
-            this.getWeaponAmmoId(slot.itemDefinitionId),
+            this.getWeaponAmmoId(
+              slot.itemDefinitionId,
+              slot.weapon.currentFiregroupIndex,
+              slot.weapon.currentFiremodeIndex
+            ),
             slot.weapon.ammoCount
           );
           if (
@@ -3553,9 +3557,17 @@ export class ZoneServer2016 extends EventEmitter {
       case WeaponDefinitionIds.WEAPON_CROSSBOW:
       case WeaponDefinitionIds.WEAPON_BOW_WOOD:
         delete client.fireHints[data.projectileId];
+        // Recover the arrow that was actually loaded (crossbow: wooden/flaming/explosive), resolved
+        // through the weapon's selected firegroup/firemode. Falls back to AMMO_ARROW if unresolved.
         this.worldObjectManager.createLootEntity(
           this,
-          this.generateItem(Items.AMMO_ARROW),
+          this.generateItem(
+            this.getWeaponAmmoId(
+              itemDefId,
+              weaponItem.weapon?.currentFiregroupIndex ?? 0,
+              weaponItem.weapon?.currentFiremodeIndex ?? 0
+            ) || Items.AMMO_ARROW
+          ),
           data.position,
           data.rotation
         );
@@ -6670,20 +6682,35 @@ export class ZoneServer2016 extends EventEmitter {
   }
 
   /**
-   * Gets the ammoId for a given weapon.
+   * Gets the ammoId for a given weapon, resolved through the SELECTED firegroup/firemode. Multi-firegroup
+   * weapons (e.g. the crossbow) use different ammo per firegroup (0=wooden 112, 1=flaming 1434,
+   * 2=explosive 138); pass the weapon's current selection (weapon.currentFiregroupIndex/FiremodeIndex).
+   * Defaults to firegroup 0 / firemode 0, so single-firegroup weapons and generic callers behave exactly
+   * as before.
    *
    * @param {number} itemDefinitionId - The itemDefinitionId of the weapon.
+   * @param {number} firegroupIndex - Selected firegroup index into the weapon def's FIRE_GROUPS (default 0).
+   * @param {number} firemodeIndex - Selected firemode index into the firegroup's FIRE_MODES (default 0).
    * @returns {number} The ammoId (0 if undefined).
    */
-  getWeaponAmmoId(itemDefinitionId: number): number {
+  getWeaponAmmoId(
+    itemDefinitionId: number,
+    firegroupIndex: number = 0,
+    firemodeIndex: number = 0
+  ): number {
     const itemDefinition = this.getItemDefinition(itemDefinitionId),
       weaponDefinition = this.getWeaponDefinition(itemDefinition?.PARAM1 || 0),
       firegroupDefinition = this.getFiregroupDefinition(
-        weaponDefinition?.FIRE_GROUPS[0]?.FIRE_GROUP_ID
+        weaponDefinition?.FIRE_GROUPS[firegroupIndex]?.FIRE_GROUP_ID
       ),
-      firemodeDefinition = this.getFiremodeDefinition(
-        firegroupDefinition?.FIRE_MODES[0]?.FIRE_MODE_ID
-      );
+      // Ammo is a property of the firegroup - hip (firemode 0) and ADS (firemode 1) share the same
+      // ammo. Fall back to firemode 0 if the requested firemode index doesn't exist, so an ADS
+      // firemodeIndex (the client sends firemodeIndex==1 while aiming, for every weapon) never breaks
+      // ammo resolution for weapons that only define a single firemode.
+      firemode =
+        firegroupDefinition?.FIRE_MODES[firemodeIndex] ??
+        firegroupDefinition?.FIRE_MODES[0],
+      firemodeDefinition = this.getFiremodeDefinition(firemode?.FIRE_MODE_ID);
 
     return firemodeDefinition?.AMMO_ITEM_ID || 0;
   }
@@ -7123,8 +7150,8 @@ export class ZoneServer2016 extends EventEmitter {
         loadoutItem.itemGuid,
         "Update.SwitchFireMode",
         {
-          firegroupIndex: 0,
-          firemodeIndex: 0
+          firegroupIndex: loadoutItem.weapon?.currentFiregroupIndex ?? 0,
+          firemodeIndex: loadoutItem.weapon?.currentFiremodeIndex ?? 0
         }
       );
       span?.end();
@@ -7522,7 +7549,11 @@ export class ZoneServer2016 extends EventEmitter {
       itemDefinition.ITEM_CLASS != ItemClasses.WEAPON_THROWABLES
     ) {
       const ammo = this.generateItem(
-        this.getWeaponAmmoId(dropItem.itemDefinitionId),
+        this.getWeaponAmmoId(
+          dropItem.itemDefinitionId,
+          dropItem.weapon.currentFiregroupIndex,
+          dropItem.weapon.currentFiremodeIndex
+        ),
         dropItem.weapon.ammoCount
       );
       if (
@@ -9129,7 +9160,11 @@ export class ZoneServer2016 extends EventEmitter {
       "Update.Reload",
       {}
     );
-    const weaponAmmoId = this.getWeaponAmmoId(weaponItem.itemDefinitionId),
+    const weaponAmmoId = this.getWeaponAmmoId(
+        weaponItem.itemDefinitionId,
+        weaponItem.weapon.currentFiregroupIndex,
+        weaponItem.weapon.currentFiremodeIndex
+      ),
       reloadTime = this.getWeaponReloadTime(weaponItem.itemDefinitionId);
 
     const itemDefinition = this.getItemDefinition(weaponItem.itemDefinitionId);

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -9138,7 +9138,17 @@ export class ZoneServer2016 extends EventEmitter {
     if (!weaponItem.weapon) return;
     if (weaponItem.weapon.reloadTimer) return;
     const maxAmmo = this.getWeaponMaxAmmo(weaponItem.itemDefinitionId); // max clip size
-    if (weaponItem.weapon.ammoCount >= maxAmmo) return;
+    // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
+    console.log(
+      `[crossbow-reload] reload req item=${weaponItem.itemDefinitionId} fg=${weaponItem.weapon.currentFiregroupIndex} fm=${weaponItem.weapon.currentFiremodeIndex} ammoCount=${weaponItem.weapon.ammoCount} maxAmmo=${maxAmmo} ammoId=${this.getWeaponAmmoId(weaponItem.itemDefinitionId, weaponItem.weapon.currentFiregroupIndex, weaponItem.weapon.currentFiremodeIndex)}`
+    );
+    if (weaponItem.weapon.ammoCount >= maxAmmo) {
+      // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
+      console.log(
+        `[crossbow-reload] EARLY RETURN: ammoCount ${weaponItem.weapon.ammoCount} >= maxAmmo ${maxAmmo} (magazine still holds old ammo type?)`
+      );
+      return;
+    }
     // force 0 firestate so gun doesnt shoot randomly after reloading
     this.sendRemoteWeaponUpdateDataToAllOthers(
       client,
@@ -9283,11 +9293,24 @@ export class ZoneServer2016 extends EventEmitter {
         reloadAmount =
           reserveAmmo >= maxReloadAmount ? maxReloadAmount : reserveAmmo; // actual amount able to reload
 
+      // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
+      console.log(
+        `[crossbow-reload] generic reload ammoId=${weaponAmmoId} reserve=${reserveAmmo} maxReload=${maxReloadAmount} reloadAmount=${reloadAmount}`
+      );
+
       if (
         !this.removeInventoryItems(client.character, weaponAmmoId, reloadAmount)
       ) {
+        // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
+        console.log(
+          `[crossbow-reload] removeInventoryItems FAILED ammoId=${weaponAmmoId} amount=${reloadAmount}`
+        );
         return;
       }
+      // TEMP [crossbow-reload] remove after verifying multi-firegroup reload
+      console.log(
+        `[crossbow-reload] loaded ${reloadAmount} of ammoId=${weaponAmmoId}; new ammoCount=${weaponItem.weapon.ammoCount + reloadAmount}`
+      );
       this.sendWeaponReload(
         client,
         weaponItem,


### PR DESCRIPTION
Enables crossbow ammo-type switching (press B: wooden → flaming → explosive) and wires
per-arrow effects. Server-side only — the Dec-2016 client already supports this; no client
or patch changes.

Changes:
- Per-item weapon data now emits ALL weapon-def firegroups (was length-1), so the client
  recognizes multi-firegroup weapons and lets B cycle them.
- Track selected firegroup/firemode on the Weapon; store the SwitchFireModeRequest (0x830c)
  before the empty-clip/ADS guards so switches aren't dropped.
- Unload the previously loaded arrow on firegroup switch so the new ammo type reloads.
- Route ammo (reload/consume/refund/drop/recover) through the selected
  firegroup → firemode → AMMO_ITEM_ID.
- Per-arrow on-hit effects (networked): flaming sets players/zombies on fire (molotov
  mechanic); explosive does an AoE blast (OnExplosiveHit) + baseConstructionDamage/18 to
  structures.

Generic: any multi-firegroup weapon benefits; single-firegroup weapons are unchanged.

Tested: crossbow cycles all three arrows, switched type reloads, flaming ignites,
explosive blasts and damages structures (networked visuals confirmed with a second client).