### PR TITLE
refactor(ClientProtocol_1080): name outgoing-RE-confirmed receive-schema fields

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/items.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/items.ts
@@ -507,7 +507,7 @@ export const itemsPackets: PacketStructures = [
       fields: [
         { name: "itemCount", type: "uint32", defaultValue: 0 },
         { name: "unknownDword2", type: "uint32", defaultValue: 0 },
-        { name: "unknownDword3", type: "uint32", defaultValue: 0 },
+        { name: "itemUseOption", type: "uint32", defaultValue: 0 },
         { name: "itemDefinitionId", type: "uint32", defaultValue: 0 },
         {
           name: "itemSubData",

--- a/src/packets/ClientProtocol/ClientProtocol_1080/loadout.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/loadout.ts
@@ -66,7 +66,7 @@ export const loadoutPackets: PacketStructures = [
       fields: [
         { name: "unknownDword1", type: "uint32", defaultValue: 0 },
         { name: "slotId", type: "uint32", defaultValue: 0 },
-        { name: "unknownDword2", type: "uint32", defaultValue: 0 }
+        { name: "gameTime", type: "uint32", defaultValue: 0 }
       ]
     }
   ],

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -3581,7 +3581,7 @@ export class ZonePacketHandlers {
 
     const itemSubData: any = packet.data.itemSubData;
 
-    switch (packet.data.unknownDword3) {
+    switch (packet.data.itemUseOption) {
       case ItemUseOptions.OPEN_CRATE:
         const rewards = server.getCrateRewards(packet.data.itemDefinitionId),
           rewardResult = server.getRandomCrateReward(

--- a/src/types/zone2016packets.ts
+++ b/src/types/zone2016packets.ts
@@ -2426,7 +2426,7 @@ export interface LoadoutSetLoadoutSlot {
 export interface LoadoutSelectSlot {
   unknownDword1?: number;
   slotId?: number;
-  unknownDword2?: number;
+  gameTime?: number;
 }
 export interface LoadoutCreateCustomLoadout {
   slotId?: number;
@@ -3120,7 +3120,7 @@ export interface ItemsRequestUseItem {
 export interface ItemsRequestUseAccountItem {
   itemCount?: number;
   unknownDword2?: number;
-  unknownDword3?: number;
+  itemUseOption?: number;
   itemDefinitionId?: number;
   itemSubData?: unknown;
 }


### PR DESCRIPTION
Pure field renames (no parse/logic/offset change), mirroring the incoming reconciliation:
- Items.RequestUseAccountItem.unknownDword3 -> itemUseOption (the value the handler already switches on: OPEN_CRATE / APPLY_SKIN); renamed in the schema, the generated interface and the requestUseAccountItem switch.
- Loadout.SelectSlot.unknownDword2 -> gameTime (client clock ms; parsed-but-unused, handler reads only slotId).

itemSubData.unknownBoolean1 -> noSubData and Vehicle.StateData gameTick were already applied on dev (via #2873 / prior work) - verified present, no change needed. Regenerated packet types/interfaces.