### PR TITLE
fix(construction): align PlacementFinalizeRequest rotation to the 2016 client wire

### DIFF
--- a/src/packets/ClientProtocol/ClientProtocol_1080/construction.ts
+++ b/src/packets/ClientProtocol/ClientProtocol_1080/construction.ts
@@ -44,12 +44,25 @@ export const constructionPackets: PacketStructures = [
           defaultValue: ""
         },
         { name: "BuildingSlot", type: "string", defaultValue: "" },
-        { name: "unkByte1", type: "uint8", defaultValue: 0 },
-        { name: "unk1", type: "float", defaultValue: 0 },
-        { name: "rotation1", type: "floatvector4", defaultValue: [0, 0, 0, 0] },
-        { name: "rotation2", type: "floatvector4", defaultValue: [0, 0, 0, 0] },
-        { name: "rotation3", type: "floatvector4", defaultValue: [0, 0, 0, 0] },
-        { name: "unk6", type: "float", defaultValue: 0 },
+        { name: "unknownDword1", type: "uint32", defaultValue: 0 },
+        { name: "unknownFloat1", type: "float", defaultValue: 0 },
+        { name: "unknownByte1", type: "uint8", defaultValue: 0 },
+        // placement actor world matrix: right (X row), up (Y row), forward (Z row), then position (translation)
+        {
+          name: "placementRight",
+          type: "floatvector4",
+          defaultValue: [0, 0, 0, 0]
+        },
+        {
+          name: "placementUp",
+          type: "floatvector4",
+          defaultValue: [0, 0, 0, 0]
+        },
+        {
+          name: "placementForward",
+          type: "floatvector4",
+          defaultValue: [0, 0, 0, 0]
+        },
         { name: "position2", type: "floatvector4", defaultValue: [0, 0, 0, 0] }
       ]
     }

--- a/src/servers/ZoneServer2016/zonepackethandlers.ts
+++ b/src/servers/ZoneServer2016/zonepackethandlers.ts
@@ -1980,16 +1980,17 @@ export class ZonePacketHandlers {
   ) {
     if (
       !packet.data.itemDefinitionId ||
-      !packet.data.rotation1 ||
-      !packet.data.rotation2 ||
+      !packet.data.placementForward ||
       !packet.data.position2
     ) {
       return;
     }
 
-    const y = packet.data.rotation1[1],
-      w = packet.data.rotation1[3],
-      yaw = Math.atan2(-w, y),
+    // world-up is Y; yaw is the heading of the placement forward (Z) basis row
+    const yaw = Math.atan2(
+        packet.data.placementForward[0],
+        packet.data.placementForward[2]
+      ),
       final = new Float32Array([yaw, 0, 0, 0]);
 
     const modelId = server.getItemDefinition(

--- a/src/types/zone2016packets.ts
+++ b/src/types/zone2016packets.ts
@@ -4119,12 +4119,12 @@ export interface ConstructionPlacementFinalizeRequest {
   scale?: Float32Array;
   parentObjectCharacterId?: string;
   BuildingSlot?: string;
-  unkByte1?: number;
-  unk1?: number;
-  rotation1?: Float32Array;
-  rotation2?: Float32Array;
-  rotation3?: Float32Array;
-  unk6?: number;
+  unknownDword1?: number;
+  unknownFloat1?: number;
+  unknownByte1?: number;
+  placementRight?: Float32Array;
+  placementUp?: Float32Array;
+  placementForward?: Float32Array;
   position2?: Float32Array;
 }
 export interface ConstructionPlacementFinalizeResponse {


### PR DESCRIPTION
The 0xca0300 schema tail (after BuildingSlot) read a u8 where the client writes a u32 and inserted a phantom float before position2. The two size errors cancel over the 73-byte tail so position2 landed correctly by coincidence, but rotation1/2/3 were parsed 4 bytes early - so the placement yaw (atan2(-w, y) over rotation1) used misaligned quat components and placed structures at the wrong rotation.

Correct the tail to the client wire: unknownDword1 u32, unknownFloat1 f32, unknownByte1 u8, rotation1/2/3 fv4, position2 fv4 (phantom float removed). The handler (ConstructionPlacementFinalizeRequest) already reads rotation1/2/3/position2/itemDefinitionId by name - unchanged; the yaw math is untouched and now reads aligned rotation. Regenerated packet types/interfaces.