### PR TITLE
fix: address review feedback on spatial query optimizations

### DIFF
--- a/src/servers/ZoneServer2016/entities/trapentity.ts
+++ b/src/servers/ZoneServer2016/entities/trapentity.ts
@@ -306,11 +306,9 @@ export class TrapEntity extends BaseSimpleNpc {
         this.isTriggered = true;
       }
     }
-    for (const a in server._vehicles) {
-      if (
-        getDistance(server._vehicles[a].state.position, this.state.position) < 2
-      ) {
-        server._vehicles[a].getPassengerList().map((passenger) => {
+    for (const vehicle of server.getVehiclesInRange(this.state.position, 2)) {
+      if (getDistance(vehicle.state.position, this.state.position) < 2) {
+        vehicle.getPassengerList().map((passenger) => {
           this.detonateTrap(server, { entity: passenger, damage: 0 });
           this.isTriggered = true;
         });

--- a/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
+++ b/src/servers/ZoneServer2016/jsms/screamer.jsm.ts
@@ -241,7 +241,8 @@ function screamAtNearbyPlayers(screamer: ScreamerInstance): void {
         if (entry.faction !== Factions.HUMAN) continue;
         if (getDistance2d(pos, entry.position) > SCREAM_RADIUS) continue;
         const client = screamer.server.getClientByCharId(entry.id);
-        if (!client) continue;
+        if (!client || client.character.isVanished || client.character.isHidden)
+          continue;
         screamer.server.applyMovementModifier(client, MovementModifiers.SCREAM);
       }
     }

--- a/src/servers/ZoneServer2016/managers/constructionmanager.ts
+++ b/src/servers/ZoneServer2016/managers/constructionmanager.ts
@@ -280,6 +280,9 @@ export class ConstructionManager {
       !Number(parentObjectCharacterId) &&
       !this.overridePlacementItems.includes(itemDefinitionId)
     ) {
+      // anti-stack must see just-placed constructions, so rebuild from the live dicts
+      // (the cached hash is fine for the proximity readers, but stale here bypasses the check)
+      this._stackedPlacementHash = undefined;
       const hash = this.getStackedPlacementHash(server);
       for (const c of ConstructionManager._entitiesNear(
         hash.worldSimple,


### PR DESCRIPTION
- screamer: restore vanished/hidden guard dropped in the rewrite so vanished/hidden players aren't hit by the SCREAM modifier
- construction: force a fresh stacked-placement hash in detectStackedPlacement so the anti-stack check always sees just-placed constructions (cache kept for the proximity readers where 1s staleness is harmless)
- trap: use getVehiclesInRange for the vehicle-detonation scan instead of iterating all vehicles, completing the intended optimization