### PR TITLE
fix(soe): bound ack() by the real sent range, not maxSequenceAvailable

### DIFF
--- a/src/servers/SoeServer/soeoutputstream.ts
+++ b/src/servers/SoeServer/soeoutputstream.ts
@@ -168,11 +168,18 @@ export class SOEOutputStream extends EventEmitter {
     const distance =
       (wrappedSequence - this.lastAck.get() + SEQUENCE_SPACE) % SEQUENCE_SPACE;
 
-    // We never have more than maxSequenceAvailable packets in flight, so an ack
-    // further ahead than that is bogus. Without this bound a single crafted ack
-    // costs up to 65535 cache lookups, and a sequence that wrap() cannot bring
-    // back into range would loop forever.
-    if (distance > 0 && distance <= this.maxSequenceAvailable) {
+    // Max distance a client could legitimately ack = up to the last sequence we
+    // actually made available/sent. The in-flight window can exceed
+    // maxSequenceAvailable, so bounding by that constant wrongly rejects valid
+    // cumulative acks and stalls the outbound window forever (zone-in never
+    // completes). Bounding by the real sent range still stops a crafted far-ahead
+    // ack from driving the cumulative-delete loop past what exists.
+    const availableDistance =
+      (this._last_available_reliable_sequence.get() -
+        this.lastAck.get() +
+        SEQUENCE_SPACE) %
+      SEQUENCE_SPACE;
+    if (distance > 0 && distance <= availableDistance) {
       while (this.lastAck.get() !== wrappedSequence) {
         this.removeFromCache(this.lastAck.get());
         unAckData.delete(this.lastAck.get());


### PR DESCRIPTION
PR #2866's ack() rewrite bounded a cumulative ack's forward distance by the fixed maxSequenceAvailable constant, but the in-flight reliable window can exceed it. SOE_TRACE ground truth during a zone-in hang showed outstanding=182 > maxSeq=100 with lastAck frozen and flooded=true: the client's legit cumulative ack (distance 182) failed the <=100 guard, fell to the single-entry else branch, lastAck never advanced, the outbound window never freed and sending halted -> infinite load.

Bound the cumulative-ack branch by the forward distance to _last_available_reliable_sequence (the highest sequence actually sent) instead. A client can never legitimately ack beyond what was sent, so every valid cumulative ack is accepted regardless of window size, while a crafted far-ahead ack (beyond the sent range) still falls to the else branch - preserving the DoS bound the guard intended. Flood/congestion logic and maxSequenceAvailable unchanged.