### PR TITLE
perf(resources): change-gate ResourceEvent sends to stop per-tick spam

### DIFF
--- a/src/servers/ZoneServer2016/entities/basefullcharacter.ts
+++ b/src/servers/ZoneServer2016/entities/basefullcharacter.ts
@@ -150,6 +150,9 @@ export abstract class BaseFullCharacter extends BaseLightweightCharacter {
 
   /** BaseFullCharacter loadout values */
   _resources: { [resourceId: number]: number } = {};
+  /** Last resource value actually sent to clients, per resourceId - used to change-gate ResourceEvent
+   *  spam so a resource is only re-sent when the client-displayed value changes. Reset on respawn/resync. */
+  _lastSentResources: { [resourceId: number]: number } = {};
   _loadout: { [loadoutSlotId: number]: LoadoutItem } = {};
   _equipment: { [equipmentSlotId: number]: CharacterEquipment } = {};
   _containers: { [loadoutSlotId: number]: LoadoutContainer } = {};

--- a/src/servers/ZoneServer2016/entities/character.ts
+++ b/src/servers/ZoneServer2016/entities/character.ts
@@ -1579,6 +1579,8 @@ export class Character2016 extends BaseFullCharacter {
   }
 
   resetResources(server: ZoneServer2016) {
+    // Full resource resync: clear the change-gate cache so every value below is (re)sent.
+    this._lastSentResources = {};
     this._resources[ResourceIds.HEALTH] = 10000;
     this._resources[ResourceIds.STAMINA] = 600;
     this._resources[ResourceIds.BLEEDING] = 0;

--- a/src/servers/ZoneServer2016/zoneserver.ts
+++ b/src/servers/ZoneServer2016/zoneserver.ts
@@ -331,6 +331,11 @@ const spawnLocations2 = PluginManager.loadServerData(
     "2016/sampleData/equipmentModelTexturesMapping.json"
   );
 
+// A player resource is only re-sent to clients when it crosses one of these fractions of its MAX_VALUE
+// (permille), so continuously-decaying resources no longer emit a ResourceEvent every tick for a change
+// the client cannot render. TODO: RE-confirm the client's actual resource-bar granularity.
+const RESOURCE_SEND_STEPS = 1000;
+
 export class ZoneServer2016 extends EventEmitter {
   /** Networking layer - allows sending game data to the game client,
    * lays on top of the H1Z1 protocol (on top of the actual H1Z1 packets)
@@ -4024,6 +4029,39 @@ export class ZoneServer2016 extends EventEmitter {
     }
   }
 
+  /**
+   * Change-gate for ResourceEvent sends. Returns true (and updates the character's last-sent cache) only
+   * when the value differs from the last value sent by enough to change what the client displays - killing
+   * per-tick spam for continuously-decaying resources whose raw value ticks by a client-imperceptible
+   * amount. The client renders resources as a fraction of MAX_VALUE, so the value is quantized to
+   * RESOURCE_SEND_STEPS. Non-player entities (vehicles/doors/etc., not in _characters) are never gated, so
+   * their existing behavior is unchanged.
+   */
+  private _shouldSendResourceEvent(
+    entityId: string,
+    resourceId: number,
+    value: number
+  ): boolean {
+    const character = this._characters[entityId];
+    if (!character) return true; // non-player resource - preserve existing behavior
+    const v = value >= 0 ? value : 0;
+    const last = character._lastSentResources[resourceId];
+    const max = this.getResourceMaxValue(resourceId as ResourceIds);
+    let changed: boolean;
+    if (last === undefined || max <= 0) {
+      changed = last !== v;
+    } else {
+      const quantum = (n: number) =>
+        Math.round((n / max) * RESOURCE_SEND_STEPS);
+      changed =
+        quantum(v) !== quantum(last) ||
+        // always emit exact empty/full transitions (drive starving/dehydrated/full states)
+        ((v <= 0 || v >= max) && v !== last);
+    }
+    if (changed) character._lastSentResources[resourceId] = v;
+    return changed;
+  }
+
   updateResource(
     client: Client,
     entityId: string,
@@ -4031,6 +4069,7 @@ export class ZoneServer2016 extends EventEmitter {
     resourceId: ResourceIds,
     resourceType?: number // most resources have the same id and type
   ) {
+    if (!this._shouldSendResourceEvent(entityId, resourceId, value)) return;
     this.sendData<ResourceEvent>(client, "ResourceEvent", {
       eventData: {
         type: 3,
@@ -4051,6 +4090,7 @@ export class ZoneServer2016 extends EventEmitter {
     resourceType: number,
     dictionary: EntityDictionary<BaseEntity>
   ) {
+    if (!this._shouldSendResourceEvent(entityId, resourceId, value)) return;
     this.sendDataToAllWithSpawnedEntity<ResourceEvent>(
       dictionary,
       entityId,


### PR DESCRIPTION
server.updateResource and updateResourceToAllWithSpawnedEntity sent a ResourceEvent every call with no comparison to the last value sent, so the 3s resource tick re-sent decaying resources (hunger/hydration/endurance/comfort, and virus via virusBurnTick) every tick even though the raw change was too small to move the client-displayed bar.

Track the last-sent value per resource on the character and only emit when the client- displayed value would change: quantize to permille of the resource MAX_VALUE, and always emit exact empty/full transitions. Non-player entities (vehicles/doors/construction) are never gated, so their behavior is unchanged. The cache is reset in resetResources so respawn/resync always resends; a freshly-created character starts with an empty cache.

Net: a steady-state character emits ~0 ResourceEvents; real changes (damage, eating, drinking, healing, decay crossing a visible step) still send. Permille granularity is a conservative floor pending RE confirmation of the client's real bar resolution.